### PR TITLE
Implement P1.7 — gRPC PolicyService (list/get/version/draft RPCs)

### DIFF
--- a/src/Andy.Policies.Api/Andy.Policies.Api.csproj
+++ b/src/Andy.Policies.Api/Andy.Policies.Api.csproj
@@ -34,6 +34,9 @@
 
   <ItemGroup>
     <Protobuf Include="Protos\items.proto" GrpcServices="Server" />
+    <!-- Both: integration tests reference the API project to drive the gRPC
+         surface end-to-end; they need the generated client classes too. -->
+    <Protobuf Include="Protos\policies.proto" GrpcServices="Both" />
   </ItemGroup>
 
 </Project>

--- a/src/Andy.Policies.Api/GrpcServices/PolicyGrpcService.cs
+++ b/src/Andy.Policies.Api/GrpcServices/PolicyGrpcService.cs
@@ -1,0 +1,239 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Api.Protos;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Exceptions;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Application.Queries;
+using Grpc.Core;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+
+namespace Andy.Policies.Api.GrpcServices;
+
+/// <summary>
+/// gRPC surface for the policy catalog (P1.7, story rivoli-ai/andy-policies#77).
+/// Delegates to <see cref="IPolicyService"/> — the same service powering REST
+/// (P1.5) and MCP (P1.6). Service exceptions are translated to gRPC status
+/// codes per the table below; the equivalent HTTP mappings live in
+/// <c>PolicyExceptionHandler</c>.
+///
+/// <list type="table">
+///   <listheader><term>Exception</term><description>gRPC status / HTTP equivalent</description></listheader>
+///   <item><term><see cref="ValidationException"/></term><description>InvalidArgument / 400</description></item>
+///   <item><term><see cref="NotFoundException"/></term><description>NotFound / 404</description></item>
+///   <item><term><see cref="ConflictException"/></term><description>AlreadyExists / 409</description></item>
+///   <item><term><see cref="DbUpdateConcurrencyException"/></term><description>Aborted / 412</description></item>
+/// </list>
+/// </summary>
+[Authorize]
+public class PolicyGrpcService : Protos.PolicyService.PolicyServiceBase
+{
+    private readonly IPolicyService _policies;
+
+    public PolicyGrpcService(IPolicyService policies)
+    {
+        _policies = policies;
+    }
+
+    // -- read RPCs ------------------------------------------------------------
+
+    public override async Task<ListPoliciesResponse> ListPolicies(ListPoliciesRequest request, ServerCallContext context)
+    {
+        try
+        {
+            var query = new ListPoliciesQuery(
+                NamePrefix: NullIfEmpty(request.NamePrefix),
+                Scope: NullIfEmpty(request.Scope),
+                Enforcement: NullIfEmpty(request.Enforcement),
+                Severity: NullIfEmpty(request.Severity),
+                Skip: request.Skip,
+                Take: request.Take == 0 ? 100 : request.Take);
+
+            var results = await _policies.ListPoliciesAsync(query, context.CancellationToken);
+
+            var response = new ListPoliciesResponse();
+            response.Policies.AddRange(results.Select(ToMessage));
+            return response;
+        }
+        catch (Exception ex) { throw MapToRpcException(ex); }
+    }
+
+    public override async Task<PolicyResponse> GetPolicy(GetPolicyRequest request, ServerCallContext context)
+    {
+        var id = ParseGuidOrThrow(request.Id, "id");
+        var policy = await _policies.GetPolicyAsync(id, context.CancellationToken);
+        if (policy is null)
+            throw new RpcException(new Status(StatusCode.NotFound, $"Policy {id} not found."));
+        return new PolicyResponse { Policy = ToMessage(policy) };
+    }
+
+    public override async Task<PolicyResponse> GetPolicyByName(GetPolicyByNameRequest request, ServerCallContext context)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name))
+            throw new RpcException(new Status(StatusCode.InvalidArgument, "name is required."));
+
+        var policy = await _policies.GetPolicyByNameAsync(request.Name, context.CancellationToken);
+        if (policy is null)
+            throw new RpcException(new Status(StatusCode.NotFound, $"Policy '{request.Name}' not found."));
+        return new PolicyResponse { Policy = ToMessage(policy) };
+    }
+
+    public override async Task<ListVersionsResponse> ListVersions(ListVersionsRequest request, ServerCallContext context)
+    {
+        var policyId = ParseGuidOrThrow(request.PolicyId, "policy_id");
+        var versions = await _policies.ListVersionsAsync(policyId, context.CancellationToken);
+        var response = new ListVersionsResponse();
+        response.Versions.AddRange(versions.Select(ToMessage));
+        return response;
+    }
+
+    public override async Task<PolicyVersionResponse> GetVersion(GetVersionRequest request, ServerCallContext context)
+    {
+        var policyId = ParseGuidOrThrow(request.PolicyId, "policy_id");
+        var versionId = ParseGuidOrThrow(request.VersionId, "version_id");
+        var version = await _policies.GetVersionAsync(policyId, versionId, context.CancellationToken);
+        if (version is null)
+            throw new RpcException(new Status(StatusCode.NotFound,
+                $"Version {versionId} not found under policy {policyId}."));
+        return new PolicyVersionResponse { Version = ToMessage(version) };
+    }
+
+    public override async Task<PolicyVersionResponse> GetActiveVersion(GetActiveVersionRequest request, ServerCallContext context)
+    {
+        var policyId = ParseGuidOrThrow(request.PolicyId, "policy_id");
+        var version = await _policies.GetActiveVersionAsync(policyId, context.CancellationToken);
+        if (version is null)
+            throw new RpcException(new Status(StatusCode.NotFound,
+                $"Policy {policyId} has no active version."));
+        return new PolicyVersionResponse { Version = ToMessage(version) };
+    }
+
+    // -- draft mutation RPCs --------------------------------------------------
+
+    public override async Task<PolicyVersionResponse> CreateDraft(CreateDraftRequest request, ServerCallContext context)
+    {
+        try
+        {
+            var dto = await _policies.CreateDraftAsync(
+                new CreatePolicyRequest(
+                    Name: request.Name,
+                    Description: NullIfEmpty(request.Description),
+                    Summary: request.Summary,
+                    Enforcement: request.Enforcement,
+                    Severity: request.Severity,
+                    Scopes: request.Scopes.ToList(),
+                    RulesJson: request.RulesJson),
+                ResolveSubjectId(context),
+                context.CancellationToken);
+
+            return new PolicyVersionResponse { Version = ToMessage(dto) };
+        }
+        catch (Exception ex) { throw MapToRpcException(ex); }
+    }
+
+    public override async Task<PolicyVersionResponse> UpdateDraft(UpdateDraftRequest request, ServerCallContext context)
+    {
+        var policyId = ParseGuidOrThrow(request.PolicyId, "policy_id");
+        var versionId = ParseGuidOrThrow(request.VersionId, "version_id");
+        try
+        {
+            var dto = await _policies.UpdateDraftAsync(
+                policyId, versionId,
+                new UpdatePolicyVersionRequest(
+                    Summary: request.Summary,
+                    Enforcement: request.Enforcement,
+                    Severity: request.Severity,
+                    Scopes: request.Scopes.ToList(),
+                    RulesJson: request.RulesJson),
+                ResolveSubjectId(context),
+                context.CancellationToken);
+
+            return new PolicyVersionResponse { Version = ToMessage(dto) };
+        }
+        catch (Exception ex) { throw MapToRpcException(ex); }
+    }
+
+    public override async Task<PolicyVersionResponse> BumpDraft(BumpDraftRequest request, ServerCallContext context)
+    {
+        var policyId = ParseGuidOrThrow(request.PolicyId, "policy_id");
+        var sourceVersionId = ParseGuidOrThrow(request.SourceVersionId, "source_version_id");
+        try
+        {
+            var dto = await _policies.BumpDraftFromVersionAsync(
+                policyId, sourceVersionId, ResolveSubjectId(context), context.CancellationToken);
+
+            return new PolicyVersionResponse { Version = ToMessage(dto) };
+        }
+        catch (Exception ex) { throw MapToRpcException(ex); }
+    }
+
+    // -- helpers --------------------------------------------------------------
+
+    private static string? NullIfEmpty(string? s) =>
+        string.IsNullOrWhiteSpace(s) ? null : s;
+
+    private static Guid ParseGuidOrThrow(string raw, string field)
+    {
+        if (!Guid.TryParse(raw, out var guid))
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument,
+                $"{field} '{raw}' is not a valid GUID."));
+        }
+        return guid;
+    }
+
+    private static string ResolveSubjectId(ServerCallContext context)
+    {
+        // Mirrors PoliciesController + ItemsGrpcService: prefer the
+        // authenticated principal name, fall back to a labeled placeholder.
+        var http = context.GetHttpContext();
+        return http?.User.Identity?.Name ?? "grpc-anonymous";
+    }
+
+    private static RpcException MapToRpcException(Exception ex) => ex switch
+    {
+        ValidationException v          => new RpcException(new Status(StatusCode.InvalidArgument, v.Message)),
+        NotFoundException n            => new RpcException(new Status(StatusCode.NotFound, n.Message)),
+        ConflictException c            => new RpcException(new Status(StatusCode.AlreadyExists, c.Message)),
+        DbUpdateConcurrencyException d => new RpcException(new Status(StatusCode.Aborted, d.Message)),
+        _ => throw new InvalidOperationException(
+            $"Unmapped exception in PolicyGrpcService: {ex.GetType().Name}", ex),
+    };
+
+    private static PolicyMessage ToMessage(PolicyDto dto)
+    {
+        var msg = new PolicyMessage
+        {
+            Id = dto.Id.ToString(),
+            Name = dto.Name,
+            CreatedAt = dto.CreatedAt.ToString("o"),
+            CreatedBySubjectId = dto.CreatedBySubjectId,
+            VersionCount = dto.VersionCount,
+        };
+        if (dto.Description is not null) msg.Description = dto.Description;
+        if (dto.ActiveVersionId is not null) msg.ActiveVersionId = dto.ActiveVersionId.Value.ToString();
+        return msg;
+    }
+
+    private static PolicyVersionMessage ToMessage(PolicyVersionDto dto)
+    {
+        var msg = new PolicyVersionMessage
+        {
+            Id = dto.Id.ToString(),
+            PolicyId = dto.PolicyId.ToString(),
+            Version = dto.Version,
+            State = dto.State,
+            Enforcement = dto.Enforcement,
+            Severity = dto.Severity,
+            Summary = dto.Summary,
+            RulesJson = dto.RulesJson,
+            CreatedAt = dto.CreatedAt.ToString("o"),
+            CreatedBySubjectId = dto.CreatedBySubjectId,
+            ProposerSubjectId = dto.ProposerSubjectId,
+        };
+        msg.Scopes.AddRange(dto.Scopes);
+        return msg;
+    }
+}

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -218,6 +218,7 @@ app.MapControllers();
 
 // --- gRPC endpoint ---
 app.MapGrpcService<Andy.Policies.Api.GrpcServices.ItemsGrpcService>();
