### PR TITLE
Implement P1.6 — MCP read tools (policy.list/get + policy.version.list/get/get-active)

### DIFF
--- a/src/Andy.Policies.Api/Mcp/PolicyTools.cs
+++ b/src/Andy.Policies.Api/Mcp/PolicyTools.cs
@@ -1,0 +1,192 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.ComponentModel;
+using System.Text;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Application.Queries;
+using ModelContextProtocol.Server;
+
+namespace Andy.Policies.Api.Mcp;
+
+/// <summary>
+/// Read-only MCP tools over the policy catalog (P1.6, story
+/// rivoli-ai/andy-policies#76). All five tools delegate to
+/// <see cref="IPolicyService"/> — the same service powering the REST surface
+/// (P1.5) and gRPC (P1.7) — so wire formats stay consistent across surfaces.
+///
+/// Mutating tools (create/update/bump) and lifecycle transitions land in
+/// later stories: P2.5 publishes, P3.5 bindings, P5.6 overrides, P8.5 bundles.
+/// </summary>
+[McpServerToolType]
+public static class PolicyTools
+{
+    [McpServerTool(Name = "policy.list"), Description(
+        "List policies with optional filters. Filters apply against the active version " +
+        "of each policy (highest non-Draft); policies with no active version are excluded " +
+        "from filtered results but appear in unfiltered ones. Returns a summary line per " +
+        "policy with name, version count, and active version id.")]
+    public static async Task<string> ListPolicies(
+        IPolicyService policies,
+        [Description("Optional case-sensitive prefix on Policy.Name (e.g. 'risk-')")] string? namePrefix = null,
+        [Description("Optional exact-match scope membership filter (e.g. 'prod')")] string? scope = null,
+        [Description("Optional enforcement filter — MAY / SHOULD / MUST (case-insensitive)")] string? enforcement = null,
+        [Description("Optional severity filter — info / moderate / critical (case-insensitive)")] string? severity = null,
+        [Description("Pagination offset (default 0)")] int skip = 0,
+        [Description("Page size (default 100, capped at 500)")] int take = 100)
+    {
+        var query = new ListPoliciesQuery(namePrefix, scope, enforcement, severity, skip, take);
+        var results = await policies.ListPoliciesAsync(query);
+
+        if (results.Count == 0)
+        {
+            return "No policies found matching the supplied filters.";
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"{results.Count} polic{(results.Count == 1 ? "y" : "ies")}:");
+        foreach (var p in results)
+        {
+            sb.AppendLine(FormatPolicyLine(p));
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    [McpServerTool(Name = "policy.get"), Description(
+        "Get a single policy by id. Returns the stable identity (name, description) plus " +
+        "version-history summary (count + active version id, if any). Use " +
+        "policy.version.list to enumerate the versions themselves.")]
+    public static async Task<string> GetPolicy(
+        IPolicyService policies,
+        [Description("Policy id (GUID)")] string policyId)
+    {
+        if (!Guid.TryParse(policyId, out var id))
+        {
+            return $"Invalid policy id: '{policyId}' is not a valid GUID.";
+        }
+
+        var policy = await policies.GetPolicyAsync(id);
+        if (policy is null)
+        {
+            return $"Policy {id} not found.";
+        }
+
+        return FormatPolicyDetail(policy);
+    }
+
+    [McpServerTool(Name = "policy.version.list"), Description(
+        "List all versions of a policy in descending version order (newest first). Each " +
+        "line shows version number, lifecycle state, enforcement, severity, and proposer.")]
+    public static async Task<string> ListVersions(
+        IPolicyService policies,
+        [Description("Policy id (GUID)")] string policyId)
+    {
+        if (!Guid.TryParse(policyId, out var id))
+        {
+            return $"Invalid policy id: '{policyId}' is not a valid GUID.";
+        }
+
+        var versions = await policies.ListVersionsAsync(id);
+        if (versions.Count == 0)
+        {
+            return $"No versions found for policy {id}. Either the policy does not exist or has no versions yet.";
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"{versions.Count} version{(versions.Count == 1 ? "" : "s")} of policy {id}:");
+        foreach (var v in versions)
+        {
+            sb.AppendLine(FormatVersionLine(v));
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    [McpServerTool(Name = "policy.version.get"), Description(
+        "Get a specific version of a policy. Returns full content: enforcement, severity, " +
+        "scopes, summary, and the rules JSON blob.")]
+    public static async Task<string> GetVersion(
+        IPolicyService policies,
+        [Description("Policy id (GUID)")] string policyId,
+        [Description("Version id (GUID) — use policy.version.list to discover")] string versionId)
+    {
+        if (!Guid.TryParse(policyId, out var pid))
+        {
+            return $"Invalid policy id: '{policyId}' is not a valid GUID.";
+        }
+        if (!Guid.TryParse(versionId, out var vid))
+        {
+            return $"Invalid version id: '{versionId}' is not a valid GUID.";
+        }
+
+        var version = await policies.GetVersionAsync(pid, vid);
+        if (version is null)
+        {
+            return $"Version {vid} not found under policy {pid}.";
+        }
+
+        return FormatVersionDetail(version);
+    }
+
+    [McpServerTool(Name = "policy.version.get-active"), Description(
+        "Get the active version of a policy. Active = highest version with State != Draft " +
+        "(ADR 0001 §4); returns 'no active version' while every version is still a Draft.")]
+    public static async Task<string> GetActiveVersion(
+        IPolicyService policies,
+        [Description("Policy id (GUID)")] string policyId)
+    {
+        if (!Guid.TryParse(policyId, out var id))
+        {
+            return $"Invalid policy id: '{policyId}' is not a valid GUID.";
+        }
+
+        var version = await policies.GetActiveVersionAsync(id);
+        if (version is null)
+        {
+            return $"Policy {id} has no active version (every version is still in Draft, or the policy does not exist).";
+        }
+
+        return FormatVersionDetail(version);
+    }
+
+    // -- formatters ----------------------------------------------------------
+
+    private static string FormatPolicyLine(PolicyDto p)
+    {
+        var active = p.ActiveVersionId is null
+            ? "no active version"
+            : $"active version {p.ActiveVersionId}";
+        return $"- {p.Name} ({p.Id}) — {p.VersionCount} version{(p.VersionCount == 1 ? "" : "s")}, {active}";
+    }
+
+    private static string FormatPolicyDetail(PolicyDto p)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Policy: {p.Name}");
+        sb.AppendLine($"Id: {p.Id}");
+        sb.AppendLine($"Description: {p.Description ?? "(none)"}");
+        sb.AppendLine($"Created: {p.CreatedAt:u} by {p.CreatedBySubjectId}");
+        sb.AppendLine($"Versions: {p.VersionCount}");
+        sb.AppendLine($"Active version: {(p.ActiveVersionId?.ToString() ?? "(none — all drafts)")}");
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string FormatVersionLine(PolicyVersionDto v) =>
+        $"- v{v.Version} ({v.Id}) — {v.State}, {v.Enforcement}/{v.Severity}, proposer={v.ProposerSubjectId}";
+
+    private static string FormatVersionDetail(PolicyVersionDto v)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Version: v{v.Version} of policy {v.PolicyId}");
+        sb.AppendLine($"Id: {v.Id}");
+        sb.AppendLine($"State: {v.State}");
+        sb.AppendLine($"Enforcement: {v.Enforcement}");
+        sb.AppendLine($"Severity: {v.Severity}");
+        sb.AppendLine($"Scopes: {(v.Scopes.Count == 0 ? "(none)" : string.Join(", ", v.Scopes))}");
+        sb.AppendLine($"Summary: {v.Summary}");
+        sb.AppendLine($"Created: {v.CreatedAt:u} by {v.CreatedBySubjectId} (proposer: {v.ProposerSubjectId})");
+        sb.AppendLine($"Rules:");
+        sb.AppendLine(v.RulesJson);
+        return sb.ToString().TrimEnd();
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Mcp/PolicyToolsTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/PolicyToolsTests.cs
@@ -1,0 +1,238 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Api.Mcp;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Mcp;
+
+/// <summary>
+/// Unit tests for the MCP read tools (P1.6, story rivoli-ai/andy-policies#76).
+/// Exercises the static tool methods directly against a real
+/// <see cref="PolicyService"/> backed by EF Core InMemory — proves both the
+/// formatter logic and the service delegation. The MCP transport itself is
+/// provided by the ModelContextProtocol library and is out of scope here;
+/// transport-level coverage lands with the cross-surface parity sweep
+/// (P1.11, #91).
+/// </summary>
+public class PolicyToolsTests
+{
+    private static AppDbContext CreateInMemoryDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static CreatePolicyRequest MinimalCreate(string name, string? scope = null) => new(
+        Name: name,
+        Description: null,
+        Summary: "summary",
+        Enforcement: "Must",
+        Severity: "Critical",
+        Scopes: scope is null ? Array.Empty<string>() : new[] { scope },
+        RulesJson: "{}");
+
+    [Fact]
+    public async Task ListPolicies_NoMatches_ReturnsHelpfulEmptyMessage()
+    {
+        using var db = CreateInMemoryDb();
+        var service = new PolicyService(db);
+
+        var output = await PolicyTools.ListPolicies(service, namePrefix: "no-such-");
+
+        Assert.Contains("No policies found", output);
+    }
+
+    [Fact]
+    public async Task ListPolicies_FormatsSummaryLine_PerPolicy()
+    {
+        using var db = CreateInMemoryDb();
+        var service = new PolicyService(db);
+        await service.CreateDraftAsync(MinimalCreate("first"), "sam");
+        await service.CreateDraftAsync(MinimalCreate("second"), "sam");
+
+        var output = await PolicyTools.ListPolicies(service);
+
+        Assert.Contains("2 policies:", output);
+        Assert.Contains("first", output);
+        Assert.Contains("second", output);
+        Assert.Contains("1 version", output);
+        Assert.Contains("no active version", output);
+    }
+
+    [Fact]
+    public async Task ListPolicies_PassesFiltersThrough_ToService()
+    {
+        using var db = CreateInMemoryDb();
+        var service = new PolicyService(db);
+        var a = await service.CreateDraftAsync(MinimalCreate("filtered", scope: "prod"), "sam");
+        await service.CreateDraftAsync(MinimalCreate("ignored", scope: "staging"), "sam");
+        var entity = await db.PolicyVersions.FirstAsync(v => v.Id == a.Id);
+        entity.State = LifecycleState.Active;
+        await db.SaveChangesAsync();
+
+        var output = await PolicyTools.ListPolicies(service, scope: "prod");
+
+        Assert.Contains("filtered", output);
+        Assert.DoesNotContain("ignored", output);
+    }
+
+    [Fact]
+    public async Task GetPolicy_InvalidGuid_ReturnsValidationMessage_WithoutCallingService()
+    {
+        using var db = CreateInMemoryDb();
+        var service = new PolicyService(db);
+
+        var output = await PolicyTools.GetPolicy(service, policyId: "not-a-guid");
+
+        Assert.Contains("not a valid GUID", output);
+    }
+
+    [Fact]
+    public async Task GetPolicy_NotFound_ReturnsHelpfulMessage()
+    {
+        using var db = CreateInMemoryDb();
+        var service = new PolicyService(db);
+        var missing = Guid.NewGuid();
+
+        var output = await PolicyTools.GetPolicy(service, missing.ToString());
+
+        Assert.Contains($"Policy {missing} not found", output);
+    }
+
+    [Fact]
+    public async Task GetPolicy_Found_FormatsDetail()
+    {
+        using var db = CreateInMemoryDb();
+        var service = new PolicyService(db);
+        var v = await service.CreateDraftAsync(MinimalCreate("detail-policy"), "sam");
+
+        var output = await PolicyTools.GetPolicy(service, v.PolicyId.ToString());
+
+        Assert.Contains("Policy: detail-policy", output);
+        Assert.Contains("Versions: 1", output);
+        Assert.Contains("(none — all drafts)", output);
+    }
+
+    [Fact]
+    public async Task ListVersions_ReturnsDescendingOrder_WithStateAndDimensions()
+    {
+        using var db = CreateInMemoryDb();
+        var service = new PolicyService(db);
+        var v1 = await service.CreateDraftAsync(MinimalCreate("multi-version"), "sam");
+        var entity = await db.PolicyVersions.FirstAsync(x => x.Id == v1.Id);
+        entity.State = LifecycleState.Active;
+        await db.SaveChangesAsync();
+        var v2 = await service.BumpDraftFromVersionAsync(v1.PolicyId, v1.Id, "alice");
+
+        var output = await PolicyTools.ListVersions(service, v1.PolicyId.ToString());
+
+        Assert.Contains("2 versions", output);
+        // v2 (Draft) appears before v1 (Active) — descending order.
+        var v2Index = output.IndexOf("v2 (");
+        var v1Index = output.IndexOf("v1 (");
+        Assert.True(v2Index > -1 && v1Index > v2Index, "Expected v2 before v1 (descending)");
+        Assert.Contains("Draft", output);
+        Assert.Contains("Active", output);
+        Assert.Contains("MUST/critical", output);
+    }
+
+    [Fact]
+    public async Task ListVersions_NoSuchPolicy_ReturnsHelpfulEmptyMessage()
+    {
+        using var db = CreateInMemoryDb();
+        var service = new PolicyService(db);
+
+        var output = await PolicyTools.ListVersions(service, Guid.NewGuid().ToString());
+
+        Assert.Contains("No versions found", output);
+    }
+
+    [Fact]
+    public async Task GetVersion_Found_FormatsRulesJsonAndScopes()
+    {
+        using var db = CreateInMemoryDb();
+        var service = new PolicyService(db);
+        var v = await service.CreateDraftAsync(
+            MinimalCreate("rich-version", scope: "prod") with { RulesJson = "{\"allow\":true}" },
+            "sam");
+
+        var output = await PolicyTools.GetVersion(service, v.PolicyId.ToString(), v.Id.ToString());
+
+        Assert.Contains($"v{v.Version} of policy {v.PolicyId}", output);
+        Assert.Contains("State: Draft", output);
+        Assert.Contains("Enforcement: MUST", output);
+        Assert.Contains("Severity: critical", output);
+        Assert.Contains("Scopes: prod", output);
+        Assert.Contains("{\"allow\":true}", output);
+    }
+
+    [Fact]
+    public async Task GetVersion_NotFound_ReturnsHelpfulMessage()
+    {
+        using var db = CreateInMemoryDb();
+        var service = new PolicyService(db);
+        var missingPolicy = Guid.NewGuid();
+        var missingVersion = Guid.NewGuid();
+
+        var output = await PolicyTools.GetVersion(
+            service, missingPolicy.ToString(), missingVersion.ToString());
+
+        Assert.Contains("not found", output);
+    }
+
+    [Fact]
+    public async Task GetActiveVersion_AllDraft_ReturnsHelpfulMessage()
+    {
+        using var db = CreateInMemoryDb();
+        var service = new PolicyService(db);
+        var v = await service.CreateDraftAsync(MinimalCreate("only-draft"), "sam");
+
+        var output = await PolicyTools.GetActiveVersion(service, v.PolicyId.ToString());
+
+        Assert.Contains("no active version", output);
+    }
+
+    [Fact]
+    public async Task GetActiveVersion_AfterTransition_ResolvesAndFormatsDetail()
+    {
+        using var db = CreateInMemoryDb();
+        var service = new PolicyService(db);
+        var v = await service.CreateDraftAsync(MinimalCreate("active-flow"), "sam");
+        var entity = await db.PolicyVersions.FirstAsync(x => x.Id == v.Id);
+        entity.State = LifecycleState.Active;
+        await db.SaveChangesAsync();
+
+        var output = await PolicyTools.GetActiveVersion(service, v.PolicyId.ToString());
+
+        Assert.Contains($"v{v.Version} of policy {v.PolicyId}", output);
+        Assert.Contains("State: Active", output);
+    }
+
+    [Fact]
+    public async Task AllToolsTakingGuidArguments_RejectMalformedInput_BeforeServiceCall()
+    {
+        using var db = CreateInMemoryDb();
+        var service = new PolicyService(db);
+
+        Assert.Contains("not a valid GUID",
+            await PolicyTools.GetPolicy(service, "abc"));
+        Assert.Contains("not a valid GUID",
+            await PolicyTools.ListVersions(service, "abc"));
+        Assert.Contains("not a valid GUID",
+            await PolicyTools.GetActiveVersion(service, "abc"));
+        Assert.Contains("not a valid GUID",
+            await PolicyTools.GetVersion(service, "abc", Guid.NewGuid().ToString()));
+        Assert.Contains("not a valid GUID",
+            await PolicyTools.GetVersion(service, Guid.NewGuid().ToString(), "abc"));
+    }
+}


### PR DESCRIPTION
Closes #76.

## Summary

Five read-only MCP tools over the policy catalog, all delegating to \`IPolicyService\` (the same service powering REST in P1.5):

| Tool | Purpose |
|---|---|
| \`policy.list\` | Filtered + paginated list (namePrefix / scope / enforcement / severity) |
| \`policy.get\` | By id; returns identity + version-history summary |
| \`policy.version.list\` | All versions of a policy, descending by version number |
| \`policy.version.get\` | Single version; full content (enforcement, severity, scopes, rules JSON) |
| \`policy.version.get-active\` | Highest non-Draft version per ADR 0001 §4 |

Mutating tools land in later stories (P2.5 publish, P5.6 overrides, P8.5 bundles).

## Design notes

- **Tool naming** uses the \`policy.*\` namespace via \`[McpServerTool(Name = \"policy.version.list\")]\` — the C# method name doesn't need to match the dot-separated convention.
- **Returns formatted text strings** (matching existing \`ServiceTools\` / \`HelpTools\`). Easier for LLM consumption, human-readable in MCP client UIs. Wire-format casing (MUST/SHOULD/MAY, lowercase severity) is already baked into \`PolicyVersionDto\` from P1.4.
- **GUID validation** at the tool boundary — saves a service round-trip for typos and gives LLMs an actionable error.
- **Filters** pass through verbatim to \`ListPoliciesQuery\`, so behavior matches REST exactly.

## Test plan

- [x] \`dotnet build\` — 0 warnings (TreatWarningsAsErrors)
- [x] \`dotnet test tests/Andy.Policies.Tests.Unit\` — **77/77** unchanged
- [x] \`dotnet test tests/Andy.Policies.Tests.Integration\` (excluding pre-existing \`ItemsControllerTests\`) — **52/52** (was 39 → +13 new \`PolicyToolsTests\`):
  - empty-result formatting · multi-policy summary line shape
  - filter pass-through (scope excludes non-matching)
  - GUID validation error (5 endpoints)
  - not-found vs found formatting
  - version list ordering (descending) · rules-json + scopes round-trip
  - active-version null when all-Draft · resolves after forced transition
- [x] E2E suite unaffected — runs against live stack independently

## Out of scope (tracked)

- **MCP transport-level integration tests** (real MCP client over \`/mcp\` HTTP) — the static method tests cover the logic; transport parity sweep lands in P1.11 (#91) alongside REST/gRPC/CLI parity.
- **Mutating tools** — separate stories per the issue scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)