### PR TITLE
Remove auth-bypass branch from Program.cs (security)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,11 +169,12 @@ dotnet ef database update --project src/Andy.Policies.Infrastructure --startup-p
 
 ## Authentication & Authorization
 
-- **Auth bypass**: When `AndyAuth:Authority` is empty, all endpoints are open (dev convenience)
-- **JWT Bearer**: When configured, API requires valid tokens from Andy Auth
+- **No auth bypass — ever**: There is no production code path that allows unauthenticated access. If `AndyAuth:Authority` is missing, the API refuses to start with a clear error. For local dev, run andy-auth (e.g. `docker compose up andy-auth`) and let `appsettings.json` point at `https://localhost:5001`. See #103 for the rationale.
+- **JWT Bearer**: API requires valid tokens from Andy Auth on every `[Authorize]`d endpoint.
 - **Test user**: `test@andy.local` / `Test123!` (seeded in Andy Auth for non-production)
 - **RBAC**: Application code `andy-policies` registered in Andy RBAC with admin/user/viewer roles
 - **Swagger**: Bearer security scheme configured — use "Authorize" button in Swagger UI
+- **Integration tests**: register their own `TestAuthHandler` inside `WebApplicationFactory` and override the default scheme — they never depend on a production bypass.
 
 ## Testing Requirements
 

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -4,7 +4,6 @@
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Infrastructure.Data;
 using Andy.Policies.Infrastructure.Services;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -16,42 +15,42 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddAppDatabase(builder.Configuration);
 
 // --- Authentication (Andy Auth) ---
-var andyAuthAuthority = builder.Configuration["AndyAuth:Authority"] ?? "";
-if (!string.IsNullOrEmpty(andyAuthAuthority))
+// SECURITY: There is no auth-bypass branch by design. If AndyAuth:Authority is
+// not configured the service refuses to start — failing loud beats silently
+// shipping an open-to-anonymous deployment. Tests register their own
+// authentication scheme inside their WebApplicationFactory; they do not depend
+// on a production bypass. See rivoli-ai/andy-policies#103.
+var andyAuthAuthority = builder.Configuration["AndyAuth:Authority"];
+if (string.IsNullOrEmpty(andyAuthAuthority))
 {
-    var audience = builder.Configuration["AndyAuth:Audience"] ?? "urn:andy-policies-api";
-    builder.Services.AddAuthentication("Bearer")
-        .AddJwtBearer("Bearer", options =>
-        {
-            options.Authority = andyAuthAuthority;
-            options.Audience = audience;
-            options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
-            if (builder.Environment.IsDevelopment())
-            {
-                options.BackchannelHttpHandler = new HttpClientHandler
-                {
-                    ServerCertificateCustomValidationCallback =
-                        HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-                };
-                options.TokenValidationParameters.ValidIssuers = new[]
-                {
-                    andyAuthAuthority, andyAuthAuthority.TrimEnd('/') + "/",
-                    "https://localhost:5001", "https://localhost:5001/"
-                };
-            }
-        });
-    builder.Services.AddAuthorization();
+    throw new InvalidOperationException(
+        "AndyAuth:Authority is not configured. Set it via appsettings, environment " +
+        "(AndyAuth__Authority=https://...), or Andy Settings. For local dev, run " +
+        "andy-auth (e.g. `docker compose up andy-auth`) and point at https://localhost:5001.");
 }
