### PR TITLE
E2E: real user JWT (auth_code + PKCE) + verify rbac role binding

### DIFF
--- a/tests/Andy.Policies.Tests.E2E/AuthorizationCodeFlow.cs
+++ b/tests/Andy.Policies.Tests.E2E/AuthorizationCodeFlow.cs
@@ -1,0 +1,226 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Andy.Policies.Tests.E2E;
+
+/// <summary>
+/// Programmatic OAuth 2.0 Authorization Code + PKCE flow for end-to-end tests
+/// that need a JWT representing a real user (not a service principal). Targets
+/// andy-auth (#109).
+///
+/// The flow:
+/// <list type="number">
+///   <item>POST <c>/Account/TestLogin</c> with email/password — andy-auth's
+///   Development-only login endpoint that bypasses anti-forgery so tests can
+///   establish the <c>.AspNetCore.Identity.Application</c> session cookie
+///   without scraping CSRF tokens out of an HTML form.</item>
+///   <item>Generate PKCE pair (S256 challenge) — even though andy-auth treats
+///   PKCE as optional, using it is the modern OAuth default and what real
+///   andy-policies-web clients do.</item>
+///   <item>GET <c>/connect/authorize</c> with the cookie → 302 to the
+///   client's <c>redirect_uri</c> with <c>?code=...</c> in the query.</item>
+///   <item>POST <c>/connect/token</c> exchanging the code + verifier for a
+///   bearer access_token.</item>
+/// </list>
+///
+/// The redirect_uri does not need to be reachable — andy-auth just emits a
+/// 302 Location header. We intercept rather than follow.
+/// </summary>
+public sealed class AuthorizationCodeFlow : IDisposable
+{
+    private readonly HttpClient _http;
+    private readonly string _authBaseUrl;
+    private readonly string _clientId;
+    private readonly string _redirectUri;
+    private readonly string _scope;
+
+    private readonly Dictionary<string, string> _cookies = new(StringComparer.OrdinalIgnoreCase);
+
+    public AuthorizationCodeFlow(string authBaseUrl, string clientId, string redirectUri, string scope)
+    {
+        _authBaseUrl = authBaseUrl.TrimEnd('/');
+        _clientId = clientId;
+        _redirectUri = redirectUri;
+        _scope = scope;
+
+        // Manual cookie management — andy-auth's session cookie ships with the
+        // Secure flag (correct in production), which the built-in CookieContainer
+        // would refuse to send over HTTP. Our compose stack exposes andy-auth
+        // on plain HTTP for test simplicity, so we capture Set-Cookie ourselves
+        // and ignore the Secure flag. Scoped to this fixture only.
+        _http = new HttpClient(new HttpClientHandler
+        {
+            UseCookies = false,
+            AllowAutoRedirect = false,
+        });
+    }
+
+    private void CaptureCookies(HttpResponseMessage response)
+    {
+        if (!response.Headers.TryGetValues("Set-Cookie", out var values)) return;
+        foreach (var raw in values)
+        {
+            // "name=value; path=/; secure; ..." — we only need name=value for
+            // replay; flags (path/secure/httponly/samesite) are irrelevant when
+            // we control the request manually.
+            var semi = raw.IndexOf(';');
+            var nameValue = semi < 0 ? raw : raw[..semi];
+            var eq = nameValue.IndexOf('=');
+            if (eq <= 0) continue;
+            var name = nameValue[..eq].Trim();
+            var value = nameValue[(eq + 1)..].Trim();
+            _cookies[name] = value;
+        }
+    }
+
+    private void AttachCookies(HttpRequestMessage request)
+    {
+        if (_cookies.Count == 0) return;
+        var header = string.Join("; ", _cookies.Select(kv => $"{kv.Key}={kv.Value}"));
+        request.Headers.Add("Cookie", header);
+    }
+
+    public void Dispose() => _http.Dispose();
+
+    /// <summary>Run the full flow and return the access_token.</summary>
+    public async Task<string> AcquireUserAccessTokenAsync(string email, string password)
+    {
+        await TestLoginAsync(email, password);
+
+        var (verifier, challenge) = GeneratePkcePair();
+        var state = Guid.NewGuid().ToString("N");
+
+        var code = await GetAuthorizationCodeAsync(challenge, state);
+        return await ExchangeCodeForTokenAsync(code, verifier);
+    }
+
+    private async Task TestLoginAsync(string email, string password)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, $"{_authBaseUrl}/Account/TestLogin")
+        {
+            Content = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("email", email),
+                new KeyValuePair<string, string>("password", password),
+            }),
+        };
+
+        var res = await _http.SendAsync(req);
+        CaptureCookies(res);
+        if (!res.IsSuccessStatusCode && res.StatusCode != HttpStatusCode.Redirect)
+        {
+            var body = await res.Content.ReadAsStringAsync();
+            throw new InvalidOperationException(
+                $"andy-auth /Account/TestLogin returned {(int)res.StatusCode} {res.ReasonPhrase}: {body}");
+        }
+    }
+
+    private async Task<string> GetAuthorizationCodeAsync(string codeChallenge, string state)
+    {
+        var queryParams = new Dictionary<string, string>
+        {
+            ["response_type"] = "code",
+            ["client_id"] = _clientId,
+            ["redirect_uri"] = _redirectUri,
+            ["scope"] = _scope,
+            ["state"] = state,
+            ["code_challenge"] = codeChallenge,
+            ["code_challenge_method"] = "S256",
+        };
+
+        var query = string.Join("&", queryParams.Select(kv =>
+            $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value)}"));
+
+        var req = new HttpRequestMessage(HttpMethod.Get, $"{_authBaseUrl}/connect/authorize?{query}");
+        AttachCookies(req);
+        var res = await _http.SendAsync(req);
+        CaptureCookies(res);
+
+        if (res.StatusCode != HttpStatusCode.Redirect && res.StatusCode != HttpStatusCode.Found)
+        {
+            var body = await res.Content.ReadAsStringAsync();
+            throw new InvalidOperationException(
+                $"Expected 302 from /connect/authorize, got {(int)res.StatusCode} {res.ReasonPhrase}. " +
+                $"Body: {Truncate(body, 500)}");
+        }
+
+        var location = res.Headers.Location
+            ?? throw new InvalidOperationException("/connect/authorize 302 had no Location header.");
+
+        var code = ParseQueryParam(location.Query, "code")
+            ?? throw new InvalidOperationException(
+                $"/connect/authorize redirect did not include ?code=. Location: {location}");
+
+        return code;
+    }
+
+    private static string? ParseQueryParam(string query, string name)
+    {
+        if (string.IsNullOrEmpty(query)) return null;
+        var trimmed = query.StartsWith('?') ? query[1..] : query;
+        foreach (var pair in trimmed.Split('&'))
+        {
+            var eq = pair.IndexOf('=');
+            if (eq < 0) continue;
+            var key = Uri.UnescapeDataString(pair[..eq]);
+            if (string.Equals(key, name, StringComparison.Ordinal))
+            {
+                return Uri.UnescapeDataString(pair[(eq + 1)..]);
+            }
+        }
+        return null;
+    }
+
+    private async Task<string> ExchangeCodeForTokenAsync(string code, string codeVerifier)
+    {
+        var form = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("grant_type", "authorization_code"),
+            new KeyValuePair<string, string>("code", code),
+            new KeyValuePair<string, string>("code_verifier", codeVerifier),
+            new KeyValuePair<string, string>("client_id", _clientId),
+            new KeyValuePair<string, string>("redirect_uri", _redirectUri),
+        });
+
+        var res = await _http.PostAsync($"{_authBaseUrl}/connect/token", form);
+        var body = await res.Content.ReadAsStringAsync();
+        if (!res.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"/connect/token returned {(int)res.StatusCode} {res.ReasonPhrase}: {body}");
+        }
+
+        using var doc = JsonDocument.Parse(body);
+        return doc.RootElement.GetProperty("access_token").GetString()
+            ?? throw new InvalidOperationException("/connect/token response did not include access_token.");
+    }
+
+    private static (string Verifier, string Challenge) GeneratePkcePair()
+    {
+        // RFC 7636 §4.1: 43-128 char URL-safe verifier.
+        var bytes = new byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        var verifier = Base64UrlEncode(bytes);
+
+        // S256: challenge = BASE64URL(SHA256(verifier)).
+        var hash = SHA256.HashData(Encoding.ASCII.GetBytes(verifier));
+        var challenge = Base64UrlEncode(hash);
+
+        return (verifier, challenge);
+    }
+
+    private static string Base64UrlEncode(byte[] bytes) =>
+        Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+
+    private static string Truncate(string s, int max) =>
+        s.Length <= max ? s : s.Substring(0, max) + "…";
+}

