### PR TITLE
E2E auth smoke test + fix Postgres partial-index filter

### DIFF
--- a/Andy.Policies.sln
+++ b/Andy.Policies.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
@@ -24,6 +24,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Andy.Policies.Tests.Unit", "tests\Andy.Policies.Tests.Unit\Andy.Policies.Tests.Unit.csproj", "{D6543BA1-085C-4356-8361-91AFC96D7D05}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Andy.Policies.Tests.Integration", "tests\Andy.Policies.Tests.Integration\Andy.Policies.Tests.Integration.csproj", "{933FCAA6-6ED9-4097-AC09-DC4195243C38}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Andy.Policies.Tests.E2E", "tests\Andy.Policies.Tests.E2E\Andy.Policies.Tests.E2E.csproj", "{E1199701-C18E-44BB-A76A-7F8D62988086}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -66,6 +68,10 @@ Global
 		{933FCAA6-6ED9-4097-AC09-DC4195243C38}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{933FCAA6-6ED9-4097-AC09-DC4195243C38}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{933FCAA6-6ED9-4097-AC09-DC4195243C38}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E1199701-C18E-44BB-A76A-7F8D62988086}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1199701-C18E-44BB-A76A-7F8D62988086}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1199701-C18E-44BB-A76A-7F8D62988086}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E1199701-C18E-44BB-A76A-7F8D62988086}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{1A8D5B15-C3DC-4401-9E58-797BA4096206} = {F4AED566-F8DA-478D-AF9E-8703BD95D9A5}
@@ -76,5 +82,6 @@ Global
 		{087C6760-12A6-411C-82D4-2640F2008699} = {3342D74E-E9DF-47C4-895E-BE7E2AC0E7AA}
 		{D6543BA1-085C-4356-8361-91AFC96D7D05} = {395A9CFC-92DF-4A38-A2A2-F10F1268E574}
 		{933FCAA6-6ED9-4097-AC09-DC4195243C38} = {395A9CFC-92DF-4A38-A2A2-F10F1268E574}
+		{E1199701-C18E-44BB-A76A-7F8D62988086} = {395A9CFC-92DF-4A38-A2A2-F10F1268E574}
 	EndGlobalSection
 EndGlobal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,11 @@ dotnet test
 # Run tests with coverage
 dotnet test --collect:"XPlat Code Coverage" --results-directory ./TestResults
 
+# Run E2E auth smoke test (requires live stack — see #105)
+docker compose -f docker-compose.e2e.yml up -d --build
+E2E_ENABLED=1 dotnet test tests/Andy.Policies.Tests.E2E
+docker compose -f docker-compose.e2e.yml down -v
+
 # Run the API (Development mode)
 ASPNETCORE_ENVIRONMENT=Development dotnet run --project src/Andy.Policies.Api
 
@@ -181,7 +186,8 @@ dotnet ef database update --project src/Andy.Policies.Infrastructure --startup-p
 - **Always write tests** for new code in `tests/` assemblies
 - **Run `dotnet test` before claiming completion**
 - Unit tests use EF Core InMemory provider
-- Integration tests use `WebApplicationFactory<Program>`
+- Integration tests use `WebApplicationFactory<Program>` with SQLite-backed `PoliciesApiFactory` and `TestAuthHandler`
+- E2E tests (`tests/Andy.Policies.Tests.E2E`) hit a live andy-auth + andy-policies stack via `docker-compose.e2e.yml`. Skipped silently unless `E2E_ENABLED=1`. They prove the OAuth client manifest in `config/registration.json` actually round-trips: real JWT issued by andy-auth → andy-policies validates signature/audience/issuer → 201/200 on the REST surface. Run before broadening surfaces (P1.6/7/8) — registration drift (audience typos, scope mismatches) shows up here, not in unit tests.
 - Frontend tests use Karma/Jasmine with ChromeHeadless
 
 ## Code Quality

