### PR TITLE
Implement P2.1 — RetiredAt column on PolicyVersion + EF migration

### DIFF
--- a/src/Andy.Policies.Domain/Entities/PolicyVersion.cs
+++ b/src/Andy.Policies.Domain/Entities/PolicyVersion.cs
@@ -85,6 +85,13 @@ public class PolicyVersion
 
     public string? PublishedBySubjectId { get; set; }
 
+    /// <summary>
+    /// Timestamp set when this version transitions to <see cref="LifecycleState.Retired"/>.
+    /// P2's lifecycle service stamps it inside the transition transaction; never modified
+    /// after retirement. Null for versions that never reached Retired.
+    /// </summary>
+    public DateTimeOffset? RetiredAt { get; set; }
+
     /// <summary>Set when a newer version transitions this one to WindingDown (P2 auto-supersede).</summary>
     public Guid? SupersededByVersionId { get; set; }
 

--- a/src/Andy.Policies.Infrastructure/Data/AppDbContext.cs
+++ b/src/Andy.Policies.Infrastructure/Data/AppDbContext.cs
@@ -192,6 +192,7 @@ public class AppDbContext : DbContext
             nameof(PolicyVersion.State),
             nameof(PolicyVersion.PublishedAt),
             nameof(PolicyVersion.PublishedBySubjectId),
+            nameof(PolicyVersion.RetiredAt),
             nameof(PolicyVersion.SupersededByVersionId),
             nameof(PolicyVersion.Revision),
             // Shadow properties (e.g. Npgsql's `xmin` concurrency token if ever re-enabled)

--- a/src/Andy.Policies.Infrastructure/Migrations/20260427000816_AddRetiredAtToPolicyVersion.Designer.cs
+++ b/src/Andy.Policies.Infrastructure/Migrations/20260427000816_AddRetiredAtToPolicyVersion.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Andy.Policies.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Policies.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260427000816_AddRetiredAtToPolicyVersion")]
+    partial class AddRetiredAtToPolicyVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Policies.Infrastructure/Migrations/20260427000816_AddRetiredAtToPolicyVersion.cs
+++ b/src/Andy.Policies.Infrastructure/Migrations/20260427000816_AddRetiredAtToPolicyVersion.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Policies.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRetiredAtToPolicyVersion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "RetiredAt",
+                table: "policy_versions",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RetiredAt",
+                table: "policy_versions");
+        }
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Migration/PostgresMigrationTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Migration/PostgresMigrationTests.cs
@@ -76,6 +76,7 @@ public class PostgresMigrationTests : IAsyncLifetime
         {
             "20260422024314_InitialPolicyCatalog",
             "20260422031628_AddPolicyDimensions",
+            "20260427000816_AddRetiredAtToPolicyVersion",
         });
     }
 

--- a/tests/Andy.Policies.Tests.Integration/Migration/SqliteMigrationTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Migration/SqliteMigrationTests.cs
@@ -54,6 +54,7 @@ public class SqliteMigrationTests : IDisposable
         {
             "20260422024314_InitialPolicyCatalog",
             "20260422031628_AddPolicyDimensions",
+            "20260427000816_AddRetiredAtToPolicyVersion",
         });
     }
 

--- a/tests/Andy.Policies.Tests.Unit/Persistence/AppDbContextImmutabilityGuardTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Persistence/AppDbContextImmutabilityGuardTests.cs
@@ -145,6 +145,40 @@ public class AppDbContextImmutabilityGuardTests
     }
 
     [Fact]
+    public async Task SaveChangesAsync_AllowsWritingRetiredAt_OnNonDraftVersion()
+    {
+        // P2.1 (#11) added RetiredAt as a transition field. P2's lifecycle service
+        // stamps it inside the Retired transition; the immutability guard must
+        // allow it on a non-Draft row alongside the State/PublishedAt allow-list.
+        using var db = CreateInMemoryDb();
+        var policy = new Policy { Id = Guid.NewGuid(), Name = "no-prod", CreatedBySubjectId = "u1" };
+        var version = new PolicyVersion
+        {
+            Id = Guid.NewGuid(),
+            Policy = policy,
+            Version = 1,
+            State = LifecycleState.WindingDown,
+            Summary = "v1",
+            CreatedBySubjectId = "u1",
+            ProposerSubjectId = "u1",
+            PublishedAt = DateTimeOffset.UtcNow.AddDays(-7),
+            PublishedBySubjectId = "u2",
+        };
+        db.Policies.Add(policy);
+        db.PolicyVersions.Add(version);
+        await db.SaveChangesAsync();
+
+        version.State = LifecycleState.Retired;
+        version.RetiredAt = DateTimeOffset.UtcNow;
+
+        await db.SaveChangesAsync();
+
+        var loaded = await db.PolicyVersions.AsNoTracking().FirstAsync(v => v.Id == version.Id);
+        Assert.Equal(LifecycleState.Retired, loaded.State);
+        Assert.NotNull(loaded.RetiredAt);
+    }
+
+    [Fact]
     public async Task SaveChangesAsync_RevisionBumps_OnModification()
     {
         using var db = CreateInMemoryDb();


### PR DESCRIPTION
Closes #11. First story of Epic P2 — Lifecycle states (#2).

## Summary

Most of P2.1's surface was already laid down by P1.1 — the \`LifecycleState\` enum (all four values), \`PolicyVersion.{State, PublishedAt, PublishedBySubjectId, SupersededByVersionId}\`, and the partial unique index \`ix_policy_versions_one_active_per_policy\` (enforces one Active per policy on both Postgres and Sqlite). The remaining gap from the story spec was the \`RetiredAt\` timestamp.

### Adds
- \`PolicyVersion.RetiredAt\` (nullable \`DateTimeOffset\`). P2's lifecycle service (P2.2 / P2.3) will stamp it inside the Retired transition; never modified afterwards.
- EF migration \`20260427000816_AddRetiredAtToPolicyVersion\` — clean \`ALTER TABLE\` adding the nullable column; \`Down\` drops it cleanly.
- \`AppDbContext.EnforcePolicyVersionImmutability\` allow-list extended to permit \`RetiredAt\` writes on non-Draft rows alongside the existing \`State\` / \`PublishedAt\` / \`SupersededByVersionId\` / \`Revision\` set, so the P2.3 transition flow can stamp it without tripping the guard.

### Tests
- \`Migration/SqliteMigrationTests.MigrateAsync_OnEmptyDatabase_AppliesCleanly\` and the equivalent Postgres test (Testcontainers) updated to assert the new migration is in the applied set.
- \`AppDbContextImmutabilityGuardTests.SaveChangesAsync_AllowsWritingRetiredAt_OnNonDraftVersion\` — proves a \`WindingDown -> Retired\` transition that also writes \`RetiredAt\` succeeds.

## Test plan

- [x] \`dotnet test tests/Andy.Policies.Tests.Unit\` — **114/114** (was 113)
- [x] \`dotnet test tests/Andy.Policies.Tests.Integration\` — **96/96** locally; Postgres-Testcontainers path verifies the migration applies on a real Postgres
- [x] OpenAPI yaml byte-stable on regeneration (\`RetiredAt\` is not on any DTO yet — that lands with P2.3's transition endpoints)
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)