--- a/tests/Andy.Policies.Tests.E2E/EndToEndAuthSmokeTest.cs
+++ b/tests/Andy.Policies.Tests.E2E/EndToEndAuthSmokeTest.cs
@@ -43,13 +43,27 @@ namespace Andy.Policies.Tests.E2E;
 /// </summary>
 public sealed class EndToEndAuthSmokeTest : IAsyncLifetime
 {
-    private const string AuthTokenUrl = "http://localhost:7002/connect/token";
+    private const string AuthBaseUrl = "http://localhost:7002";
+    private const string AuthTokenUrl = AuthBaseUrl + "/connect/token";
     private const string PoliciesBaseUrl = "http://localhost:7113";
     private const string RbacBaseUrl = "http://localhost:7004";
     private const string SettingsBaseUrl = "http://localhost:7301";
     private const string ClientId = "andy-policies-api";
     private const string ClientSecret = "e2e-test-secret-not-for-production";
     private const string Audience = "urn:andy-policies-api";
+
+    // andy-policies-web — public OAuth client declared in
+    // config/registration.json; allowed redirect URIs include the one below.
+    private const string WebClientId = "andy-policies-web";
+    private const string WebRedirectUri = "http://localhost:9100/policies/callback";
+
+    // Test user is auto-seeded by andy-auth in non-Production environments
+    // (DbSeeder.cs:1093). Id is pinned to a well-known constant by #56/#57
+    // so andy-rbac (#52/#53) can pre-bind roles via manifest.testUserRole
+    // before the user ever authenticates.
+    private const string TestUserEmail = "test@andy.local";
+    private const string TestUserPassword = "Test123!";
+    private const string TestUserWellKnownId = "00000000-0000-0000-0000-000000000001";
 
     private readonly HttpClient _http = new();
 
@@ -170,6 +184,76 @@ public sealed class EndToEndAuthSmokeTest : IAsyncLifetime
         // settings client wiring), where we'll exercise that path naturally.
         var health = await _http.GetAsync($"{SettingsBaseUrl}/health");
         Assert.Equal(HttpStatusCode.OK, health.StatusCode);
+    }
+
+    [Fact]
+    [Trait("Category", "E2E")]
+    public async Task UserAuthCode_TokenAccepted_ByPoliciesApi()
+    {
+        if (!E2EEnabled) return;
+
+        // 1. Acquire JWT for test@andy.local via authorization_code + PKCE.
+        //    Uses andy-auth's TestLogin endpoint (Development-only, ignores
+        //    anti-forgery) to establish the session cookie, then walks
+        //    /connect/authorize → /connect/token like a real public client.
+        // We only request the API audience scope — the andy-policies-web client
+        // is seeded with raw "email"/"profile"/"roles" permission strings (no
+        // scp: prefix, an upstream andy-auth quirk), so requesting those would
+        // be rejected. The audience scope is the one we actually need on the
+        // resulting access token anyway.
+        using var flow = new AuthorizationCodeFlow(
+            authBaseUrl: AuthBaseUrl,
+            clientId: WebClientId,
+            redirectUri: WebRedirectUri,
+            scope: Audience);
+
+        var token = await flow.AcquireUserAccessTokenAsync(TestUserEmail, TestUserPassword);
+        Assert.False(string.IsNullOrEmpty(token), "andy-auth returned an empty access_token for test user");
+
+        // 2. Use the user JWT against andy-policies. Today this returns 200
+        //    for any authenticated user — RBAC enforcement lands in Epic P7
+        //    (#51 IRbacChecker + #57 authorization handlers). When P7 ships,
+        //    add a companion test that asserts a non-admin user gets 403.
+        var req = new HttpRequestMessage(HttpMethod.Get, $"{PoliciesBaseUrl}/api/policies");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var res = await _http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+    }
+
+    [Fact]
+    [Trait("Category", "E2E")]
+    public async Task AndyRbac_TestUser_HasAdminRoleBindingForPolicies()
+    {
+        if (!E2EEnabled) return;
+
+        // Verifies the cross-repo coordination from rivoli-ai/andy-auth#57
+        // + rivoli-ai/andy-rbac#53: andy-rbac's DataSeeder consumes
+        // testUserRole from andy-policies/config/registration.json and binds
+        // the well-known test subject to the admin role on andy-policies.
+        // /api/subjects/by-external is anonymous in andy-rbac today, so we
+        // can introspect without a JWT.
+        var url = $"{RbacBaseUrl}/api/subjects/by-external/andy-auth/{TestUserWellKnownId}";
+        var res = await _http.GetAsync(url);
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+
+        using var doc = JsonDocument.Parse(await res.Content.ReadAsStringAsync());
+        var roles = doc.RootElement.GetProperty("roles");
+
+        var hasAdminOnPolicies = false;
+        foreach (var role in roles.EnumerateArray())
+        {
+            var roleCode = role.GetProperty("roleCode").GetString();
+            var appCode = role.TryGetProperty("applicationCode", out var ac) ? ac.GetString() : null;
+            if (roleCode == "admin" && appCode == "andy-policies")
+            {
+                hasAdminOnPolicies = true;
+                break;
+            }
+        }
+
+        Assert.True(hasAdminOnPolicies,
+            $"Expected test user ({TestUserEmail}) to have admin role on andy-policies after manifest seeding. " +
+            $"Roles found: {roles}");
     }
 
     private async Task<string> AcquireAccessTokenAsync()