--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ dotnet test
 cd client && npm test -- --watch=false --browsers=ChromeHeadless
 ```
 
+### End-to-end auth smoke test
+
+Brings up a real andy-auth alongside andy-policies and proves the OAuth client
+manifest in `config/registration.json` round-trips (token issuance → JWT
+validation → REST round-trip). Skipped silently unless `E2E_ENABLED=1`.
+
+```bash
+docker compose -f docker-compose.e2e.yml up -d --build
+E2E_ENABLED=1 dotnet test tests/Andy.Policies.Tests.E2E
+docker compose -f docker-compose.e2e.yml down -v
+```
+
 ## Docker modes
 
 ```bash

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,135 @@
+# End-to-end smoke test stack — issue rivoli-ai/andy-policies#105.
+#
+# Brings up andy-auth + andy-policies (each with its own Postgres) on a single
+# Docker network so the E2E test in tests/Andy.Policies.Tests.E2E/ can:
+#
+#   1. POST http://localhost:7002/connect/token  (client_credentials grant on
+#      andy-policies-api → JWT signed by andy-auth)
+#   2. POST http://localhost:7113/api/policies   (with Bearer token → 201)
+#   3. GET  http://localhost:7113/api/policies   (same token → 200, list)
+#
+# This proves the OAuth client registration in config/registration.json is
+# actually consumable by a running andy-auth, that audiences/scopes/issuer
+# line up across services, and that andy-policies validates JWTs from a real
+# andy-auth (not just TestAuthHandler).
+#
+# Out of scope for v1 (deliberate):
+#   - andy-rbac and andy-settings — andy-policies does not call them at
+#     runtime today (no IRbacChecker until P7 lands; no settings consumer
+#     code yet). Adding them grows compose surface + build prereqs (andy-rbac
+#     requires `bash ../andy-settings/scripts/pack-local.sh` first) without
+#     additional smoke-test signal. Track extension as follow-up to #105.
+#   - Real user authentication — the smoke test uses client_credentials so
+#     the token represents a service principal, not test@andy.local.
+#     test@andy.local is auto-seeded by andy-auth (DbSeeder.cs:1104) but
+#     reaching it requires authorization_code flow which is impractical in
+#     a non-interactive test. When P7 (#57) adds role-based authorization,
+#     extend with a second test that uses auth_code + plays back a captured
+#     code flow.
+#
+# Usage:
+#   docker compose -f docker-compose.e2e.yml up -d --build
+#   E2E_ENABLED=1 dotnet test tests/Andy.Policies.Tests.E2E
+#   docker compose -f docker-compose.e2e.yml down -v
+
+services:
+  andy-auth-postgres:
+    image: postgres:16-alpine
+    container_name: andy-policies-e2e-auth-pg
+    environment:
+      POSTGRES_DB: andy_auth_dev
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d andy_auth_dev"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - e2e
+
+  andy-auth:
+    build:
+      context: ../andy-auth
+      dockerfile: Dockerfile
+      additional_contexts:
+        certs: ../andy-auth/certs
+    container_name: andy-policies-e2e-auth
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_URLS=http://+:5000
+      - ConnectionStrings__DefaultConnection=Host=andy-auth-postgres;Port=5432;Database=andy_auth_dev;Username=postgres;Password=postgres
+      # Pin the issuer to the in-network URL so andy-policies (which fetches
+      # metadata from this same URL) sees a matching iss claim on tokens.
+      # The test calls localhost:7002, but token.iss will be the configured
+      # issuer regardless of how the token endpoint was reached.
+      - OpenIddict__Issuer=http://andy-auth:5000/
+      # Read andy-policies' OAuth client manifest at startup. This is what
+      # seeds the andy-policies-api confidential client (PBKDF2-hashed from
+      # ANDY_POLICIES_API_SECRET via DbSeeder.ResolveClientSecret).
+      - REGISTRATIONS__MANIFEST_PATHS=/monorepo/andy-policies/config/registration.json
+      - ANDY_POLICIES_API_SECRET=e2e-test-secret-not-for-production
+    ports:
+      - "7002:5000"
+    volumes:
+      - ../:/monorepo:ro
+    depends_on:
+      andy-auth-postgres:
+        condition: service_healthy
+    # No healthcheck: the andy-auth image (built from ../andy-auth/Dockerfile)
+    # ships without curl/wget/nc, so we rely on andy-policies' own healthcheck
+    # to gate end-to-end readiness — it implicitly proves andy-auth's metadata
+    # endpoint is reachable (JWT Bearer middleware fetches it on first request).
+    networks:
+      - e2e
+
+  andy-policies-postgres:
+    image: postgres:16-alpine
+    container_name: andy-policies-e2e-pg
+    environment:
+      POSTGRES_DB: andy_policies
+      POSTGRES_USER: andy_policies
+      POSTGRES_PASSWORD: andy_policies_dev_password
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U andy_policies -d andy_policies"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - e2e
+
+  andy-policies:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      additional_contexts:
+        certs: ./certs
+    container_name: andy-policies-e2e-api
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_URLS=http://+:8080
+      - ConnectionStrings__DefaultConnection=Host=andy-policies-postgres;Port=5432;Database=andy_policies;Username=andy_policies;Password=andy_policies_dev_password
+      # Same in-network URL as andy-auth's pinned issuer so JWT validation
+      # accepts tokens from the test.
+      - AndyAuth__Authority=http://andy-auth:5000/
+      - AndyAuth__Audience=urn:andy-policies-api
+    ports:
+      - "7113:8080"
+    depends_on:
+      andy-policies-postgres:
+        condition: service_healthy
+      andy-auth:
+        condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/health || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+    networks:
+      - e2e
+
+networks:
+  e2e:
+    name: andy-policies-e2e
+    driver: bridge

