### PR TITLE
Implement P1.9 — OpenAPI/Swagger schema + CI sync check

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "swashbuckle.aspnetcore.cli": {
+      "version": "6.6.2",
+      "commands": [
+        "swagger"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,37 @@ jobs:
           name: coverage-backend
           path: '**/coverage.cobertura.xml'
 
+  openapi-drift:
+    # P1.9 (#79): the committed docs/openapi/andy-policies-v1.yaml is the
+    # source of truth REST clients consume. Regenerating it from the live
+    # Swashbuckle pipeline must produce a byte-identical file; otherwise the
+    # PR forgot to run scripts/export-openapi.sh and the documented contract
+    # has drifted from controller code.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Regenerate OpenAPI schema
+        run: ./scripts/export-openapi.sh
+
+      - name: Fail on drift
+        run: |
+          if ! git diff --exit-code docs/openapi/andy-policies-v1.yaml; then
+            echo "::error::OpenAPI schema drift detected. Run ./scripts/export-openapi.sh and commit docs/openapi/andy-policies-v1.yaml."
+            exit 1
+          fi
+
+      - name: Spectral lint
+        uses: stoplightio/spectral-action@v0.8.2
+        with:
+          file_glob: docs/openapi/andy-policies-v1.yaml
+          spectral_ruleset: .spectral.yaml
+
   build-frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,19 @@
+# Spectral ruleset for andy-policies OpenAPI (P1.9, #79).
+# Extends the OpenAPI baseline with a few opinionated overrides:
+# - operation-tag-defined / operation-success-response stay as warnings
+#   (Swashbuckle synthesises responses in a way Spectral occasionally
+#   misclassifies; we don't want CI to fail on that).
+# - Anything operationId-related is escalated to error so a missing
+#   operationId — which would also break our drift-friendly diffing —
+#   blocks merge.
+extends:
+  - spectral:oas
+
+rules:
+  operation-operationId: error
+  operation-operationId-unique: error
+  operation-operationId-valid-in-url: error
+  info-contact: warn
+  info-license: warn
+  operation-tag-defined: warn
+  operation-success-response: warn

--- a/docs/openapi/andy-policies-v1.yaml
+++ b/docs/openapi/andy-policies-v1.yaml
@@ -1,0 +1,753 @@
+openapi: 3.0.1
+info:
+  title: Andy Policies API
+  description: 'Governance policy catalog — structured, versioned policy documents with lifecycle and audit trail, consumed by Conductor for story admission, verification, and compliance reporting (content only; enforcement lives in consumers).'
+  contact:
+    name: Rivoli AI
+    url: https://github.com/rivoli-ai/andy-policies
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+  version: v1
+paths:
+  /health:
+    get:
+      tags:
+        - 'Andy.Policies.Api, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'
+      operationId: health
+      responses:
+        '200':
+          description: OK
+  /api/Help/topics:
+    get:
+      tags:
+        - Help
+      summary: 'List all help topics (slug, title, order, tags).'
+      operationId: Help_ListTopics
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HelpTopicSummary'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HelpTopicSummary'
+            text/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HelpTopicSummary'
+  '/api/Help/topics/{slug}':
+    get:
+      tags:
+        - Help
+      summary: "Get a single help topic by slug (filename without extension).\r\nReturns title, markdown body, and metadata."
+      operationId: Help_GetTopic
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/HelpTopic'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HelpTopic'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/HelpTopic'
+  /api/Help/search:
+    get:
+      tags:
+        - Help
+      summary: 'Search help topics by keyword (searches title, tags, and body).'
+      operationId: Help_Search
+      parameters:
+        - name: q
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HelpTopicSummary'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HelpTopicSummary'
+            text/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HelpTopicSummary'
+  /api/Items:
+    get:
+      tags:
+        - Items
+      operationId: Items_GetAll
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ItemDto'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ItemDto'
+            text/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ItemDto'
+    post:
+      tags:
+        - Items
+      operationId: Items_Create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateItemRequest'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/CreateItemRequest'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/CreateItemRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ItemDto'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ItemDto'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ItemDto'
+  '/api/Items/{id}':
+    get:
+      tags:
+        - Items
+      operationId: Items_GetById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ItemDto'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ItemDto'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ItemDto'
+    put:
+      tags:
+        - Items
+      operationId: Items_Update
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateItemRequest'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/CreateItemRequest'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/CreateItemRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ItemDto'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ItemDto'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ItemDto'
+    delete:
+      tags:
+        - Items
+      operationId: Items_Delete
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+  /api/Policies:
+    get:
+      tags:
+        - Policies
+      operationId: Policies_List
+      parameters:
+        - name: namePrefix
+          in: query
+          schema:
+            type: string
+        - name: scope
+          in: query
+          schema:
+            type: string
+        - name: enforcement
+          in: query
+          schema:
+            type: string
+        - name: severity
+          in: query
+          schema:
+            type: string
+        - name: skip
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: take
+          in: query
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PolicyDto'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PolicyDto'
+            text/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PolicyDto'
+    post:
+      tags:
+        - Policies
+      operationId: Policies_Create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePolicyRequest'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/CreatePolicyRequest'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/CreatePolicyRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDto'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDto'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDto'
+  '/api/Policies/{id}':
+    get:
+      tags:
+        - Policies
+      operationId: Policies_Get
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/PolicyDto'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDto'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDto'
+  '/api/Policies/by-name/{name}':
+    get:
+      tags:
+        - Policies
+      operationId: Policies_GetByName
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/PolicyDto'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDto'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/PolicyDto'
+  '/api/Policies/{id}/versions':
+    get:
+      tags:
+        - Policies
+      operationId: Policies_ListVersions
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PolicyVersionDto'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PolicyVersionDto'
+            text/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PolicyVersionDto'
+  '/api/Policies/{id}/versions/active':
+    get:
+      tags:
+        - Policies
+      summary: "Resolves the active version per ADR 0001 (highest `Version` with\r\n`State != Draft` in P1; `State == Active` after P2 lands).\r\nRoute literal \"active\" sits before `{versionId:guid}` in match precedence,\r\nand the GUID constraint makes the two routes unambiguous regardless."
+      operationId: Policies_GetActiveVersion
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDto'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDto'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDto'
+  '/api/Policies/{id}/versions/{versionId}':
+    get:
+      tags:
+        - Policies
+      operationId: Policies_GetVersion
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: versionId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDto'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDto'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDto'
+    put:
+      tags:
+        - Policies
+      operationId: Policies_UpdateDraft
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: versionId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdatePolicyVersionRequest'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/UpdatePolicyVersionRequest'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/UpdatePolicyVersionRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDto'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDto'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDto'
+  '/api/Policies/{id}/versions/{sourceVersionId}/bump':
+    post:
+      tags:
+        - Policies
+      operationId: Policies_Bump
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: sourceVersionId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDto'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDto'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDto'
+components:
+  schemas:
+    CreateItemRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+      additionalProperties: false
+    CreatePolicyRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        summary:
+          type: string
+          nullable: true
+        enforcement:
+          enum:
+            - MUST
+            - SHOULD
+            - MAY
+          type: string
+          nullable: true
+        severity:
+          enum:
+            - info
+            - moderate
+            - critical
+          type: string
+          nullable: true
+        scopes:
+          type: array
+          items:
+            type: string
+          nullable: true
+        rulesJson:
+          type: string
+          nullable: true
+      additionalProperties: false
+      description: "Request payload for `IPolicyService.CreateDraftAsync`. Creates both the\r\nstable `Policy` row and its first `PolicyVersion` (version 1, Draft).\r\nEnum fields accept any casing on input (parsed case-insensitively by the service)."
+    HelpTopic:
+      type: object
+      properties:
+        slug:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        order:
+          type: integer
+          format: int32
+        tags:
+          type: array
+          items:
+            type: string
+          nullable: true
+        markdown:
+          type: string
+          nullable: true
+      additionalProperties: false
+    HelpTopicSummary:
+      type: object
+      properties:
+        slug:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        order:
+          type: integer
+          format: int32
+        tags:
+          type: array
+          items:
+            type: string
+          nullable: true
+      additionalProperties: false
+    ItemDto:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        status:
+          type: string
+          nullable: true
+        createdBy:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+      additionalProperties: false
+    PolicyDto:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        createdBySubjectId:
+          type: string
+          nullable: true
+        versionCount:
+          type: integer
+          format: int32
+        activeVersionId:
+          type: string
+          format: uuid
+          nullable: true
+      additionalProperties: false
+      description: "Stable identity of a policy plus summary metadata about its version history.\r\nAndy.Policies.Application.Dtos.PolicyDto.ActiveVersionId resolves per P1 rule \"highest `Version` with\r\n`State != Draft`\"; P2 tightens to `State == Active`. Null while every\r\nversion is still a Draft."
+    PolicyVersionDto:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        policyId:
+          type: string
+          format: uuid
+        version:
+          type: integer
+          format: int32
+        state:
+          enum:
+            - Draft
+            - Active
+            - WindingDown
+            - Retired
+          type: string
+          nullable: true
+        enforcement:
+          enum:
+            - MUST
+            - SHOULD
+            - MAY
+          type: string
+          nullable: true
+        severity:
+          enum:
+            - info
+            - moderate
+            - critical
+          type: string
+          nullable: true
+        scopes:
+          type: array
+          items:
+            type: string
+          nullable: true
+        summary:
+          type: string
+          nullable: true
+        rulesJson:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        createdBySubjectId:
+          type: string
+          nullable: true
+        proposerSubjectId:
+          type: string
+          nullable: true
+      additionalProperties: false
+      description: "Wire-format projection of a `PolicyVersion`. Enum-shaped fields are\r\nserialised in the casing required by ADR 0001 §6:\r\n<list type=\"bullet\"><item><term>Enforcement</term><description>uppercase RFC 2119 tokens (`MUST` / `SHOULD` / `MAY`).</description></item><item><term>Severity</term><description>lowercase (`info` / `moderate` / `critical`).</description></item><item><term>State</term><description>PascalCase (`Draft` / `Active` / `WindingDown` / `Retired`) — matches DB storage and consumer-visible lifecycle labels.</description></item></list>\r\nService layer performs the casing conversion; controllers pass the DTO through unchanged."
+    UpdatePolicyVersionRequest:
+      type: object
+      properties:
+        summary:
+          type: string
+          nullable: true
+        enforcement:
+          enum:
+            - MUST
+            - SHOULD
+            - MAY
+          type: string
+          nullable: true
+        severity:
+          enum:
+            - info
+            - moderate
+            - critical
+          type: string
+          nullable: true
+        scopes:
+          type: array
+          items:
+            type: string
+          nullable: true
+        rulesJson:
+          type: string
+          nullable: true
+      additionalProperties: false
+      description: "Request payload for `IPolicyService.UpdateDraftAsync`. Mutates the content\r\nof an existing Draft version. The `Policy.Name` slug is never updated via\r\nthis path — that would require a separate endpoint (deliberately deferred)."
+  securitySchemes:
+    Bearer:
+      type: http
+      description: JWT Authorization header using the Bearer scheme.
+      scheme: bearer
+      bearerFormat: JWT
+security:
+  - Bearer: [ ]
+tags:
+  - name: Help
+    description: "Serves help content from markdown files in content/help/.\r\nConsumable by any client: Angular, Swift (Conductor), CLI, MCP."
+  - name: Policies
+    description: "REST surface for the policy catalog (P1.5, story rivoli-ai/andy-policies#75).\r\nAll endpoints delegate to Andy.Policies.Application.Interfaces.IPolicyService; service exceptions are\r\nmapped to status codes by `PolicyExceptionHandler` (registered globally)."

--- a/scripts/export-openapi.sh
+++ b/scripts/export-openapi.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copyright (c) Rivoli AI 2026. All rights reserved.
+#
+# Regenerates docs/openapi/andy-policies-v1.yaml from the running Swashbuckle
+# document. CI runs this and fails on `git diff` so the committed schema can
+# never drift from controller attributes / DTO shapes (P1.9, #79).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+OUTPUT_DIR="docs/openapi"
+OUTPUT_FILE="$OUTPUT_DIR/andy-policies-v1.yaml"
+API_PROJECT="src/Andy.Policies.Api"
+API_DLL="$API_PROJECT/bin/Release/net8.0/Andy.Policies.Api.dll"
+
+mkdir -p "$OUTPUT_DIR"
+
+# Restore the locally-pinned Swashbuckle.AspNetCore.Cli tool. Idempotent.
+dotnet tool restore >/dev/null
+
+# Build Release once so the resolved DLL has the production Swagger config.
+dotnet build "$API_PROJECT" -c Release --nologo --verbosity minimal
+
+# AndyAuth__Authority and AndySettings__ApiBaseUrl are required at startup
+# (#103, #108 — no silent dev bypass). Provide placeholders for the document
+# generator; nothing reaches over the network because Swashbuckle only walks
+# the controller graph in-process.
+ASPNETCORE_ENVIRONMENT="Testing" \
+AndyAuth__Authority="https://export.invalid" \
+AndyAuth__Audience="urn:andy-policies-api" \
+AndySettings__ApiBaseUrl="https://export.invalid" \
+    dotnet tool run swagger tofile --yaml --output "$OUTPUT_FILE" "$API_DLL" v1
+
+echo "Wrote $OUTPUT_FILE"

--- a/src/Andy.Policies.Api/Andy.Policies.Api.csproj
+++ b/src/Andy.Policies.Api/Andy.Policies.Api.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -137,8 +137,47 @@ builder.Services.AddSwaggerGen(options =>
     {
         Title = "Andy Policies API",
         Version = "v1",
-        Description = "Governance policy catalog — structured, versioned policy documents with lifecycle and audit trail, consumed by Conductor for story admission, verification, and compliance reporting (content only; enforcement lives in consumers)"
+        Description = "Governance policy catalog — structured, versioned policy documents with lifecycle and audit trail, consumed by Conductor for story admission, verification, and compliance reporting (content only; enforcement lives in consumers).",
+        Contact = new Microsoft.OpenApi.Models.OpenApiContact
+        {
+            Name = "Rivoli AI",
+            Url = new Uri("https://github.com/rivoli-ai/andy-policies"),
+        },
+        License = new Microsoft.OpenApi.Models.OpenApiLicense
+        {
+            Name = "Apache-2.0",
+            Url = new Uri("https://www.apache.org/licenses/LICENSE-2.0"),
+        },
     });
+
+    // Stable, code-derived operationIds keep the schema diff-friendly. Without
+    // this Swashbuckle synthesises names that depend on overload order, which
+    // makes the drift check noisy. Spectral's `operation-operationId` rule
+    // requires every operation to have a non-null operationId. The fallbacks
+    // cover minimal-API endpoints (e.g. `/health`) that have no controller /
+    // action route values.
+    options.CustomOperationIds(api =>
+    {
+        var routeValues = api.ActionDescriptor.RouteValues;
+        if (routeValues.TryGetValue("controller", out var ctrl)
+            && routeValues.TryGetValue("action", out var act)
+            && !string.IsNullOrEmpty(ctrl) && !string.IsNullOrEmpty(act))
+        {
+            return $"{ctrl}_{act}";
+        }
+        return api.RelativePath?.Replace('/', '_').Trim('_') ?? api.HttpMethod ?? "operation";
+    });
+
+    foreach (var xml in new[] { "Andy.Policies.Api.xml", "Andy.Policies.Application.xml" })
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, xml);
+        if (File.Exists(path))
+        {
+            options.IncludeXmlComments(path, includeControllerXmlComments: true);
+        }
+    }
+
+    options.SchemaFilter<Andy.Policies.Api.Swagger.PolicyDimensionSchemaFilter>();
 
     options.AddSecurityDefinition("Bearer", new Microsoft.OpenApi.Models.OpenApiSecurityScheme
     {
@@ -199,7 +238,10 @@ builder.Services
 var app = builder.Build();
 
 // --- Middleware ---
-if (app.Environment.IsDevelopment())
+// Swagger document + UI are exposed in Development and the integration-test
+// "Testing" environment. The OpenAPI document drives the committed
+// `docs/openapi/andy-policies-v1.yaml` and the CI drift check (P1.9, #79).
+if (app.Environment.IsDevelopment() || app.Environment.IsEnvironment("Testing"))
 {
     app.UseSwagger();
     app.UseSwaggerUI();

--- a/src/Andy.Policies.Api/Swagger/PolicyDimensionSchemaFilter.cs
+++ b/src/Andy.Policies.Api/Swagger/PolicyDimensionSchemaFilter.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Andy.Policies.Api.Swagger;
+
+/// <summary>
+/// Annotates the three string-typed policy-dimension fields
+/// (<c>enforcement</c>, <c>severity</c>, <c>state</c>) with the enum union
+/// they actually accept on the wire (per ADR 0001 §6). The DTOs hold these
+/// as plain <see cref="string"/> so callers can round-trip raw values, but
+/// the OpenAPI schema must advertise the closed set so generated clients
+/// and Spectral validators reject typos.
+/// </summary>
+internal sealed class PolicyDimensionSchemaFilter : ISchemaFilter
+{
+    private static readonly IReadOnlyDictionary<string, string[]> Dimensions = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["enforcement"] = new[] { "MUST", "SHOULD", "MAY" },
+        ["severity"] = new[] { "info", "moderate", "critical" },
+        ["state"] = new[] { "Draft", "Active", "WindingDown", "Retired" },
+    };
+
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (schema.Properties is null || schema.Properties.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var (name, allowed) in Dimensions)
+        {
+            if (!schema.Properties.TryGetValue(name, out var prop) || prop.Type != "string")
+            {
+                continue;
+            }
+            prop.Enum = allowed.Select(v => (IOpenApiAny)new OpenApiString(v)).ToList();
+        }
+    }
+}

--- a/src/Andy.Policies.Application/Andy.Policies.Application.csproj
+++ b/src/Andy.Policies.Application/Andy.Policies.Application.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Andy.Policies.Tests.Integration/OpenApi/SchemaShapeTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/OpenApi/SchemaShapeTests.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json;
+using Andy.Policies.Tests.Integration.Controllers;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.OpenApi;
+
+/// <summary>
+/// P1.9 (#79): the live <c>/swagger/v1/swagger.json</c> document is the
+/// runtime contract REST clients consume. The committed
+/// <c>docs/openapi/andy-policies-v1.yaml</c> is regenerated from this same
+/// pipeline by <c>scripts/export-openapi.sh</c>; the CI drift check guards
+/// the YAML, while these tests guard the *shape* the YAML is built from.
+/// </summary>
+public class SchemaShapeTests : IClassFixture<PoliciesApiFactory>
+{
+    private readonly PoliciesApiFactory _factory;
+
+    public SchemaShapeTests(PoliciesApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task SwaggerJson_IsReachable_AndValidJson()
+    {
+        using var client = _factory.CreateClient();
+        var response = await client.GetAsync("/swagger/v1/swagger.json");
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync();
+        using var _ = JsonDocument.Parse(body); // throws on invalid JSON
+    }
+
+    [Fact]
+    public async Task EveryOperation_HasOperationId()
+    {
+        using var doc = await LoadAsync();
+        var paths = doc.RootElement.GetProperty("paths");
+        foreach (var path in paths.EnumerateObject())
+        {
+            foreach (var op in path.Value.EnumerateObject())
+            {
+                if (!IsHttpMethod(op.Name))
+                {
+                    continue;
+                }
+                Assert.True(
+                    op.Value.TryGetProperty("operationId", out var opId)
+                    && opId.ValueKind == JsonValueKind.String
+                    && !string.IsNullOrEmpty(opId.GetString()),
+                    $"Missing operationId for {op.Name.ToUpperInvariant()} {path.Name}");
+            }
+        }
+    }
+
+    [Fact]
+    public async Task PolicyDto_IsExposed_WithExpectedProperties()
+    {
+        using var doc = await LoadAsync();
+        var schemas = doc.RootElement.GetProperty("components").GetProperty("schemas");
+        Assert.True(schemas.TryGetProperty("PolicyDto", out var dto), "PolicyDto schema missing");
+        var props = dto.GetProperty("properties");
+        foreach (var expected in new[] { "id", "name", "createdAt", "createdBySubjectId", "versionCount", "activeVersionId" })
+        {
+            Assert.True(props.TryGetProperty(expected, out _), $"PolicyDto missing property '{expected}'");
+        }
+    }
+
+    [Fact]
+    public async Task PolicyVersionDto_DimensionFields_AreEnumUnions()
+    {
+        using var doc = await LoadAsync();
+        var version = doc.RootElement
+            .GetProperty("components")
+            .GetProperty("schemas")
+            .GetProperty("PolicyVersionDto")
+            .GetProperty("properties");
+
+        AssertEnum(version, "enforcement", new[] { "MUST", "SHOULD", "MAY" });
+        AssertEnum(version, "severity", new[] { "info", "moderate", "critical" });
+        AssertEnum(version, "state", new[] { "Draft", "Active", "WindingDown", "Retired" });
+    }
+
+    [Fact]
+    public async Task SchemaComponents_DoNotExpose_RevisionConcurrencyToken()
+    {
+        using var doc = await LoadAsync();
+        var schemas = doc.RootElement.GetProperty("components").GetProperty("schemas");
+        foreach (var schema in schemas.EnumerateObject())
+        {
+            if (!schema.Value.TryGetProperty("properties", out var props))
+            {
+                continue;
+            }
+            foreach (var prop in props.EnumerateObject())
+            {
+                Assert.False(
+                    string.Equals(prop.Name, "revision", StringComparison.OrdinalIgnoreCase),
+                    $"Schema '{schema.Name}' leaks the EF concurrency token 'revision'");
+            }
+        }
+    }
+
+    [Fact]
+    public async Task BearerSecurityScheme_IsRegistered()
+    {
+        using var doc = await LoadAsync();
+        var schemes = doc.RootElement
+            .GetProperty("components")
+            .GetProperty("securitySchemes");
+        Assert.True(schemes.TryGetProperty("Bearer", out var bearer), "Bearer security scheme missing");
+        Assert.Equal("http", bearer.GetProperty("type").GetString());
+        Assert.Equal("bearer", bearer.GetProperty("scheme").GetString());
+    }
+
+    [Fact]
+    public async Task PolicyOperations_AreAllPresent()
+    {
+        using var doc = await LoadAsync();
+        var ids = new HashSet<string>(StringComparer.Ordinal);
+        var paths = doc.RootElement.GetProperty("paths");
+        foreach (var path in paths.EnumerateObject())
+        {
+            foreach (var op in path.Value.EnumerateObject())
+            {
+                if (op.Value.TryGetProperty("operationId", out var opId) && opId.ValueKind == JsonValueKind.String)
+                {
+                    ids.Add(opId.GetString()!);
+                }
+            }
+        }
+        foreach (var expected in new[]
+        {
+            "Policies_List",
+            "Policies_Create",
+            "Policies_Get",
+            "Policies_GetByName",
+            "Policies_ListVersions",
+            "Policies_GetActiveVersion",
+            "Policies_GetVersion",
+            "Policies_UpdateDraft",
+            "Policies_Bump",
+        })
+        {
+            Assert.Contains(expected, ids);
+        }
+    }
+
+    private static void AssertEnum(JsonElement schemaProperties, string name, IReadOnlyList<string> expected)
+    {
+        Assert.True(schemaProperties.TryGetProperty(name, out var prop), $"Property '{name}' missing");
+        Assert.True(prop.TryGetProperty("enum", out var enumProp), $"Property '{name}' has no enum");
+        var actual = enumProp.EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Equal(expected.ToArray(), actual);
+    }
+
+    private static bool IsHttpMethod(string name) => name switch
+    {
+        "get" or "post" or "put" or "patch" or "delete" or "head" or "options" or "trace" => true,
+        _ => false,
+    };
+
+    private async Task<JsonDocument> LoadAsync()
+    {
+        using var client = _factory.CreateClient();
+        var response = await client.GetAsync("/swagger/v1/swagger.json");
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync();
+        return JsonDocument.Parse(body);
+    }
+}


### PR DESCRIPTION
Closes #79. Contributes to Epic P1 (#1).

## Summary

- Tightens the REST surface (built in P1.5) with a real, complete, lint-clean OpenAPI document at `/swagger/v1/swagger.json`.
- Commits the generated schema at `docs/openapi/andy-policies-v1.yaml` (source of truth for downstream clients).
- New CI job `openapi-drift` regenerates the YAML on every PR and fails if it doesn't match the committed file — controllers and the documented contract can no longer drift silently.
- Spectral lint runs on the committed YAML with `operation-operationId*` escalated to error.

## Implementation notes

- DTOs hold `Enforcement`/`Severity`/`State` as plain `string` (so callers can round-trip raw values), but the OpenAPI schema needs to advertise the closed enum unions. Added a small `PolicyDimensionSchemaFilter` that targets those property names and emits the ADR 0001 §6 sets (`MUST|SHOULD|MAY`, `info|moderate|critical`, `Draft|Active|WindingDown|Retired`).
- `CustomOperationIds` uses `{Controller}_{Action}` with a relative-path fallback for minimal-API endpoints like `/health` — without the fallback, Swashbuckle threw on the `/health` lambda.
- `scripts/export-openapi.sh` runs in `ASPNETCORE_ENVIRONMENT=Testing` with placeholder `AndyAuth__Authority` / `AndySettings__ApiBaseUrl` so the fail-loud config gates (#103, #108) are satisfied without hitting any network. Swashbuckle only walks the controller graph in-process.
- Swagger UI is now also exposed in the `Testing` environment so the new integration tests can fetch the document via `PoliciesApiFactory`.
- Schema-shape tests landed in the **Integration** project (not Unit as the issue sketched) because that's where `WebApplicationFactory<Program>` already lives.

## Test plan

- [x] `dotnet build Andy.Policies.sln` — clean
- [x] `dotnet test Andy.Policies.Tests.Unit` — **92 passed**
- [x] `dotnet test Andy.Policies.Tests.Integration` (excluding pre-existing Postgres-dependent `ItemsControllerTests`) — **75 passed** (7 new schema-shape tests)
- [x] `./scripts/export-openapi.sh` produces a byte-stable file (running it twice yields no diff)
- [x] All 9 `Policies_*` operations are present in the generated YAML
- [x] `Revision` concurrency token is not exposed in any schema component
- [ ] CI's `openapi-drift` job (will be exercised by this PR)
- [ ] Spectral lint passes (also exercised by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)