### PR TITLE
Implement P2.3 — REST publish/winding-down/retire endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,28 @@ docker compose up -d
 open http://localhost:6206
 ```
 
+### Lifecycle endpoints
+
+Three action-shaped endpoints drive `PolicyVersion` lifecycle transitions
+(P2.3, [#13](https://github.com/rivoli-ai/andy-policies/issues/13)). All three
+require a `rationale` body and a Bearer token; they share
+`ILifecycleTransitionService` with the MCP / gRPC / CLI surfaces.
+
+```http
+POST /api/policies/{id}/versions/{versionId}/publish
+POST /api/policies/{id}/versions/{versionId}/winding-down
+POST /api/policies/{id}/versions/{versionId}/retire
+Content-Type: application/json
+Authorization: Bearer <jwt>
+
+{ "rationale": "promote v3 — passed canary" }
+```
+
+Publishing auto-supersedes the prior `Active` version inside the same DB
+transaction (it transitions to `WindingDown` with `SupersededByVersionId` set
+to the new version). Disallowed transitions return `409 Conflict`; an empty
+rationale returns `400 Bad Request`; missing or unknown ids return `404`.
+
 ## Ports
 
 Per the ecosystem registry at [`../andy-service-template/docs/ports.md`](../andy-service-template/docs/ports.md). Three deployment modes; the same host can run any combination because each mode uses a distinct port range.

--- a/docs/openapi/andy-policies-v1.yaml
+++ b/docs/openapi/andy-policies-v1.yaml
@@ -512,6 +512,189 @@ paths:
             text/json:
               schema:
                 $ref: '#/components/schemas/PolicyVersionDto'
+  '/api/policies/{id}/versions/{versionId}/publish':
+    post:
+      tags:
+        - PolicyVersionsLifecycle
+      summary: "Promote a Draft to Active. Auto-supersedes the existing Active version\r\n(if any) within the same DB transaction."
+      operationId: PolicyVersionsLifecycle_Publish
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: versionId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LifecycleTransitionRequest'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/LifecycleTransitionRequest'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/LifecycleTransitionRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDto'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+  '/api/policies/{id}/versions/{versionId}/winding-down':
+    post:
+      tags:
+        - PolicyVersionsLifecycle
+      summary: "Mark an Active version as winding down. Reads against the previous\r\nActive continue to resolve until the version is retired."
+      operationId: PolicyVersionsLifecycle_WindDown
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: versionId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LifecycleTransitionRequest'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/LifecycleTransitionRequest'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/LifecycleTransitionRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDto'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+  '/api/policies/{id}/versions/{versionId}/retire':
+    post:
+      tags:
+        - PolicyVersionsLifecycle
+      summary: "Tombstone a version. Stamps `RetiredAt`; subsequent transitions are\r\nrejected by the matrix."
+      operationId: PolicyVersionsLifecycle_Retire
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: versionId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LifecycleTransitionRequest'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/LifecycleTransitionRequest'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/LifecycleTransitionRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyVersionDto'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
 components:
   schemas:
     CreateItemRequest:
@@ -625,6 +808,14 @@ components:
           format: date-time
           nullable: true
       additionalProperties: false
+    LifecycleTransitionRequest:
+      type: object
+      properties:
+        rationale:
+          type: string
+          nullable: true
+      additionalProperties: false
+      description: "Request payload for the lifecycle transition endpoints (P2.3, story\r\nrivoli-ai/andy-policies#13): publish, winding-down, retire. The single\r\n`rationale` field is forwarded to `ILifecycleTransitionService`\r\nwhere `IRationalePolicy` validates it against the\r\n`andy.policies.rationaleRequired` setting (P2.4 wires the dynamic\r\ngate; P2.3 ships with the require-non-empty default)."
     PolicyDto:
       type: object
       properties:
@@ -708,6 +899,26 @@ components:
           nullable: true
       additionalProperties: false
       description: "Wire-format projection of a `PolicyVersion`. Enum-shaped fields are\r\nserialised in the casing required by ADR 0001 §6:\r\n<list type=\"bullet\"><item><term>Enforcement</term><description>uppercase RFC 2119 tokens (`MUST` / `SHOULD` / `MAY`).</description></item><item><term>Severity</term><description>lowercase (`info` / `moderate` / `critical`).</description></item><item><term>State</term><description>PascalCase (`Draft` / `Active` / `WindingDown` / `Retired`) — matches DB storage and consumer-visible lifecycle labels.</description></item></list>\r\nService layer performs the casing conversion; controllers pass the DTO through unchanged."
+    ProblemDetails:
+      type: object
+      properties:
+        type:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        status:
+          type: integer
+          format: int32
+          nullable: true
+        detail:
+          type: string
+          nullable: true
+        instance:
+          type: string
+          nullable: true
+      additionalProperties: { }
     UpdatePolicyVersionRequest:
       type: object
       properties:
@@ -751,3 +962,5 @@ tags:
     description: "Serves help content from markdown files in content/help/.\r\nConsumable by any client: Angular, Swift (Conductor), CLI, MCP."
   - name: Policies
     description: "REST surface for the policy catalog (P1.5, story rivoli-ai/andy-policies#75).\r\nAll endpoints delegate to Andy.Policies.Application.Interfaces.IPolicyService; service exceptions are\r\nmapped to status codes by `PolicyExceptionHandler` (registered globally)."
+  - name: PolicyVersionsLifecycle
+    description: "REST surface for lifecycle transitions on a `PolicyVersion` (P2.3, story\r\nrivoli-ai/andy-policies#13). Three action-shaped endpoints — `publish`,\r\n`winding-down`, `retire` — sit on top of\r\nAndy.Policies.Application.Interfaces.ILifecycleTransitionService. Auto-supersede of the previous\r\nActive happens inside the service's serializable transaction; the controller\r\nis a thin wire-format adapter and never re-implements state-machine logic.\r\nService exceptions map to status codes via `PolicyExceptionHandler`:\r\nAndy.Policies.Application.Exceptions.ValidationException → 400 (rationale\r\nmissing), Andy.Policies.Application.Exceptions.NotFoundException → 404\r\n(unknown id), Andy.Policies.Application.Exceptions.InvalidLifecycleTransitionException\r\nand Andy.Policies.Application.Exceptions.ConcurrentPublishException → 409."

--- a/src/Andy.Policies.Api/Controllers/PolicyVersionsLifecycleController.cs
+++ b/src/Andy.Policies.Api/Controllers/PolicyVersionsLifecycleController.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Claims;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Enums;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Andy.Policies.Api.Controllers;
+
+/// <summary>
+/// REST surface for lifecycle transitions on a <c>PolicyVersion</c> (P2.3, story
+/// rivoli-ai/andy-policies#13). Three action-shaped endpoints — <c>publish</c>,
+/// <c>winding-down</c>, <c>retire</c> — sit on top of
+/// <see cref="ILifecycleTransitionService"/>. Auto-supersede of the previous
+/// Active happens inside the service's serializable transaction; the controller
+/// is a thin wire-format adapter and never re-implements state-machine logic.
+/// Service exceptions map to status codes via <c>PolicyExceptionHandler</c>:
+/// <see cref="Application.Exceptions.ValidationException"/> → 400 (rationale
+/// missing), <see cref="Application.Exceptions.NotFoundException"/> → 404
+/// (unknown id), <see cref="Application.Exceptions.InvalidLifecycleTransitionException"/>
+/// and <see cref="Application.Exceptions.ConcurrentPublishException"/> → 409.
+/// </summary>
+[ApiController]
+[Authorize]
+[Route("api/policies/{id:guid}/versions/{versionId:guid}")]
+[Produces("application/json")]
+public sealed class PolicyVersionsLifecycleController : ControllerBase
+{
+    private readonly ILifecycleTransitionService _transitions;
+
+    public PolicyVersionsLifecycleController(ILifecycleTransitionService transitions)
+    {
+        _transitions = transitions;
+    }
+
+    /// <summary>
+    /// Promote a Draft to Active. Auto-supersedes the existing Active version
+    /// (if any) within the same DB transaction.
+    /// </summary>
+    [HttpPost("publish")]
+    [ProducesResponseType(typeof(PolicyVersionDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public Task<ActionResult<PolicyVersionDto>> Publish(
+        Guid id, Guid versionId,
+        [FromBody] LifecycleTransitionRequest body,
+        CancellationToken ct)
+        => ExecuteAsync(id, versionId, LifecycleState.Active, body, ct);
+
+    /// <summary>
+    /// Mark an Active version as winding down. Reads against the previous
+    /// Active continue to resolve until the version is retired.
+    /// </summary>
+    [HttpPost("winding-down")]
+    [ProducesResponseType(typeof(PolicyVersionDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public Task<ActionResult<PolicyVersionDto>> WindDown(
+        Guid id, Guid versionId,
+        [FromBody] LifecycleTransitionRequest body,
+        CancellationToken ct)
+        => ExecuteAsync(id, versionId, LifecycleState.WindingDown, body, ct);
+
+    /// <summary>
+    /// Tombstone a version. Stamps <c>RetiredAt</c>; subsequent transitions are
+    /// rejected by the matrix.
+    /// </summary>
+    [HttpPost("retire")]
+    [ProducesResponseType(typeof(PolicyVersionDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public Task<ActionResult<PolicyVersionDto>> Retire(
+        Guid id, Guid versionId,
+        [FromBody] LifecycleTransitionRequest body,
+        CancellationToken ct)
+        => ExecuteAsync(id, versionId, LifecycleState.Retired, body, ct);
+
+    private async Task<ActionResult<PolicyVersionDto>> ExecuteAsync(
+        Guid id, Guid versionId, LifecycleState target,
+        LifecycleTransitionRequest? body, CancellationToken ct)
+    {
+        // Per #13 security firewall: never write a fallback subject id into the
+        // catalog. JwtBearer maps `sub` to NameIdentifier; TestAuthHandler sets
+        // the Name claim. If neither is present, [Authorize] should already have
+        // returned 401 — this is the belt to the framework's braces.
+        var subjectId = User.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? User.Identity?.Name;
+        if (string.IsNullOrEmpty(subjectId))
+        {
+            return Unauthorized();
+        }
+
+        var dto = await _transitions.TransitionAsync(
+            id, versionId, target,
+            body?.Rationale ?? string.Empty,
+            subjectId, ct);
+
+        return Ok(dto);
+    }
+}

--- a/src/Andy.Policies.Application/Dtos/LifecycleTransitionRequest.cs
+++ b/src/Andy.Policies.Application/Dtos/LifecycleTransitionRequest.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.Dtos;
+
+/// <summary>
+/// Request payload for the lifecycle transition endpoints (P2.3, story
+/// rivoli-ai/andy-policies#13): publish, winding-down, retire. The single
+/// <c>rationale</c> field is forwarded to <c>ILifecycleTransitionService</c>
+/// where <c>IRationalePolicy</c> validates it against the
+/// <c>andy.policies.rationaleRequired</c> setting (P2.4 wires the dynamic
+/// gate; P2.3 ships with the require-non-empty default).
+/// </summary>
+public record LifecycleTransitionRequest(string? Rationale);

--- a/src/Andy.Policies.Infrastructure/Services/LifecycleTransitionService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/LifecycleTransitionService.cs
@@ -125,10 +125,21 @@ public sealed class LifecycleTransitionService : ILifecycleTransitionService
 
                 if (previousActive is not null)
                 {
+                    // Issue the WindingDown UPDATE in its own SaveChanges so the
+                    // partial unique index on (PolicyId) WHERE State = 'Active'
+                    // sees the row leave the Active set before the new version's
+                    // UPDATE adds the successor. EF batches updates by tracking
+                    // order, which on the loader path above puts `version`
+                    // (loaded first) ahead of `previousActive` (loaded second);
+                    // SQLite then trips the unique index on the still-Active v1
+                    // when v2's UPDATE lands first. Splitting the writes inside
+                    // the open serializable transaction preserves atomicity
+                    // without depending on EF's update-ordering heuristics.
                     previousActive.State = LifecycleState.WindingDown;
                     previousActive.SupersededByVersionId = version.Id;
                     pendingSuperseded = new PolicyVersionSuperseded(
                         policyId, previousActive.Id, version.Id, now);
+                    await _db.SaveChangesAsync(ct).ConfigureAwait(false);
                 }
 
                 version.State = LifecycleState.Active;

--- a/tests/Andy.Policies.Tests.Integration/Controllers/PolicyVersionsLifecycleControllerActorClaimTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/PolicyVersionsLifecycleControllerActorClaimTests.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Claims;
+using Andy.Policies.Api.Controllers;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Enums;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Controllers;
+
+/// <summary>
+/// Direct controller-level tests for the actor-fallback firewall mandated by
+/// P2.3 (story rivoli-ai/andy-policies#13 §"Actor-fallback firewall"). The
+/// controller must never write a fallback subject id like <c>"anonymous"</c>
+/// into <c>ILifecycleTransitionService.TransitionAsync</c>; if neither
+/// <c>NameIdentifier</c> (production JWT <c>sub</c>) nor <c>Name</c> (test
+/// principal) is present it must short-circuit to 401 before the service
+/// runs. This test exercises the controller in-process with a fake principal —
+/// the HTTP integration tests cover the happy path through TestAuthHandler.
+/// </summary>
+public class PolicyVersionsLifecycleControllerActorClaimTests
+{
+    private static (PolicyVersionsLifecycleController controller, RecordingTransitionService stub) Build(
+        ClaimsPrincipal principal)
+    {
+        var stub = new RecordingTransitionService();
+        var controller = new PolicyVersionsLifecycleController(stub)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = principal },
+            },
+        };
+        return (controller, stub);
+    }
+
+    [Fact]
+    public async Task Publish_WithNoSubjectClaims_Returns401_AndDoesNotCallService()
+    {
+        var anonymous = new ClaimsPrincipal(new ClaimsIdentity());
+        var (controller, stub) = Build(anonymous);
+
+        var result = await controller.Publish(
+            Guid.NewGuid(), Guid.NewGuid(), new LifecycleTransitionRequest("ship"), CancellationToken.None);
+
+        result.Result.Should().BeOfType<UnauthorizedResult>();
+        stub.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Publish_WithNameIdentifier_PassesSubjectIdToService()
+    {
+        var jwt = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, "user-42"),
+        }, authenticationType: "Bearer"));
+        var (controller, stub) = Build(jwt);
+
+        await controller.Publish(
+            Guid.NewGuid(), Guid.NewGuid(), new LifecycleTransitionRequest("ship"), CancellationToken.None);
+
+        stub.Calls.Should().ContainSingle().Which.ActorSubjectId.Should().Be("user-42");
+    }
+
+    [Fact]
+    public async Task Publish_WithOnlyNameClaim_FallsBackToName_ForTestSchemes()
+    {
+        // TestAuthHandler in the integration suite issues only a Name claim
+        // (TestSubjectId = "test-user"). The controller must accept that path
+        // so [Authorize]-gated integration tests don't depend on a separate
+        // production-JWT-style claim shape.
+        var testPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.Name, "test-user"),
+        }, authenticationType: "Test"));
+        var (controller, stub) = Build(testPrincipal);
+
+        await controller.Publish(
+            Guid.NewGuid(), Guid.NewGuid(), new LifecycleTransitionRequest("ship"), CancellationToken.None);
+
+        stub.Calls.Should().ContainSingle().Which.ActorSubjectId.Should().Be("test-user");
+    }
+
+    [Fact]
+    public async Task Retire_WithNoSubjectClaims_Returns401()
+    {
+        var anonymous = new ClaimsPrincipal(new ClaimsIdentity());
+        var (controller, stub) = Build(anonymous);
+
+        var result = await controller.Retire(
+            Guid.NewGuid(), Guid.NewGuid(), new LifecycleTransitionRequest("tomb"), CancellationToken.None);
+
+        result.Result.Should().BeOfType<UnauthorizedResult>();
+        stub.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task WindDown_WithNoSubjectClaims_Returns401()
+    {
+        var anonymous = new ClaimsPrincipal(new ClaimsIdentity());
+        var (controller, stub) = Build(anonymous);
+
+        var result = await controller.WindDown(
+            Guid.NewGuid(), Guid.NewGuid(), new LifecycleTransitionRequest("sunset"), CancellationToken.None);
+
+        result.Result.Should().BeOfType<UnauthorizedResult>();
+        stub.Calls.Should().BeEmpty();
+    }
+
+    private sealed record RecordedCall(
+        Guid PolicyId, Guid VersionId, LifecycleState Target,
+        string Rationale, string ActorSubjectId);
+
+    private sealed class RecordingTransitionService : ILifecycleTransitionService
+    {
+        public List<RecordedCall> Calls { get; } = new();
+
+        public bool IsTransitionAllowed(LifecycleState from, LifecycleState to) => true;
+
+        public IReadOnlyList<LifecycleTransitionRule> GetMatrix() => Array.Empty<LifecycleTransitionRule>();
+
+        public Task<PolicyVersionDto> TransitionAsync(
+            Guid policyId, Guid versionId, LifecycleState target,
+            string rationale, string actorSubjectId, CancellationToken ct = default)
+        {
+            Calls.Add(new RecordedCall(policyId, versionId, target, rationale, actorSubjectId));
+            return Task.FromResult(new PolicyVersionDto(
+                versionId, policyId, 1, target.ToString(),
+                "MUST", "critical", Array.Empty<string>(),
+                "summary", "{}", DateTimeOffset.UtcNow, actorSubjectId, actorSubjectId));
+        }
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Controllers/PolicyVersionsLifecycleControllerTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/PolicyVersionsLifecycleControllerTests.cs
@@ -1,0 +1,210 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Json;
+using Andy.Policies.Application.Dtos;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Controllers;
+
+/// <summary>
+/// Integration tests for the lifecycle endpoints (P2.3, story
+/// rivoli-ai/andy-policies#13). Exercises publish/winding-down/retire over the
+/// real MVC pipeline plus <c>LifecycleTransitionService</c> against a
+/// SQLite-backed factory. Verifies wire contract: 200 with updated DTO on the
+/// happy path, 400 on missing rationale, 404 on unknown ids, 409 on disallowed
+/// transitions, and that auto-supersede flips the previous Active to
+/// WindingDown atomically.
+/// </summary>
+public class PolicyVersionsLifecycleControllerTests : IClassFixture<PoliciesApiFactory>
+{
+    private readonly HttpClient _client;
+
+    public PolicyVersionsLifecycleControllerTests(PoliciesApiFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    private static CreatePolicyRequest MinimalCreate(string name) => new(
+        Name: name,
+        Description: null,
+        Summary: "summary",
+        Enforcement: "Must",
+        Severity: "Critical",
+        Scopes: Array.Empty<string>(),
+        RulesJson: "{}");
+
+    private static LifecycleTransitionRequest WithRationale(string rationale = "ship-it")
+        => new(rationale);
+
+    private async Task<PolicyVersionDto> CreateDraftAsync(string name)
+    {
+        var response = await _client.PostAsJsonAsync("/api/policies", MinimalCreate(name));
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
+    }
+
+    private async Task<PolicyVersionDto> BumpDraftAsync(Guid policyId, Guid sourceVersionId)
+    {
+        var response = await _client.PostAsync(
+            $"/api/policies/{policyId}/versions/{sourceVersionId}/bump", content: null);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
+    }
+
+    [Fact]
+    public async Task Publish_OnDraft_Returns200_WithActiveState()
+    {
+        var draft = await CreateDraftAsync("publish-happy");
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
+            WithRationale());
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<PolicyVersionDto>();
+        dto!.State.Should().Be("Active");
+        dto.Id.Should().Be(draft.Id);
+    }
+
+    [Fact]
+    public async Task Publish_NewerDraft_AutoSupersedesPreviousActive()
+    {
+        var v1 = await CreateDraftAsync("auto-supersede");
+        await _client.PostAsJsonAsync(
+            $"/api/policies/{v1.PolicyId}/versions/{v1.Id}/publish",
+            WithRationale("v1-go-live"));
+
+        // Bumping the published v1 mints a fresh Draft (v2) under the same policy.
+        var v2 = await BumpDraftAsync(v1.PolicyId, v1.Id);
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/policies/{v2.PolicyId}/versions/{v2.Id}/publish",
+            WithRationale("v2-go-live"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var publishedV2 = await response.Content.ReadFromJsonAsync<PolicyVersionDto>();
+        publishedV2!.State.Should().Be("Active");
+
+        // Re-read v1 — it must now be WindingDown.
+        var v1After = await _client.GetFromJsonAsync<PolicyVersionDto>(
+            $"/api/policies/{v1.PolicyId}/versions/{v1.Id}");
+        v1After!.State.Should().Be("WindingDown");
+
+        // The active resolution endpoint should now return v2.
+        var active = await _client.GetFromJsonAsync<PolicyVersionDto>(
+            $"/api/policies/{v1.PolicyId}/versions/active");
+        active!.Id.Should().Be(v2.Id);
+    }
+
+    [Fact]
+    public async Task Publish_WithEmptyRationale_Returns400()
+    {
+        var draft = await CreateDraftAsync("publish-no-rationale");
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
+            new LifecycleTransitionRequest(Rationale: "   "));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        problem!.Title.Should().Be("Validation failed");
+    }
+
+    [Fact]
+    public async Task Publish_OnUnknownPolicy_Returns404()
+    {
+        var response = await _client.PostAsJsonAsync(
+            $"/api/policies/{Guid.NewGuid()}/versions/{Guid.NewGuid()}/publish",
+            WithRationale());
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Publish_OnRetiredVersion_Returns409()
+    {
+        var draft = await CreateDraftAsync("publish-retired-blocked");
+        await _client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
+            WithRationale("live"));
+        // Active -> Retired is allowed and tombstones the version.
+        await _client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/retire",
+            WithRationale("tomb"));
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
+            WithRationale("rezz"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        problem!.Title.Should().Be("Invalid lifecycle transition");
+    }
+
+    [Fact]
+    public async Task WindDown_OnActive_Returns200_AndState()
+    {
+        var draft = await CreateDraftAsync("wind-down-happy");
+        await _client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
+            WithRationale("live"));
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/winding-down",
+            WithRationale("sunset"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<PolicyVersionDto>();
+        dto!.State.Should().Be("WindingDown");
+    }
+
+    [Fact]
+    public async Task WindDown_OnDraft_Returns409()
+    {
+        // Draft -> WindingDown is not in the matrix.
+        var draft = await CreateDraftAsync("wind-down-from-draft");
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/winding-down",
+            WithRationale("nope"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Retire_FromWindingDown_Returns200_AndStampsState()
+    {
+        var draft = await CreateDraftAsync("retire-from-winding");
+        await _client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
+            WithRationale("live"));
+        await _client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/winding-down",
+            WithRationale("sunset"));
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/retire",
+            WithRationale("tomb"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<PolicyVersionDto>();
+        dto!.State.Should().Be("Retired");
+    }
+
+    [Fact]
+    public async Task Retire_OnDraft_Returns409()
+    {
+        // Draft -> Retired is not in the matrix; only Active and WindingDown can retire.
+        var draft = await CreateDraftAsync("retire-from-draft");
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/retire",
+            WithRationale("nope"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+}


### PR DESCRIPTION
## Summary
- Adds `PolicyVersionsLifecycleController` with three action endpoints (`publish`, `winding-down`, `retire`) sitting on top of `ILifecycleTransitionService`. Auto-supersede happens inside the service's serializable transaction; the controller is a thin wire-format adapter.
- Service exceptions map to status codes via the existing `PolicyExceptionHandler`: `ValidationException` → 400, `NotFoundException` → 404, `InvalidLifecycleTransitionException` and `ConcurrentPublishException` → 409.
- Actor read from `NameIdentifier` (JWT `sub`) with fallback to `Name` (`TestAuthHandler`); returns 401 if neither is present, so a fallback subject id is never written into the catalog (#13 §Actor-fallback firewall).
- Fixes a P2.2 ordering bug surfaced by the auto-supersede integration test: EF's batched updates emit v2 → Active before v1 → WindingDown, which trips the partial unique index on real SQLite and Postgres. `LifecycleTransitionService` now saves the `WindingDown` update first within the same serializable transaction. In-memory unit tests don't enforce partial indexes so it didn't surface in P2.2.

Closes #13.

## Test plan
- [x] `dotnet test` — 138 unit + 111 integration pass; 6 E2E skipped (`E2E_ENABLED=0`).
- [x] `scripts/export-openapi.sh` regenerates `docs/openapi/andy-policies-v1.yaml` cleanly with the three new operations and `LifecycleTransitionRequest` schema (CI drift check should be green).
- [x] Integration coverage: 200 happy path on all three endpoints, auto-supersede flips previous Active to WindingDown, 400 on empty rationale, 404 on unknown ids, 409 on disallowed transitions (publish→retired, draft→winding-down, draft→retire).
- [x] Controller-level coverage: 401 when no subject claims present (all three endpoints), `NameIdentifier` and `Name` claim shapes both accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)