--- a/src/Andy.Policies.Infrastructure/Data/AppDbContext.cs
+++ b/src/Andy.Policies.Infrastructure/Data/AppDbContext.cs
@@ -56,7 +56,10 @@ public class AppDbContext : DbContext
             entity.Property(v => v.Version).IsRequired();
 
             // State stored as string so migrations + filtered-unique-index SQL is portable
-            // across Postgres and SQLite (both honour the `WHERE state = 'Draft'` filter literal).
+            // across Postgres and SQLite (both honour the `WHERE "State" = 'Draft'` filter literal).
+            // The PascalCase column name is double-quoted so Postgres preserves case — unquoted
+            // `state` resolves to a non-existent lowercase column on Postgres (case-folding rule).
+            // SQLite is case-insensitive for identifiers either way.
             entity.Property(v => v.State)
                 .HasConversion<string>()
                 .HasMaxLength(32)
@@ -138,11 +141,11 @@ public class AppDbContext : DbContext
             // via the overload registers them as separate logical indexes.
             entity.HasIndex(v => v.PolicyId, "ix_policy_versions_one_draft_per_policy")
                 .IsUnique()
-                .HasFilter("state = 'Draft'");
+                .HasFilter("\"State\" = 'Draft'");
 
             entity.HasIndex(v => v.PolicyId, "ix_policy_versions_one_active_per_policy")
                 .IsUnique()
-                .HasFilter("state = 'Active'");
+                .HasFilter("\"State\" = 'Active'");
         });
 
         // Optimistic-concurrency token: a uniform <c>uint Revision</c> column on both providers,

--- a/src/Andy.Policies.Infrastructure/Migrations/20260422024314_InitialPolicyCatalog.Designer.cs
+++ b/src/Andy.Policies.Infrastructure/Migrations/20260422024314_InitialPolicyCatalog.Designer.cs
@@ -156,11 +156,11 @@ namespace Andy.Policies.Infrastructure.Migrations
 
                     b.HasIndex(new[] { "PolicyId" }, "ix_policy_versions_one_active_per_policy")
                         .IsUnique()
-                        .HasFilter("state = 'Active'");
+                        .HasFilter("\"State\" = 'Active'");
 
                     b.HasIndex(new[] { "PolicyId" }, "ix_policy_versions_one_draft_per_policy")
                         .IsUnique()
-                        .HasFilter("state = 'Draft'");
+                        .HasFilter("\"State\" = 'Draft'");
 
                     b.ToTable("policy_versions", (string)null);
                 });

--- a/src/Andy.Policies.Infrastructure/Migrations/20260422024314_InitialPolicyCatalog.cs
+++ b/src/Andy.Policies.Infrastructure/Migrations/20260422024314_InitialPolicyCatalog.cs
@@ -93,14 +93,14 @@ namespace Andy.Policies.Infrastructure.Migrations
                 table: "policy_versions",
                 column: "PolicyId",
                 unique: true,