+app.MapGrpcService<Andy.Policies.Api.GrpcServices.PolicyGrpcService>();
 
 // --- MCP endpoint ---
 app.MapMcp("/mcp")

--- a/src/Andy.Policies.Api/Protos/policies.proto
+++ b/src/Andy.Policies.Api/Protos/policies.proto
@@ -1,0 +1,137 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+//
+// Wire contract for the policy catalog gRPC surface (P1.7,
+// rivoli-ai/andy-policies#77). All operations delegate to IPolicyService —
+// the same service powering REST (P1.5), MCP (P1.6), and the future CLI
+// (P1.8). Wire-format casing follows ADR 0001 §6:
+//
+//   - enforcement: uppercase RFC 2119 — MAY / SHOULD / MUST
+//   - severity:    lowercase           — info / moderate / critical
+//   - state:       PascalCase          — Draft / Active / WindingDown / Retired
+//
+// Casing is enforced by the service layer; this proto stays neutral with
+// `string` typing rather than enums so we don't fork the contract.
+
+syntax = "proto3";
+
+option csharp_namespace = "Andy.Policies.Api.Protos";
+
+package andy_policies;
+
+service PolicyService {
+  // -- read --
+  rpc ListPolicies (ListPoliciesRequest) returns (ListPoliciesResponse);
+  rpc GetPolicy (GetPolicyRequest) returns (PolicyResponse);
+  rpc GetPolicyByName (GetPolicyByNameRequest) returns (PolicyResponse);
+  rpc ListVersions (ListVersionsRequest) returns (ListVersionsResponse);
+  rpc GetVersion (GetVersionRequest) returns (PolicyVersionResponse);
+  rpc GetActiveVersion (GetActiveVersionRequest) returns (PolicyVersionResponse);
+
+  // -- draft mutations --
+  rpc CreateDraft (CreateDraftRequest) returns (PolicyVersionResponse);
+  rpc UpdateDraft (UpdateDraftRequest) returns (PolicyVersionResponse);
+  rpc BumpDraft (BumpDraftRequest) returns (PolicyVersionResponse);
+}
+
+// -- shared messages -------------------------------------------------------
+
+message PolicyMessage {
+  string id = 1;
+  string name = 2;
+  optional string description = 3;
+  string created_at = 4;             // ISO 8601 (DateTimeOffset.ToString("o"))
+  string created_by_subject_id = 5;
+  int32 version_count = 6;
+  optional string active_version_id = 7;  // null while every version is Draft
+}
+
+message PolicyVersionMessage {
+  string id = 1;
+  string policy_id = 2;
+  int32 version = 3;
+  string state = 4;                  // PascalCase per ADR 0001 §6
+  string enforcement = 5;            // uppercase per ADR 0001 §6
+  string severity = 6;               // lowercase per ADR 0001 §6
+  repeated string scopes = 7;
+  string summary = 8;
+  string rules_json = 9;             // opaque DSL blob, capped at 64 KB (ADR 0001 §5)
+  string created_at = 10;
+  string created_by_subject_id = 11;
+  string proposer_subject_id = 12;
+}
+
+// -- read RPCs -------------------------------------------------------------
+
+message ListPoliciesRequest {
+  optional string name_prefix = 1;
+  optional string scope = 2;
+  optional string enforcement = 3;
+  optional string severity = 4;
+  int32 skip = 5;                    // default 0
+  int32 take = 6;                    // default 100, capped at 500
+}
+
+message ListPoliciesResponse {
+  repeated PolicyMessage policies = 1;
+}
+
+message GetPolicyRequest {
+  string id = 1;
+}
+
+message GetPolicyByNameRequest {
+  string name = 1;
+}
+
+message PolicyResponse {
+  PolicyMessage policy = 1;
+}
+
+message ListVersionsRequest {
+  string policy_id = 1;
+}
+
+message ListVersionsResponse {
+  repeated PolicyVersionMessage versions = 1;
+}
+
+message GetVersionRequest {
+  string policy_id = 1;
+  string version_id = 2;
+}
+
+message GetActiveVersionRequest {
+  string policy_id = 1;
+}
+
+message PolicyVersionResponse {
+  PolicyVersionMessage version = 1;
+}
+
+// -- draft mutation RPCs ---------------------------------------------------
+
+message CreateDraftRequest {
+  string name = 1;
+  optional string description = 2;
+  string summary = 3;
+  string enforcement = 4;            // case-insensitive on input
+  string severity = 5;
+  repeated string scopes = 6;
+  string rules_json = 7;
+}
+
+message UpdateDraftRequest {
+  string policy_id = 1;
+  string version_id = 2;
+  string summary = 3;
+  string enforcement = 4;
+  string severity = 5;
+  repeated string scopes = 6;
+  string rules_json = 7;
+}
+
+message BumpDraftRequest {
+  string policy_id = 1;
+  string source_version_id = 2;
+}