-else
-{
-    builder.Services.AddAuthentication();
-    builder.Services.AddAuthorization(options =>
+
+var audience = builder.Configuration["AndyAuth:Audience"] ?? "urn:andy-policies-api";
+builder.Services.AddAuthentication("Bearer")
+    .AddJwtBearer("Bearer", options =>
     {
-        options.DefaultPolicy = new AuthorizationPolicyBuilder()
-            .RequireAssertion(_ => true)
-            .Build();
+        options.Authority = andyAuthAuthority;
+        options.Audience = audience;
+        options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
+        if (builder.Environment.IsDevelopment())
+        {
+            options.BackchannelHttpHandler = new HttpClientHandler
+            {
+                ServerCertificateCustomValidationCallback =
+                    HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+            };
+            options.TokenValidationParameters.ValidIssuers = new[]
+            {
+                andyAuthAuthority, andyAuthAuthority.TrimEnd('/') + "/",
+                "https://localhost:5001", "https://localhost:5001/"
+            };
+        }
     });
-}
+builder.Services.AddAuthorization();
 
 // --- RBAC (Andy.Rbac.Client) ---
 var rbacBaseUrl = builder.Configuration["Rbac:ApiBaseUrl"];

--- a/tests/Andy.Policies.Tests.Integration/Controllers/PoliciesApiFactory.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/PoliciesApiFactory.cs
@@ -42,8 +42,11 @@ public sealed class PoliciesApiFactory : WebApplicationFactory<Program>
             config.AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["Database:Provider"] = "Sqlite",
-                // Empty string disables andy-auth bearer setup → AllowAnonymous default.
-                ["AndyAuth:Authority"] = "",
+                // Production Program.cs throws if AndyAuth:Authority is empty (see #103
+                // — there is no auth-bypass branch). Provide a placeholder so the JWT
+                // Bearer registration runs without throwing; the scheme is never invoked
+                // because ConfigureServices below installs TestAuthHandler as the default.
+                ["AndyAuth:Authority"] = "https://test-auth.invalid",
             });
         });
 


### PR DESCRIPTION
Closes #103.

## Summary

There is no longer a production code path that allows unauthenticated access. The previous "dev convenience" bypass — when `AndyAuth:Authority` was empty, `Program.cs` registered an empty auth scheme + an allow-all authorization policy — silently turned every endpoint into open-to-anonymous on a misconfigured deployment. P1.5 added enough mutation surface (create/update/bump policies) that this stopped being acceptable.

The rule is: **never skip auth.** Production now refuses to start without an authority configured, with a clear error message pointing operators at appsettings, env vars, Andy Settings, and the local `docker compose up andy-auth` flow.

## Changes

- **`Program.cs`** — removed the `else` branch. The check throws `InvalidOperationException` with operator-actionable guidance. Removed the now-dead `using Microsoft.AspNetCore.Authorization` (only the deleted branch referenced `AuthorizationPolicyBuilder`).
- **`CLAUDE.md`** — replaced the "Auth bypass" bullet with "No auth bypass — ever" documenting fail-loud behavior, andy-auth dependency, and the test pattern (so future contributors don't reach for a production bypass).
- **`PoliciesApiFactory.cs`** — set `AndyAuth:Authority` to a placeholder so the JWT Bearer registration runs without throwing. The Bearer scheme is never invoked because `TestAuthHandler` (added in P1.5) is installed as the default scheme.

## Tests don't depend on the production bypass

`PoliciesApiFactory` was already installing `TestAuthHandler` as the default authentication scheme via `ConfigureServices` — that behaviour pre-dates this PR. The only adjustment needed was setting a non-empty `AndyAuth:Authority` placeholder so the new fail-loud check doesn't fire before `ConfigureServices` runs.

## Test plan

- [x] `dotnet build` — 0 warnings (TreatWarningsAsErrors)
- [x] **77/77 unit pass** (unchanged)
- [x] **37/37 relevant integration pass** (PoliciesController + persistence + dimensions + migrations)
- [ ] **Pre-existing `ItemsControllerTests` (4 failures)** — unchanged failure mode (Postgres on :5439 unavailable). `appsettings.json` provides `AndyAuth:Authority`, so the new throw does not fire there. Migrating `ItemsControllerTests` to a fixture-style setup is a separate cleanup.

## Upstream concern

The same bypass pattern almost certainly lives in **every service scaffolded from `rivoli-ai/andy-service-template`**. Worth filing a sibling issue against the template so this fix propagates rather than getting re-introduced on the next service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)