-                filter: "state = 'Active'");
+                filter: "\"State\" = 'Active'");
 
             migrationBuilder.CreateIndex(
                 name: "ix_policy_versions_one_draft_per_policy",
                 table: "policy_versions",
                 column: "PolicyId",
                 unique: true,
-                filter: "state = 'Draft'");
+                filter: "\"State\" = 'Draft'");
 
             migrationBuilder.CreateIndex(
                 name: "IX_policy_versions_PolicyId_Version",

--- a/src/Andy.Policies.Infrastructure/Migrations/20260422031628_AddPolicyDimensions.Designer.cs
+++ b/src/Andy.Policies.Infrastructure/Migrations/20260422031628_AddPolicyDimensions.Designer.cs
@@ -174,11 +174,11 @@ namespace Andy.Policies.Infrastructure.Migrations
 
                     b.HasIndex(new[] { "PolicyId" }, "ix_policy_versions_one_active_per_policy")
                         .IsUnique()
-                        .HasFilter("state = 'Active'");
+                        .HasFilter("\"State\" = 'Active'");
 
                     b.HasIndex(new[] { "PolicyId" }, "ix_policy_versions_one_draft_per_policy")
                         .IsUnique()
-                        .HasFilter("state = 'Draft'");
+                        .HasFilter("\"State\" = 'Draft'");
 
                     b.ToTable("policy_versions", (string)null);
                 });

--- a/src/Andy.Policies.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
+++ b/src/Andy.Policies.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
@@ -171,11 +171,11 @@ namespace Andy.Policies.Infrastructure.Migrations
 
                     b.HasIndex(new[] { "PolicyId" }, "ix_policy_versions_one_active_per_policy")
                         .IsUnique()
-                        .HasFilter("state = 'Active'");
+                        .HasFilter("\"State\" = 'Active'");
 
                     b.HasIndex(new[] { "PolicyId" }, "ix_policy_versions_one_draft_per_policy")
                         .IsUnique()
-                        .HasFilter("state = 'Draft'");
+                        .HasFilter("\"State\" = 'Draft'");
 
                     b.ToTable("policy_versions", (string)null);
                 });