--- a/tests/Andy.Policies.Tests.Integration/Andy.Policies.Tests.Integration.csproj
+++ b/tests/Andy.Policies.Tests.Integration/Andy.Policies.Tests.Integration.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Grpc.Net.Client" Version="2.67.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />

--- a/tests/Andy.Policies.Tests.Integration/GrpcServices/PolicyGrpcServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/GrpcServices/PolicyGrpcServiceTests.cs
@@ -1,0 +1,247 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Api.Protos;
+using Andy.Policies.Tests.Integration.Controllers;
+using Grpc.Core;
+using Grpc.Net.Client;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.GrpcServices;
+
+/// <summary>
+/// End-to-end gRPC tests (P1.7, story rivoli-ai/andy-policies#77). Spins up
+/// the API via <see cref="PoliciesApiFactory"/>, builds an in-process HTTP/2
+/// channel against the test server, and exercises every RPC. Catches any
+/// regression in the proto contract, generated stubs, exception mapping, or
+/// service delegation.
+/// </summary>
+public class PolicyGrpcServiceTests : IClassFixture<PoliciesApiFactory>
+{
+    private readonly PoliciesApiFactory _factory;
+    private readonly PolicyService.PolicyServiceClient _client;
+    private readonly GrpcChannel _channel;
+
+    public PolicyGrpcServiceTests(PoliciesApiFactory factory)
+    {
+        _factory = factory;
+        var handler = factory.Server.CreateHandler();
+        _channel = GrpcChannel.ForAddress(factory.Server.BaseAddress, new GrpcChannelOptions
+        {
+            HttpHandler = handler,
+        });
+        _client = new PolicyService.PolicyServiceClient(_channel);
+    }
+
+    private static CreateDraftRequest MinimalCreate(string name) => new()
+    {
+        Name = name,
+        Description = "",
+        Summary = "summary",
+        Enforcement = "Must",
+        Severity = "Critical",
+        RulesJson = "{}",
+    };
+
+    [Fact]
+    public async Task ListPolicies_EmptyByDefault_ReturnsEmptyResponse()
+    {
+        var res = await _client.ListPoliciesAsync(new ListPoliciesRequest { NamePrefix = "no-such-zzz" });
+        Assert.Empty(res.Policies);
+    }
+
+    [Fact]
+    public async Task CreateDraft_Returns_VersionWithWireFormatCasing()
+    {
+        var slug = $"grpc-create-{Guid.NewGuid():N}".Substring(0, 16);
+        var res = await _client.CreateDraftAsync(MinimalCreate(slug));
+
+        Assert.Equal(1, res.Version.Version);
+        Assert.Equal("Draft", res.Version.State);
+        Assert.Equal("MUST", res.Version.Enforcement);    // ADR 0001 §6
+        Assert.Equal("critical", res.Version.Severity);   // ADR 0001 §6
+    }
+
+    [Fact]
+    public async Task CreateDraft_WithDuplicateSlug_ThrowsAlreadyExists()
+    {
+        var slug = $"grpc-dup-{Guid.NewGuid():N}".Substring(0, 16);
+        await _client.CreateDraftAsync(MinimalCreate(slug));
+
+        var ex = await Assert.ThrowsAsync<RpcException>(
+            () => _client.CreateDraftAsync(MinimalCreate(slug)).ResponseAsync);
+        Assert.Equal(StatusCode.AlreadyExists, ex.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateDraft_WithInvalidName_ThrowsInvalidArgument()
+    {
+        var bad = MinimalCreate("BAD_SLUG"); // uppercase rejected by ADR 0001 §1
+        var ex = await Assert.ThrowsAsync<RpcException>(
+            () => _client.CreateDraftAsync(bad).ResponseAsync);
+        Assert.Equal(StatusCode.InvalidArgument, ex.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetPolicy_Found_ReturnsPolicy()
+    {
+        var slug = $"grpc-get-{Guid.NewGuid():N}".Substring(0, 16);
+        var created = await _client.CreateDraftAsync(MinimalCreate(slug));
+
+        var res = await _client.GetPolicyAsync(new GetPolicyRequest { Id = created.Version.PolicyId });
+
+        Assert.Equal(slug, res.Policy.Name);
+        Assert.Equal(1, res.Policy.VersionCount);
+        Assert.False(res.Policy.HasActiveVersionId); // every version still Draft
+    }
+
+    [Fact]
+    public async Task GetPolicy_Missing_ThrowsNotFound()
+    {
+        var ex = await Assert.ThrowsAsync<RpcException>(
+            () => _client.GetPolicyAsync(new GetPolicyRequest { Id = Guid.NewGuid().ToString() }).ResponseAsync);
+        Assert.Equal(StatusCode.NotFound, ex.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetPolicy_InvalidGuid_ThrowsInvalidArgument()
+    {
+        var ex = await Assert.ThrowsAsync<RpcException>(
+            () => _client.GetPolicyAsync(new GetPolicyRequest { Id = "not-a-guid" }).ResponseAsync);
+        Assert.Equal(StatusCode.InvalidArgument, ex.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetPolicyByName_RoundTrips()
+    {
+        var slug = $"grpc-byname-{Guid.NewGuid():N}".Substring(0, 16);
+        await _client.CreateDraftAsync(MinimalCreate(slug));
+
+        var res = await _client.GetPolicyByNameAsync(new GetPolicyByNameRequest { Name = slug });
+
+        Assert.Equal(slug, res.Policy.Name);
+    }
+
+    [Fact]
+    public async Task ListVersions_AfterCreate_ReturnsSingleEntry()
+    {
+        var slug = $"grpc-listver-{Guid.NewGuid():N}".Substring(0, 16);
+        var created = await _client.CreateDraftAsync(MinimalCreate(slug));
+
+        var res = await _client.ListVersionsAsync(new ListVersionsRequest { PolicyId = created.Version.PolicyId });
+
+        Assert.Single(res.Versions);
+        Assert.Equal(1, res.Versions[0].Version);
+    }
+
+    [Fact]
+    public async Task GetVersion_RoundTrips()
+    {
+        var slug = $"grpc-getver-{Guid.NewGuid():N}".Substring(0, 16);
+        var created = await _client.CreateDraftAsync(MinimalCreate(slug));
+
+        var res = await _client.GetVersionAsync(new GetVersionRequest
+        {
+            PolicyId = created.Version.PolicyId,
+            VersionId = created.Version.Id,
+        });
+
+        Assert.Equal(created.Version.Id, res.Version.Id);
+    }
+
+    [Fact]
+    public async Task GetActiveVersion_AllDraft_ThrowsNotFound()
+    {
+        var slug = $"grpc-noactive-{Guid.NewGuid():N}".Substring(0, 16);
+        var created = await _client.CreateDraftAsync(MinimalCreate(slug));
+
+        var ex = await Assert.ThrowsAsync<RpcException>(
+            () => _client.GetActiveVersionAsync(
+                new GetActiveVersionRequest { PolicyId = created.Version.PolicyId }).ResponseAsync);
+        Assert.Equal(StatusCode.NotFound, ex.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateDraft_AppliesMutations()
+    {
+        var slug = $"grpc-update-{Guid.NewGuid():N}".Substring(0, 16);
+        var created = await _client.CreateDraftAsync(MinimalCreate(slug));
+
+        var updated = await _client.UpdateDraftAsync(new UpdateDraftRequest
+        {
+            PolicyId = created.Version.PolicyId,
+            VersionId = created.Version.Id,
+            Summary = "revised",
+            Enforcement = "should",
+            Severity = "moderate",
+            RulesJson = "{\"allow\":true}",
+        });
+
+        Assert.Equal("revised", updated.Version.Summary);
+        Assert.Equal("SHOULD", updated.Version.Enforcement);
+        Assert.Equal("moderate", updated.Version.Severity);
+    }
+
+    [Fact]
+    public async Task UpdateDraft_OnMissingVersion_ThrowsNotFound()
+    {
+        var ex = await Assert.ThrowsAsync<RpcException>(
+            () => _client.UpdateDraftAsync(new UpdateDraftRequest
+            {
+                PolicyId = Guid.NewGuid().ToString(),
+                VersionId = Guid.NewGuid().ToString(),
+                Summary = "x",
+                Enforcement = "must",
+                Severity = "critical",
+                RulesJson = "{}",
+            }).ResponseAsync);
+        Assert.Equal(StatusCode.NotFound, ex.StatusCode);
+    }
+
+    [Fact]
+    public async Task BumpDraft_WithOpenDraft_ThrowsAlreadyExists()
+    {
+        // ADR 0001 §4: only one open Draft per policy.
+        var slug = $"grpc-bump-blocked-{Guid.NewGuid():N}".Substring(0, 16);
+        var created = await _client.CreateDraftAsync(MinimalCreate(slug));
+
+        var ex = await Assert.ThrowsAsync<RpcException>(
+            () => _client.BumpDraftAsync(new BumpDraftRequest
+            {
+                PolicyId = created.Version.PolicyId,
+                SourceVersionId = created.Version.Id,
+            }).ResponseAsync);
+        Assert.Equal(StatusCode.AlreadyExists, ex.StatusCode);
+    }
+
+    [Fact]
+    public async Task BumpDraft_OnMissingPolicy_ThrowsNotFound()
+    {
+        var ex = await Assert.ThrowsAsync<RpcException>(
+            () => _client.BumpDraftAsync(new BumpDraftRequest
+            {
+                PolicyId = Guid.NewGuid().ToString(),
+                SourceVersionId = Guid.NewGuid().ToString(),
+            }).ResponseAsync);
+        Assert.Equal(StatusCode.NotFound, ex.StatusCode);
+    }
+
+    [Fact]
+    public async Task ListPolicies_FiltersAndPagination_PassThrough()
+    {
+        // Pagination round-trip — small slice over a few created policies.
+        for (var i = 0; i < 3; i++)
+        {
+            await _client.CreateDraftAsync(MinimalCreate($"grpc-pag-{i:D2}-{Guid.NewGuid():N}".Substring(0, 16)));
+        }
+
+        var res = await _client.ListPoliciesAsync(new ListPoliciesRequest
+        {
+            NamePrefix = "grpc-pag-",
+            Take = 2,
+        });
+
+        Assert.True(res.Policies.Count <= 2);
+    }
+}


### PR DESCRIPTION
Closes #77.

## Summary

Third surface over \`IPolicyService\` (after REST in P1.5 and MCP in P1.6). Nine RPCs: read paths plus draft mutations.

| Group | RPCs |
|---|---|
| Read | \`ListPolicies\`, \`GetPolicy\`, \`GetPolicyByName\`, \`ListVersions\`, \`GetVersion\`, \`GetActiveVersion\` |
| Draft mutations | \`CreateDraft\`, \`UpdateDraft\`, \`BumpDraft\` |

Wire-format casing already baked into DTOs from P1.4 (uppercase enforcement / lowercase severity / PascalCase state per ADR 0001 §6) — proto stays neutral with \`string\` typing rather than enums so the contract doesn't fork from REST/MCP.

## Exception → gRPC StatusCode (mirrors PolicyExceptionHandler)

| Exception | gRPC | HTTP equivalent |
|---|---|---|
| \`ValidationException\` | \`InvalidArgument\` | 400 |
| \`NotFoundException\` | \`NotFound\` | 404 |
| \`ConflictException\` | \`AlreadyExists\` | 409 |
| \`DbUpdateConcurrencyException\` | \`Aborted\` | 412 |

## Changes

- **\`Protos/policies.proto\`** — wire contract. GUIDs / timestamps as strings, optional fields via proto3 \`optional\`, ADR references inline.
- **\`Andy.Policies.Api.csproj\`** — \`<Protobuf ... GrpcServices=\"Both\" />\` so generated client stubs flow to the integration test project (and any future external consumer) via project reference.
- **\`GrpcServices/PolicyGrpcService.cs\`** — service implementation. \`[Authorize]\` on the class. GUID validation at the RPC boundary. Subject id from \`User.Identity?.Name\` with a labeled \`grpc-anonymous\` fallback (matches \`PoliciesController\` and \`ItemsGrpcService\`).
- **\`Program.cs\`** — \`MapGrpcService<PolicyGrpcService>()\`.
- **Test infra** — added \`Grpc.Net.Client 2.67.0\` to \`Tests.Integration\` (pinned to match transitive minimum from \`Andy.Rbac.Client 1.0.0\`; NU1605 caught the downgrade attempt at 2.62.0).

## Test plan

- [x] \`dotnet build\` — 0 warnings (TreatWarningsAsErrors)
- [x] \`dotnet test tests/Andy.Policies.Tests.Unit\` — **77/77** unchanged
- [x] \`dotnet test tests/Andy.Policies.Tests.Integration\` (excluding pre-existing \`ItemsControllerTests\`) — **68/68** (was 52 → +16 new gRPC tests):
  - in-process channel via \`PoliciesApiFactory.Server.CreateHandler()\`
  - happy paths for every RPC
  - StatusCode assertions for \`InvalidArgument\` (bad slug, bad GUID), \`AlreadyExists\` (duplicate slug, bump-while-open-draft), \`NotFound\` (missing policy / version / no active)
  - wire-format casing assertion on a CreateDraft response
  - filter pass-through on ListPolicies

## Out of scope (tracked)

- **Cross-surface parity sweep** — P1.11 (#91), once CLI lands too.
- **CLI parity** — P1.8 (#78), naturally next.
- **gRPC over the live e2e stack** with real JWT — could extend \`docker-compose.e2e.yml\`; current in-process tests use \`TestAuthHandler\` (same as REST tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)