### PR TITLE
Implement P1.11 — integration tests: cross-provider migrations + cross-surface parity

### DIFF
--- a/tests/Andy.Policies.Tests.Integration/Andy.Policies.Tests.Integration.csproj
+++ b/tests/Andy.Policies.Tests.Integration/Andy.Policies.Tests.Integration.csproj
@@ -11,12 +11,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Grpc.Net.Client" Version="2.67.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="3.10.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/tests/Andy.Policies.Tests.Integration/Migration/PostgresMigrationTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Migration/PostgresMigrationTests.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Infrastructure.Data;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Migration;
+
+/// <summary>
+/// P1.11 (#91): EF Core migrations must apply cleanly on Postgres — the
+/// production provider. Existing tests use SQLite-backed factories for speed;
+/// this fixture spins up a real ephemeral Postgres via Testcontainers so the
+/// Npgsql-specific bits (jsonb columns, text[] arrays, partial unique indexes)
+/// are exercised end-to-end.
+///
+/// Skipped silently when the Docker daemon is unavailable so contributor
+/// laptops without Docker don't fail the suite. CI runners (ubuntu-latest)
+/// have Docker by default.
+/// </summary>
+public class PostgresMigrationTests : IAsyncLifetime
+{
+    private PostgreSqlContainer? _container;
+    private string _connectionString = string.Empty;
+    private bool _dockerAvailable;
+
+    public async Task InitializeAsync()
+    {
+        try
+        {
+            _container = new PostgreSqlBuilder()
+                .WithImage("postgres:16-alpine")
+                .WithDatabase("andy_policies_test")
+                .WithUsername("test")
+                .WithPassword("test")
+                .Build();
+            await _container.StartAsync();
+            _connectionString = _container.GetConnectionString();
+            _dockerAvailable = true;
+        }
+        catch (Exception)
+        {
+            // Docker unavailable on this host: tests below short-circuit. We
+            // intentionally swallow rather than fail the fixture so a
+            // contributor without Docker still gets a green Sqlite suite.
+            _dockerAvailable = false;
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_container is not null)
+        {
+            await _container.DisposeAsync();
+        }
+    }
+
+    private DbContextOptions<AppDbContext> NewOptions() =>
+        new DbContextOptionsBuilder<AppDbContext>()
+            .UseNpgsql(_connectionString)
+            .Options;
+
+    [SkippableFact]
+    public async Task MigrateAsync_OnEmptyPostgres_AppliesCleanly()
+    {
+        Skip.IfNot(_dockerAvailable);
+
+        await using var db = new AppDbContext(NewOptions());
+
+        await db.Database.MigrateAsync();
+
+        var applied = await db.Database.GetAppliedMigrationsAsync();
+        applied.Should().Contain(new[]
+        {
+            "20260422024314_InitialPolicyCatalog",
+            "20260422031628_AddPolicyDimensions",
+        });
+    }
+
+    [SkippableFact]
+    public async Task MigrateAsync_AppliedTwice_SecondCallIsNoOp()
+    {
+        Skip.IfNot(_dockerAvailable);
+
+        await using (var first = new AppDbContext(NewOptions()))
+        {
+            await first.Database.MigrateAsync();
+        }
+
+        await using var second = new AppDbContext(NewOptions());
+        var pendingBefore = await second.Database.GetPendingMigrationsAsync();
+        pendingBefore.Should().BeEmpty();
+
+        await second.Database.MigrateAsync();
+
+        var pendingAfter = await second.Database.GetPendingMigrationsAsync();
+        pendingAfter.Should().BeEmpty();
+    }
+
+    [SkippableFact]
+    public async Task MigratedSchema_UsesNativeTextArrayForScopes()
+    {
+        // The Sqlite provider stores scopes as a delimited string via a value
+        // converter; Postgres uses native text[]. This assertion guards the
+        // provider-specific column type configuration in AppDbContext.
+        Skip.IfNot(_dockerAvailable);
+
+        await using var db = new AppDbContext(NewOptions());
+        await db.Database.MigrateAsync();
+
+        var dataType = (await db.Database.SqlQueryRaw<string>(
+                """
+                SELECT data_type
+                FROM information_schema.columns
+                WHERE table_name = 'policy_versions' AND column_name = 'Scopes'
+                """).ToListAsync()).Single();
+
+        dataType.Should().Be("ARRAY");
+    }
+
+    [SkippableFact]
+    public async Task MigratedSchema_RulesJsonStoredAsJsonb()
+    {
+        Skip.IfNot(_dockerAvailable);
+
+        await using var db = new AppDbContext(NewOptions());
+        await db.Database.MigrateAsync();
+
+        var udtName = (await db.Database.SqlQueryRaw<string>(
+                """
+                SELECT udt_name
+                FROM information_schema.columns
+                WHERE table_name = 'policy_versions' AND column_name = 'RulesJson'
+                """).ToListAsync()).Single();
+
+        udtName.Should().Be("jsonb");
+    }
+
+    [SkippableFact]
+    public async Task MigratedSchema_HasOneDraftAndOneActivePartialIndex()
+    {
+        Skip.IfNot(_dockerAvailable);
+
+        await using var db = new AppDbContext(NewOptions());
+        await db.Database.MigrateAsync();
+
+        var indexNames = await db.Database.SqlQueryRaw<string>(
+                """
+                SELECT indexname
+                FROM pg_indexes
+                WHERE tablename = 'policy_versions'
+                """).ToListAsync();
+
+        indexNames.Should().Contain(new[]
+        {
+            "ix_policy_versions_one_draft_per_policy",
+            "ix_policy_versions_one_active_per_policy",
+        });
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Migration/SqliteMigrationTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Migration/SqliteMigrationTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Infrastructure.Data;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Migration;
+
+/// <summary>
+/// P1.11 (#91): EF Core migrations must apply cleanly on Sqlite — the embedded
+/// provider used by the Conductor bundling mode (Epic P10). Existing tests use
+/// SQLite in-memory via <c>EnsureCreated</c> for speed; this fixture uses
+/// <c>MigrateAsync</c> against a tempfile-backed DB so the actual migration
+/// scripts (not just the model) are exercised.
+/// </summary>
+public class SqliteMigrationTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly SqliteConnection _connection;
+
+    public SqliteMigrationTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"andy-policies-mig-{Guid.NewGuid():N}.db");
+        _connection = new SqliteConnection($"Data Source={_dbPath}");
+        _connection.Open();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        if (File.Exists(_dbPath))
+        {
+            File.Delete(_dbPath);
+        }
+    }
+
+    private DbContextOptions<AppDbContext> NewOptions() =>
+        new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+    [Fact]
+    public async Task MigrateAsync_OnEmptyDatabase_AppliesCleanly()
+    {
+        await using var db = new AppDbContext(NewOptions());
+
+        await db.Database.MigrateAsync();
+
+        var applied = await db.Database.GetAppliedMigrationsAsync();
+        applied.Should().Contain(new[]
+        {
+            "20260422024314_InitialPolicyCatalog",
+            "20260422031628_AddPolicyDimensions",
+        });
+    }
+
+    [Fact]
+    public async Task MigrateAsync_AppliedTwice_IsNoOpOnSecondCall()
+    {
+        await using (var first = new AppDbContext(NewOptions()))
+        {
+            await first.Database.MigrateAsync();
+        }
+
+        await using var second = new AppDbContext(NewOptions());
+        var beforeApplied = (await second.Database.GetAppliedMigrationsAsync()).ToList();
+        var pendingBefore = (await second.Database.GetPendingMigrationsAsync()).ToList();
+        pendingBefore.Should().BeEmpty();
+
+        await second.Database.MigrateAsync();
+
+        var afterApplied = (await second.Database.GetAppliedMigrationsAsync()).ToList();
+        afterApplied.Should().BeEquivalentTo(beforeApplied);
+    }
+
+    [Fact]
+    public async Task MigratedSchema_HasPoliciesAndPolicyVersionsTables()
+    {
+        await using var db = new AppDbContext(NewOptions());
+        await db.Database.MigrateAsync();
+
+        var tables = await db.Database.SqlQueryRaw<string>(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name <> '__EFMigrationsHistory'")
+            .ToListAsync();
+
+        tables.Should().Contain(new[] { "policies", "policy_versions" });
+    }
+
+    [Fact]
+    public async Task MigratedSchema_EnforcesPartialUniqueIndexOnDraftPerPolicy()
+    {
+        await using var db = new AppDbContext(NewOptions());
+        await db.Database.MigrateAsync();
+
+        var indexes = await db.Database.SqlQueryRaw<string>(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='policy_versions'")
+            .ToListAsync();
+
+        indexes.Should().Contain(new[]
+        {
+            "ix_policy_versions_one_draft_per_policy",
+            "ix_policy_versions_one_active_per_policy",
+        });
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Parity/CrossSurfaceParityTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Parity/CrossSurfaceParityTests.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net.Http.Json;
+using Andy.Policies.Api.Mcp;
+using Andy.Policies.Api.Protos;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Tests.Integration.Controllers;
+using FluentAssertions;
+using Grpc.Net.Client;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Parity;
+
+/// <summary>
+/// P1.11 (#91): every read surface (REST, MCP, gRPC) must return semantically
+/// equivalent results for the same operation. The CLI is a thin REST client
+/// (P1.8) so its parity is implied by the REST assertion — a separate
+/// subprocess-based golden test would couple this suite to dotnet-run startup
+/// time without adding signal beyond what we already get here.
+///
+/// All four surfaces resolve through the same <see cref="IPolicyService"/>
+/// instance under <see cref="PoliciesApiFactory"/>; this fixture proves the
+/// surface-specific serializers don't drift.
+/// </summary>
+public class CrossSurfaceParityTests : IClassFixture<PoliciesApiFactory>
+{
+    private readonly PoliciesApiFactory _factory;
+    private readonly HttpClient _restClient;
+    private readonly GrpcChannel _grpcChannel;
+    private readonly PolicyService.PolicyServiceClient _grpcClient;
+
+    public CrossSurfaceParityTests(PoliciesApiFactory factory)
+    {
+        _factory = factory;
+        _restClient = factory.CreateClient();
+        _grpcChannel = GrpcChannel.ForAddress(factory.Server.BaseAddress, new GrpcChannelOptions
+        {
+            HttpHandler = factory.Server.CreateHandler(),
+        });
+        _grpcClient = new PolicyService.PolicyServiceClient(_grpcChannel);
+    }
+
+    private async Task<PolicyDto> SeedPolicyAsync(string name)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IPolicyService>();
+        var version = await service.CreateDraftAsync(new CreatePolicyRequest(
+            Name: name,
+            Description: "parity-fixture",
+            Summary: "parity-fixture-summary",
+            Enforcement: "Must",
+            Severity: "Critical",
+            Scopes: new[] { "prod" },
+            RulesJson: "{}"), "parity-test");
+        var policy = await service.GetPolicyAsync(version.PolicyId);
+        return policy!;
+    }
+
+    [Fact]
+    public async Task GetPolicy_RestVsGrpc_ReturnEquivalentDtos()
+    {
+        var seeded = await SeedPolicyAsync($"parity-grpc-{Guid.NewGuid():N}");
+
+        var rest = await _restClient.GetFromJsonAsync<PolicyDto>($"/api/policies/{seeded.Id}");
+        var grpc = await _grpcClient.GetPolicyAsync(new GetPolicyRequest { Id = seeded.Id.ToString() });
+
+        rest.Should().NotBeNull();
+        grpc.Policy.Id.Should().Be(rest!.Id.ToString());
+        grpc.Policy.Name.Should().Be(rest.Name);
+        grpc.Policy.Description.Should().Be(rest.Description);
+        grpc.Policy.VersionCount.Should().Be(rest.VersionCount);
+        grpc.Policy.CreatedBySubjectId.Should().Be(rest.CreatedBySubjectId);
+    }
+
+    [Fact]
+    public async Task GetPolicy_RestVsMcp_DescribeSamePolicy()
+    {
+        var seeded = await SeedPolicyAsync($"parity-mcp-{Guid.NewGuid():N}");
+
+        var rest = await _restClient.GetFromJsonAsync<PolicyDto>($"/api/policies/{seeded.Id}");
+
+        using var scope = _factory.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IPolicyService>();
+        var mcp = await PolicyTools.GetPolicy(service, seeded.Id.ToString());
+
+        rest.Should().NotBeNull();
+        mcp.Should().Contain(rest!.Name);
+        mcp.Should().Contain(rest.Id.ToString());
+    }
+
+    [Fact]
+    public async Task ListVersions_RestVsGrpc_ReturnEquivalentVersionMetadata()
+    {
+        var seeded = await SeedPolicyAsync($"parity-versions-{Guid.NewGuid():N}");
+
+        var rest = await _restClient.GetFromJsonAsync<List<PolicyVersionDto>>(
+            $"/api/policies/{seeded.Id}/versions");
+        var grpc = await _grpcClient.ListVersionsAsync(new ListVersionsRequest
+        {
+            PolicyId = seeded.Id.ToString(),
+        });
+
+        rest.Should().NotBeNull();
+        rest!.Should().HaveCount(grpc.Versions.Count);
+        var restFirst = rest![0];
+        var grpcFirst = grpc.Versions[0];
+        grpcFirst.Id.Should().Be(restFirst.Id.ToString());
+        grpcFirst.Version.Should().Be(restFirst.Version);
+        grpcFirst.State.Should().Be(restFirst.State);
+        grpcFirst.Enforcement.Should().Be(restFirst.Enforcement);
+        grpcFirst.Severity.Should().Be(restFirst.Severity);
+        grpcFirst.Scopes.Should().BeEquivalentTo(restFirst.Scopes);
+        grpcFirst.Summary.Should().Be(restFirst.Summary);
+    }
+
+    [Fact]
+    public async Task GetActiveVersion_DraftOnly_AllSurfacesReturnNotFound()
+    {
+        // No publish yet — REST returns 404, gRPC raises NOT_FOUND, MCP returns
+        // a "no active version" message. Same semantic across surfaces.
+        var seeded = await SeedPolicyAsync($"parity-active-{Guid.NewGuid():N}");
+
+        var rest = await _restClient.GetAsync($"/api/policies/{seeded.Id}/versions/active");
+        rest.StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
+
+        var grpcCall = async () => await _grpcClient.GetActiveVersionAsync(new GetActiveVersionRequest
+        {
+            PolicyId = seeded.Id.ToString(),
+        });
+        await grpcCall.Should().ThrowAsync<Grpc.Core.RpcException>()
+            .Where(e => e.StatusCode == Grpc.Core.StatusCode.NotFound);
+
+        using var scope = _factory.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IPolicyService>();
+        var mcp = await PolicyTools.GetActiveVersion(service, seeded.Id.ToString());
+        mcp.Should().Contain("no active version");
+    }
+}


### PR DESCRIPTION
Closes #91. Contributes to Epic P1 (#1).

## Summary

Two real gaps the existing integration suite didn't cover:

### 1. Cross-provider migrations

Production runs on Postgres; embedded Conductor mode (Epic P10) runs on Sqlite. Existing tests use SQLite \`EnsureCreated\` for speed; nothing exercised the actual EF migration scripts on either provider.

- \`Migration/SqliteMigrationTests.cs\` (4 tests) — tempfile DB, \`MigrateAsync\` applies cleanly, second call is idempotent, schema has the expected tables and partial unique indexes.
- \`Migration/PostgresMigrationTests.cs\` (5 tests) — Testcontainers spins up a real ephemeral Postgres. Asserts the Npgsql-specific column types hold (\`text[]\` for \`Scopes\`, \`jsonb\` for \`RulesJson\`) — those are silently lost if SQLite is the only path tested. \`SkippableFact\` gates on Docker availability so contributors without Docker don't fail the suite.

### 2. Cross-surface parity

The four read surfaces (REST, MCP, gRPC, CLI) share an \`IPolicyService\` instance. A single assertion per scenario pins the surface-specific serializers so they can't drift independently.

- \`Parity/CrossSurfaceParityTests.cs\` (4 tests) — \`GetPolicy\` via REST vs gRPC vs MCP, \`ListVersions\` REST vs gRPC, \`GetActiveVersion\` error semantics across all three.

CLI golden subprocess tests are deliberately deferred. The CLI is a thin REST client (P1.8) so its parity is implied by the REST assertion; a separate \`dotnet run --project tools/...\` subprocess test would couple this suite to dotnet-run startup time without adding signal beyond what's already here.

## Packages added

- \`FluentAssertions 6.12.2\`
- \`Testcontainers.PostgreSql 3.10.0\`
- \`Xunit.SkippableFact 1.4.13\`

## Test plan

- [x] \`dotnet test tests/Andy.Policies.Tests.Unit\` — **113/113** (unchanged)
- [x] \`dotnet test tests/Andy.Policies.Tests.Integration\` — **96/96** (was 83; +13 new)
- [x] Full integration sweep ~15s locally with Docker (Postgres cold-start included) — well under the 90s target
- [x] OpenAPI yaml byte-stable on regeneration
- [ ] CI on this PR exercises both Sqlite and Postgres migration paths (postgres service container is already wired into \`build-backend\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)