--- a/tests/Andy.Policies.Tests.E2E/Andy.Policies.Tests.E2E.csproj
+++ b/tests/Andy.Policies.Tests.E2E/Andy.Policies.Tests.E2E.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Andy.Policies.Application\Andy.Policies.Application.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Andy.Policies.Tests.E2E/EndToEndAuthSmokeTest.cs
+++ b/tests/Andy.Policies.Tests.E2E/EndToEndAuthSmokeTest.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Andy.Policies.Application.Dtos;
+using Xunit;
+
+namespace Andy.Policies.Tests.E2E;
+
+/// <summary>
+/// End-to-end auth smoke test (issue rivoli-ai/andy-policies#105).
+///
+/// Requires the live stack from <c>docker-compose.e2e.yml</c> to be running:
+/// <code>
+/// docker compose -f docker-compose.e2e.yml up -d --build
+/// E2E_ENABLED=1 dotnet test tests/Andy.Policies.Tests.E2E
+/// </code>
+///
+/// Skipped by default (env var <c>E2E_ENABLED</c> must be set) so the standard
+/// <c>dotnet test</c> run on dev machines / CI without Docker doesn't require it.
+///
+/// What this test proves:
+/// <list type="bullet">
+///   <item>The OAuth client (<c>andy-policies-api</c>) declared in
+///   <c>config/registration.json</c> is consumable by a running andy-auth.</item>
+///   <item>andy-auth issues a JWT for the configured audience
+///   (<c>urn:andy-policies-api</c>).</item>
+///   <item>andy-policies validates the JWT (issuer, signature, audience) end-to-end.</item>
+///   <item>The full REST surface accepts the resulting Bearer token.</item>
+/// </list>
+///
+/// What this test does NOT prove (deferred):
+/// <list type="bullet">
+///   <item>User-claim flow — uses client_credentials so the token represents
+///   a service principal, not <c>test@andy.local</c>. When P7 (#57) lands,
+///   add a second test that exercises authorization_code flow.</item>
+///   <item>andy-rbac / andy-settings registration — those services aren't
+///   in the e2e compose v1.</item>
+/// </list>
+/// </summary>
+public sealed class EndToEndAuthSmokeTest : IAsyncLifetime
+{
+    private const string AuthTokenUrl = "http://localhost:7002/connect/token";
+    private const string PoliciesBaseUrl = "http://localhost:7113";
+    private const string ClientId = "andy-policies-api";
+    private const string ClientSecret = "e2e-test-secret-not-for-production";
+    private const string Audience = "urn:andy-policies-api";
+
+    private readonly HttpClient _http = new();
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync()
+    {
+        _http.Dispose();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Skip unless E2E_ENABLED=1.</summary>
+    private static bool E2EEnabled =>
+        string.Equals(Environment.GetEnvironmentVariable("E2E_ENABLED"), "1", StringComparison.Ordinal);
+
+    [Fact]
+    [Trait("Category", "E2E")]
+    public async Task ClientCredentials_TokenAccepted_ByPoliciesApi()
+    {
+        if (!E2EEnabled)
+        {
+            // xUnit's Skip API would be cleaner but requires Skippable;
+            // returning quietly avoids a noisy failure on dev machines.
+            return;
+        }
+
+        // 1. Acquire a JWT from andy-auth via client_credentials.
+        var token = await AcquireAccessTokenAsync();
+        Assert.False(string.IsNullOrEmpty(token), "andy-auth returned an empty access_token");
+
+        // 2. Create a policy through the REST surface using the Bearer token.
+        var slug = $"e2e-{Guid.NewGuid():N}".Substring(0, 16);
+        var create = new CreatePolicyRequest(
+            Name: slug,
+            Description: "Created by EndToEndAuthSmokeTest",
+            Summary: "smoke",
+            Enforcement: "Must",
+            Severity: "Critical",
+            Scopes: new[] { "prod" },
+            RulesJson: "{}");
+
+        var createReq = new HttpRequestMessage(HttpMethod.Post, $"{PoliciesBaseUrl}/api/policies")
+        {
+            Content = JsonContent.Create(create),
+        };
+        createReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var createRes = await _http.SendAsync(createReq);
+        Assert.Equal(HttpStatusCode.Created, createRes.StatusCode);
+
+        var version = await createRes.Content.ReadFromJsonAsync<PolicyVersionDto>();
+        Assert.NotNull(version);
+        Assert.Equal(1, version!.Version);
+        Assert.Equal("MUST", version.Enforcement);
+
+        // 3. Read it back through a separate authenticated request — proves the
+        // same token is accepted on subsequent calls (caching, key rotation).
+        var listReq = new HttpRequestMessage(HttpMethod.Get,
+            $"{PoliciesBaseUrl}/api/policies/by-name/{slug}");
+        listReq.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var listRes = await _http.SendAsync(listReq);
+        Assert.Equal(HttpStatusCode.OK, listRes.StatusCode);
+
+        var policy = await listRes.Content.ReadFromJsonAsync<PolicyDto>();
+        Assert.Equal(slug, policy!.Name);
+        Assert.Equal(1, policy.VersionCount);
+    }
+
+    [Fact]
+    [Trait("Category", "E2E")]
+    public async Task UnauthenticatedRequest_Returns401()
+    {
+        if (!E2EEnabled) return;
+
+        // No Authorization header — andy-policies must reject (proves the bypass
+        // really is gone; #103).
+        var res = await _http.GetAsync($"{PoliciesBaseUrl}/api/policies");
+        Assert.Equal(HttpStatusCode.Unauthorized, res.StatusCode);
+    }
+
+    private async Task<string> AcquireAccessTokenAsync()
+    {
+        var form = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("grant_type", "client_credentials"),
+            new KeyValuePair<string, string>("client_id", ClientId),
+            new KeyValuePair<string, string>("client_secret", ClientSecret),
+            new KeyValuePair<string, string>("scope", Audience),
+        });
+
+        var res = await _http.PostAsync(AuthTokenUrl, form);
+        var body = await res.Content.ReadAsStringAsync();
+        Assert.True(res.IsSuccessStatusCode,
+            $"Token endpoint returned {(int)res.StatusCode} {res.ReasonPhrase}: {body}");
+
+        using var doc = JsonDocument.Parse(body);
+        return doc.RootElement.GetProperty("access_token").GetString() ?? string.Empty;
+    }
+}