### PR DESCRIPTION
Issue #109. **Leaving open** — closes the user-side of the integration narrative we've been building, but the 403 assertion remains gated on Epic P7 (#51 + #57). When those land, add a non-admin user variant.

## Summary

The cross-repo coordination from rivoli-ai/andy-auth#57 + rivoli-ai/andy-rbac#53 is now exercised end-to-end:

- andy-auth seeds \`test@andy.local\` with a deterministic Id (\`00000000-0000-0000-0000-000000000001\`)
- andy-rbac's \`DataSeeder\` reads \`testUserRole\` from \`andy-policies/config/registration.json\` and binds the well-known test subject to the admin role on andy-policies
- This PR's tests prove the chain: real JWT issued to \`test@andy.local\` is accepted by andy-policies, AND the role binding is queryable in andy-rbac with the matching ExternalId

## Changes

- **\`AuthorizationCodeFlow.cs\`** — programmatic \`authorization_code\` + PKCE (S256) helper. Uses andy-auth's Development-only \`/Account/TestLogin\` (bypasses anti-forgery for test session establishment), then walks \`/connect/authorize\` → \`/connect/token\` like a real public client. Manages cookies manually (built-in \`CookieContainer\` respects the \`Secure\` flag; compose exposes andy-auth on plain HTTP for test simplicity).
- **EndToEndAuthSmokeTest** — two new tests:
  - \`UserAuthCode_TokenAccepted_ByPoliciesApi\` — full flow: acquire JWT for test user via auth_code, hit \`GET /api/policies\`, expect 200. Once P7 ships, the same path will return 403 for non-admin users (add the companion test then).
  - \`AndyRbac_TestUser_HasAdminRoleBindingForPolicies\` — assert the role binding is queryable in andy-rbac. Locks cross-repo coordination so a regression in either DataSeeder breaks CI immediately.

## Notable upstream quirks (documented inline)

- The \`andy-policies-web\` client's permissions list bare scope strings (\`email\`, \`profile\`, \`roles\`) instead of \`scp:email\` etc. — only \`scp:urn:andy-policies-api\` is grantable today. Test requests only the audience scope. Worth a separate andy-auth issue if anyone needs the standard OIDC scopes.

## Test plan

- [x] \`bash ../andy-settings/scripts/pack-local.sh\` (one-time prereq)
- [x] \`docker compose -f docker-compose.e2e.yml up -d --build\` — full 8-container stack
- [x] \`E2E_ENABLED=1 dotnet test tests/Andy.Policies.Tests.E2E\` — **6/6** ✅
- [x] \`dotnet test tests/Andy.Policies.Tests.E2E\` (no env var) — passes silently (3ms)
- [x] Pre-existing unit + integration suites unchanged

## What's left on #109

- 403 assertion for non-admin user — blocked on Epic P7. Test infrastructure is in place; assertion is a 5-line addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)