### PR TITLE
Implement P1.3 — seed stock policies at v1/Draft

### DIFF
--- a/scripts/export-openapi.sh
+++ b/scripts/export-openapi.sh
@@ -26,11 +26,18 @@ dotnet build "$API_PROJECT" -c Release --nologo --verbosity minimal
 # AndyAuth__Authority and AndySettings__ApiBaseUrl are required at startup
 # (#103, #108 — no silent dev bypass). Provide placeholders for the document
 # generator; nothing reaches over the network because Swashbuckle only walks
-# the controller graph in-process.
+# the controller graph in-process. Database:Provider=Sqlite + an in-memory
+# data source keeps the boot-time stock-policy seeder (#73) happy without
+# needing a live Postgres. The temp file path is wiped on each run so the
+# seed never carries over.
+TMP_DB="$(mktemp -t andy-policies-export-openapi-XXXXXX.db)"
+trap 'rm -f "$TMP_DB"' EXIT
 ASPNETCORE_ENVIRONMENT="Testing" \
 AndyAuth__Authority="https://export.invalid" \
 AndyAuth__Audience="urn:andy-policies-api" \
 AndySettings__ApiBaseUrl="https://export.invalid" \
+Database__Provider="Sqlite" \
+ConnectionStrings__DefaultConnection="Data Source=$TMP_DB" \
     dotnet tool run swagger tofile --yaml --output "$OUTPUT_FILE" "$API_DLL" v1
 
 echo "Wrote $OUTPUT_FILE"

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -274,16 +274,30 @@ app.MapGet("/health", () => Results.Ok(new { status = "healthy", timestamp = Dat
 app.MapFallbackToFile("index.html");
 
 // --- Auto-migrate in development ---
+// Postgres migrations are operator-driven outside Development; SQLite EnsureCreated
+// is also allowed in the integration-test "Testing" environment (and in turn the
+// OpenAPI export pipeline that boots Program.cs in Testing) so the boot-time
+// stock-policy seeder below has a schema to land into.
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
-if (app.Environment.IsDevelopment() && !string.IsNullOrEmpty(connectionString))
+if (!string.IsNullOrEmpty(connectionString))
 {
     using var scope = app.Services.CreateScope();
     var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-    if (db.Database.IsNpgsql())
+    if (db.Database.IsNpgsql() && app.Environment.IsDevelopment())
+    {
         await db.Database.MigrateAsync();
-    else if (db.Database.IsSqlite())
+    }
+    else if (db.Database.IsSqlite()
+             && (app.Environment.IsDevelopment() || app.Environment.IsEnvironment("Testing")))
+    {
         await db.Database.EnsureCreatedAsync();
+    }
 }
+
+// --- Seed stock policies (P1.3, #73) ---
+// Idempotent. Runs in every environment after migrations have applied; if the
+// schema is missing the underlying AnyAsync probe throws and boot fails loudly.
+await app.Services.EnsureSeedDataAsync();
 
 app.Run();
 

--- a/src/Andy.Policies.Infrastructure/Data/DatabaseExtensions.cs
+++ b/src/Andy.Policies.Infrastructure/Data/DatabaseExtensions.cs
@@ -31,4 +31,20 @@ public static class DatabaseExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Resolves <see cref="AppDbContext"/> from the root provider in a fresh scope
+    /// and runs <see cref="PolicySeeder.SeedStockPoliciesAsync"/> against it
+    /// (P1.3, #73). Idempotent — safe to call on every boot. Must run after
+    /// migrations have applied; if the schema is missing the underlying
+    /// <c>AnyAsync</c> probe throws and boot fails loudly.
+    /// </summary>
+    public static async Task EnsureSeedDataAsync(this IServiceProvider services, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        using var scope = services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        await PolicySeeder.SeedStockPoliciesAsync(db, ct).ConfigureAwait(false);
+    }
 }

--- a/src/Andy.Policies.Infrastructure/Data/PolicySeeder.cs
+++ b/src/Andy.Policies.Infrastructure/Data/PolicySeeder.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+
+namespace Andy.Policies.Infrastructure.Data;
+
+/// <summary>
+/// Boot-time seeder for the six canonical stock policies (P1.3, #73). Each policy
+/// lands with a single <see cref="LifecycleState.Draft"/> v1; promotion to
+/// <see cref="LifecycleState.Active"/> is operator-driven via Epic P2 and is
+/// intentionally out of scope here.
+/// </summary>
+/// <remarks>
+/// Idempotency is by-presence: if the catalog has any rows we short-circuit. That
+/// preserves operator edits across restarts and means the seeder is safe to run
+/// from <c>Program.cs</c> on every boot. A re-seed escape hatch (CLI flag, bundle
+/// import) is the responsibility of P1.8 / Epic P8 and not this story.
+/// </remarks>
+public static class PolicySeeder
+{
+    /// <summary>Subject id stamped on seed-created rows. Filterable in audit queries.</summary>
+    public const string SeedSubjectId = "system:seed";
+
+    /// <summary>
+    /// Six stock policies sourced from the andy-rbac#18 reconciliation note (Epic V V2).
+    /// Public so unit tests can assert the table row-by-row without re-listing the values.
+    /// </summary>
+    public static readonly IReadOnlyList<StockPolicy> StockPolicies = new[]
+    {
+        new StockPolicy(
+            Name: "read-only",
+            Enforcement: EnforcementLevel.Must,
+            Severity: Severity.Info,
+            Scopes: Array.Empty<string>(),
+            Summary: "Read/list operations only; no writes, no side effects."),
+        new StockPolicy(
+            Name: "write-branch",
+            Enforcement: EnforcementLevel.Should,
+            Severity: Severity.Moderate,
+            Scopes: new[] { "repo" },
+            Summary: "Writes are permitted only on non-default branches."),
+        new StockPolicy(
+            Name: "sandboxed",
+            Enforcement: EnforcementLevel.Must,
+            Severity: Severity.Moderate,
+            Scopes: new[] { "tool", "container" },
+            Summary: "Execution must occur inside an isolated container/sandbox."),
+        new StockPolicy(
+            Name: "draft-only",
+            Enforcement: EnforcementLevel.Must,
+            Severity: Severity.Info,
+            Scopes: new[] { "template" },
+            Summary: "Output is advisory/draft; no publish/merge/deploy."),
+        new StockPolicy(
+            Name: "no-prod",
+            Enforcement: EnforcementLevel.Must,
+            Severity: Severity.Critical,
+            Scopes: new[] { "prod" },
+            Summary: "No actions against production resources."),
+        new StockPolicy(
+            Name: "high-risk",
+            Enforcement: EnforcementLevel.Must,
+            Severity: Severity.Critical,
+            Scopes: Array.Empty<string>(),
+            Summary: "Requires explicit approver sign-off."),
+    };
+
+    public static async Task SeedStockPoliciesAsync(AppDbContext db, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+
+        if (await db.Policies.AnyAsync(ct).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        foreach (var stock in StockPolicies)
+        {
+            var policy = new Policy
+            {
+                Id = Guid.NewGuid(),
+                Name = stock.Name,
+                Description = stock.Summary,
+                CreatedAt = now,
+                CreatedBySubjectId = SeedSubjectId,
+            };
+            var version = new PolicyVersion
+            {
+                Id = Guid.NewGuid(),
+                PolicyId = policy.Id,
+                Version = 1,
+                State = LifecycleState.Draft,
+                Enforcement = stock.Enforcement,
+                Severity = stock.Severity,
+                Scopes = stock.Scopes.ToList(),
+                Summary = stock.Summary,
+                RulesJson = "{}",
+                CreatedAt = now,
+                CreatedBySubjectId = SeedSubjectId,
+                ProposerSubjectId = SeedSubjectId,
+            };
+            db.Policies.Add(policy);
+            db.PolicyVersions.Add(version);
+        }
+
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+    }
+
+    public sealed record StockPolicy(
+        string Name,
+        EnforcementLevel Enforcement,
+        Severity Severity,
+        IReadOnlyCollection<string> Scopes,
+        string Summary);
+}

--- a/tests/Andy.Policies.Tests.Integration/Bootstrap/SeedOnStartupTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Bootstrap/SeedOnStartupTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net.Http.Json;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Tests.Integration.Controllers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Bootstrap;
+
+/// <summary>
+/// P1.3 (#73): the seed wiring in <c>Program.cs</c> must run during host
+/// startup so a fresh boot leaves the catalog with the six canonical stock
+/// policies. The unit-level tests cover the seeder in isolation; this fixture
+/// proves the boot pipeline (auto-migrate -> seed) is connected correctly.
+/// </summary>
+public class SeedOnStartupTests : IClassFixture<PoliciesApiFactory>
+{
+    private readonly PoliciesApiFactory _factory;
+
+    public SeedOnStartupTests(PoliciesApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task OnFirstBoot_CatalogContainsAllSixStockPolicies()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var slugs = await db.Policies.Select(p => p.Name).OrderBy(s => s).ToListAsync();
+
+        Assert.Equal(
+            new[] { "draft-only", "high-risk", "no-prod", "read-only", "sandboxed", "write-branch" },
+            slugs);
+    }
+
+    [Fact]
+    public async Task OnFirstBoot_EveryStockPolicyHasOneDraftVersionAtVersionOne()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var versions = await db.PolicyVersions.ToListAsync();
+
+        Assert.Equal(6, versions.Count);
+        Assert.All(versions, v =>
+        {
+            Assert.Equal(1, v.Version);
+            Assert.Equal(LifecycleState.Draft, v.State);
+            Assert.Equal(PolicySeeder.SeedSubjectId, v.CreatedBySubjectId);
+            Assert.Equal(PolicySeeder.SeedSubjectId, v.ProposerSubjectId);
+        });
+    }
+
+    [Fact]
+    public async Task SecondSeedCall_DoesNotDuplicateOrMutate()
+    {
+        // Re-running the seeder against the live factory's already-seeded DB
+        // must be a no-op. This is the "every boot is safe" invariant from
+        // the story: operator-edited rows survive restarts.
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var beforeIds = await db.Policies.OrderBy(p => p.Name).Select(p => p.Id).ToListAsync();
+
+        await PolicySeeder.SeedStockPoliciesAsync(db);
+
+        var afterIds = await db.Policies.OrderBy(p => p.Name).Select(p => p.Id).ToListAsync();
+        Assert.Equal(beforeIds, afterIds);
+        Assert.Equal(6, await db.Policies.CountAsync());
+        Assert.Equal(6, await db.PolicyVersions.CountAsync());
+    }
+
+    [Fact]
+    public async Task SeededPolicies_AreReachableViaTheRestSurface()
+    {
+        // End-to-end check: the slugs the seeder writes must resolve through
+        // the public `/api/policies/by-name/{slug}` route that consumers use.
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/policies/by-name/no-prod");
+        response.EnsureSuccessStatusCode();
+
+        var policy = await response.Content.ReadFromJsonAsync<PolicyDto>();
+        Assert.NotNull(policy);
+        Assert.Equal("no-prod", policy!.Name);
+        Assert.Equal(1, policy.VersionCount);
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Seed/PolicySeederTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Seed/PolicySeederTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Seed;
+
+/// <summary>
+/// P1.3 (#73): the six stock policies are a product requirement that downstream
+/// services (Conductor admission, andy-tasks gates) reference by stable slug from
+/// day one. These tests pin the contents of the seed table row-by-row so an
+/// accidental edit (slug rename, scope drop, severity change) breaks loudly here.
+/// </summary>
+public class PolicySeederTests
+{
+    private static AppDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            // The InMemory provider warns on raw-SQL/transaction features that the
+            // real provider supports — irrelevant here, silencing keeps the test
+            // signal clean.
+            .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task Seed_OnEmptyCatalog_CreatesSixPolicies()
+    {
+        await using var db = NewContext();
+
+        await PolicySeeder.SeedStockPoliciesAsync(db);
+
+        Assert.Equal(6, await db.Policies.CountAsync());
+    }
+
+    [Fact]
+    public async Task Seed_CreatesSixDraftVersionsAtVersionOne()
+    {
+        await using var db = NewContext();
+
+        await PolicySeeder.SeedStockPoliciesAsync(db);
+
+        var versions = await db.PolicyVersions.ToListAsync();
+        Assert.Equal(6, versions.Count);
+        Assert.All(versions, v =>
+        {
+            Assert.Equal(1, v.Version);
+            Assert.Equal(LifecycleState.Draft, v.State);
+        });
+    }
+
+    [Fact]
+    public async Task Seed_IsIdempotentWhenCatalogNonEmpty()
+    {
+        await using var db = NewContext();
+
+        await PolicySeeder.SeedStockPoliciesAsync(db);
+        await PolicySeeder.SeedStockPoliciesAsync(db);
+
+        Assert.Equal(6, await db.Policies.CountAsync());
+        Assert.Equal(6, await db.PolicyVersions.CountAsync());
+    }
+
+    [Fact]
+    public async Task Seed_AssignsSeedSubjectIdOnPolicyAndVersion()
+    {
+        await using var db = NewContext();
+
+        await PolicySeeder.SeedStockPoliciesAsync(db);
+
+        Assert.All(await db.Policies.ToListAsync(),
+            p => Assert.Equal(PolicySeeder.SeedSubjectId, p.CreatedBySubjectId));
+        Assert.All(await db.PolicyVersions.ToListAsync(), v =>
+        {
+            Assert.Equal(PolicySeeder.SeedSubjectId, v.CreatedBySubjectId);
+            Assert.Equal(PolicySeeder.SeedSubjectId, v.ProposerSubjectId);
+        });
+    }
+
+    public static IEnumerable<object[]> StockMappingRows() => new[]
+    {
+        new object[] { "read-only",    EnforcementLevel.Must,   Severity.Info,     Array.Empty<string>() },
+        new object[] { "write-branch", EnforcementLevel.Should, Severity.Moderate, new[] { "repo" } },
+        new object[] { "sandboxed",    EnforcementLevel.Must,   Severity.Moderate, new[] { "tool", "container" } },
+        new object[] { "draft-only",   EnforcementLevel.Must,   Severity.Info,     new[] { "template" } },
+        new object[] { "no-prod",      EnforcementLevel.Must,   Severity.Critical, new[] { "prod" } },
+        new object[] { "high-risk",    EnforcementLevel.Must,   Severity.Critical, Array.Empty<string>() },
+    };
+
+    [Theory]
+    [MemberData(nameof(StockMappingRows))]
+    public async Task Seed_AssignsCorrectDimensionsPerStockPolicy(
+        string slug,
+        EnforcementLevel expectedEnforcement,
+        Severity expectedSeverity,
+        string[] expectedScopes)
+    {
+        await using var db = NewContext();
+
+        await PolicySeeder.SeedStockPoliciesAsync(db);
+
+        var policy = await db.Policies.SingleAsync(p => p.Name == slug);
+        var version = await db.PolicyVersions.SingleAsync(v => v.PolicyId == policy.Id);
+
+        Assert.Equal(expectedEnforcement, version.Enforcement);
+        Assert.Equal(expectedSeverity, version.Severity);
+        Assert.Equal(expectedScopes, version.Scopes);
+    }
+
+    [Fact]
+    public void StockPolicies_ListIsExactlySix()
+    {
+        // Guards against accidental additions/removals: a new stock policy is a
+        // product decision that should land in this issue trail, not by drive-by
+        // edit. Bump the expected count when intentionally extending the catalog.
+        Assert.Equal(6, PolicySeeder.StockPolicies.Count);
+    }
+
+    [Fact]
+    public void StockPolicies_SlugsAreUnique()
+    {
+        var slugs = PolicySeeder.StockPolicies.Select(s => s.Name).ToList();
+        Assert.Equal(slugs.Count, slugs.Distinct().Count());
+    }
+}


### PR DESCRIPTION
Closes #73. Contributes to Epic P1 (#1).

## Summary

Seeds the six canonical stock policies on first boot so downstream services (Conductor admission, andy-tasks per-task gates) can reference them by stable slug from day one. Each lands at \`Version=1, State=Draft\`; operators promote to \`Active\` via Epic P2.

The mapping mirrors the rivoli-ai/andy-rbac#18 (Epic V V2) reconciliation note:

| Slug | Enforcement | Severity | Scopes |
|---|---|---|---|
| \`read-only\` | MUST | Info | \`[]\` |
| \`write-branch\` | SHOULD | Moderate | \`[repo]\` |
| \`sandboxed\` | MUST | Moderate | \`[tool, container]\` |
| \`draft-only\` | MUST | Info | \`[template]\` |
| \`no-prod\` | MUST | Critical | \`[prod]\` |
| \`high-risk\` | MUST | Critical | \`[]\` |

## Implementation notes

- **Seeder is idempotent by-presence**: short-circuits if any \`Policy\` row exists. Safe to call on every boot; operator edits survive restarts. A re-seed escape hatch lands in P1.8 / Epic P8.
- **Wired from \`Program.cs\`** after the auto-migration block via a new \`IServiceProvider.EnsureSeedDataAsync\` extension (kept on \`IServiceProvider\` rather than \`IApplicationBuilder\` so the Infrastructure project doesn't take a dependency on AspNetCore).
- **Auto-migrate gate relaxed** for SQLite to also fire in the \`Testing\` environment. The integration-test factory has its own \`EnsureCreated\` and is unchanged; the relaxation matters for the OpenAPI export pipeline which boots Program.cs in Testing — the seeder needs a schema to land into. Postgres migration path stays Development-only; ops drive prod migrations.
- **\`scripts/export-openapi.sh\`** now sets \`Database__Provider=Sqlite\` + a tempfile data source so the in-process export-time boot reaches the seeder without a live Postgres.
- **Subject id**: literal \`\"system:seed\"\` on both \`Policy.CreatedBySubjectId\` and \`PolicyVersion.{CreatedBySubjectId,ProposerSubjectId}\`.

## Test plan

- [x] \`dotnet build Andy.Policies.sln\` clean
- [x] \`dotnet test tests/Andy.Policies.Tests.Unit\` — **104/104** (12 new PolicySeederTests, table-driven row-by-row mapping)
- [x] \`dotnet test tests/Andy.Policies.Tests.Integration\` — **83/83** (4 new SeedOnStartupTests covering boot wiring, idempotency, REST resolution)
- [x] \`./scripts/export-openapi.sh\` regenerates the yaml byte-stably (no schema impact)
- [ ] CI on this PR exercises the postgres-service path for the boot-time seed too

🤖 Generated with [Claude Code](https://claude.com/claude-code)