### PR DESCRIPTION
Closes #105.

## Summary

Brings up a real andy-auth alongside andy-policies via a new \`docker-compose.e2e.yml\` and round-trips a real JWT through the REST surface. **Surfaced a real Postgres-only bug on first run** (caught exactly the kind of registration / SQL-dialect drift this test was filed to catch).

## The bug it caught

The partial unique indexes for \"one open Draft per policy\" / \"one Active per policy\" used unquoted column references in their filters:

\`\`\`sql
state = 'Draft'   -- becomes lowercase 'state' on Postgres → column does not exist
state = 'Active'
\`\`\`

SQLite is case-insensitive for identifiers, so unit tests + SQLite integration tests passed. Postgres folds unquoted identifiers to lowercase, so the migration failed at startup with:

\`\`\`
ERROR: column \"state\" does not exist
HINT: Perhaps you meant to reference the column \"policy_versions.State\".
\`\`\`

Fixed by quoting the column name (\`\"State\" = 'Draft'\` / \`\"State\" = 'Active'\`) across \`AppDbContext\`, both migrations + designers, and the model snapshot. **Edited migrations in place**: acceptable because the buggy filter was never successfully applied to Postgres anywhere — this PR's compose stack was the first attempt.

## What v1 of the smoke test proves

- The OAuth client (\`andy-policies-api\`) declared in \`config/registration.json\` is consumable by a running andy-auth (read at startup via \`REGISTRATIONS__MANIFEST_PATHS\`).
- andy-auth issues a JWT for the configured audience (\`urn:andy-policies-api\`).
- andy-policies validates the JWT (issuer, signature, audience) end-to-end.
- The full REST surface accepts the resulting Bearer token.
- The auth-bypass removal from #103 actually holds (\`UnauthenticatedRequest_Returns401\`).

## Architecture

- \`docker-compose.e2e.yml\` — andy-auth + andy-policies + 2 Postgres containers on a private \`andy-policies-e2e\` bridge network. andy-auth pinned to a stable in-network issuer (\`http://andy-auth:5000/\`) via \`OpenIddict__Issuer\` so token \`iss\` matches what andy-policies validates against. Mounts the parent monorepo dir at \`/monorepo:ro\` so andy-auth can read this repo's \`config/registration.json\`.
- \`tests/Andy.Policies.Tests.E2E/\` — new xUnit project, env-var-gated (\`E2E_ENABLED=1\`) so default \`dotnet test\` on dev machines / CI without Docker doesn't break.

## Scope deferred (with rationale)

- **andy-rbac and andy-settings not in v1 compose.** andy-policies doesn't call them at runtime today (no \`IRbacChecker\` until P7 #57; no settings consumer yet). Adding them grows compose surface + build prereqs (andy-rbac requires \`bash ../andy-settings/scripts/pack-local.sh\` first) without additional smoke-test signal. Extend when there's a real consumer. Track as a follow-up to #105 if desired.
- **Real user authentication.** Uses \`client_credentials\` so the token represents a service principal, not \`test@andy.local\`. The test user is auto-seeded by andy-auth (DbSeeder.cs:1104) but reaching it requires \`authorization_code\` flow. When P7 lands, add a second test exercising auth-code + role checks.

## Test plan

- [x] \`dotnet build\` — 0 warnings (TreatWarningsAsErrors)
- [x] \`dotnet test tests/Andy.Policies.Tests.Unit\` — **77/77** unchanged
- [x] \`dotnet test tests/Andy.Policies.Tests.Integration --filter '!~ItemsController'\` — **37/37** unchanged
- [x] \`docker compose -f docker-compose.e2e.yml up -d --build && E2E_ENABLED=1 dotnet test tests/Andy.Policies.Tests.E2E\` — **2/2** ✅
- [x] \`dotnet test tests/Andy.Policies.Tests.E2E\` (no env var, no live stack) — passes silently (3ms total)
- [ ] Pre-existing \`ItemsControllerTests\` (4 failures) — unchanged; need live Postgres on :5439

## Upstream concern

Same partial-index filter bug almost certainly lives in **every service scaffolded from \`andy-service-template\`** that uses the \"one open draft / one active\" pattern. Worth filing a sibling issue against the template once we know how widespread it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)