### PR TITLE
Implement P2.4 — rationale enforcement wired to andy.policies.rationaleRequired

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ transaction (it transitions to `WindingDown` with `SupersededByVersionId` set
 to the new version). Disallowed transitions return `409 Conflict`; an empty
 rationale returns `400 Bad Request`; missing or unknown ids return `404`.
 
+The `rationale` field is enforced when the andy-settings toggle
+`andy.policies.rationaleRequired` is on (default; P2.4,
+[#14](https://github.com/rivoli-ai/andy-policies/issues/14)). Operators flip
+the toggle in the andy-settings admin UI; the live process picks it up on the
+next snapshot refresh (default 60s) without a restart. When the toggle is on
+and rationale is empty, the API returns
+`400` with `type=/problems/rationale-required` and `errors.rationale`
+populated; the current toggle value is exported as the OpenTelemetry gauge
+`andy_policies_rationale_required_toggle_value` (1 = on, 0 = off).
+
 ## Ports
 
 Per the ecosystem registry at [`../andy-service-template/docs/ports.md`](../andy-service-template/docs/ports.md). Three deployment modes; the same host can run any combination because each mode uses a distinct port range.

--- a/src/Andy.Policies.Api/ExceptionHandlers/PolicyExceptionHandler.cs
+++ b/src/Andy.Policies.Api/ExceptionHandlers/PolicyExceptionHandler.cs
@@ -27,6 +27,30 @@ public sealed class PolicyExceptionHandler : IExceptionHandler
         Exception exception,
         CancellationToken cancellationToken)
     {
+        // Special-case RationaleRequiredException so the response carries the
+        // typed ProblemDetails contract from P2.4 (#14): `type` points at the
+        // rationale-required problem class, and `errors.rationale` is populated
+        // for clients (Cockpit, CLI) that surface field-level validation
+        // errors. Falls through to the generic 400 branch below if anything
+        // changes — the base class is ValidationException.
+        if (exception is RationaleRequiredException rrex)
+        {
+            var problem400 = new ValidationProblemDetails(new Dictionary<string, string[]>
+            {
+                ["rationale"] = new[] { rrex.Message },
+            })
+            {
+                Status = StatusCodes.Status400BadRequest,
+                Title = "Rationale required",
+                Detail = rrex.Message,
+                Type = "/problems/rationale-required",
+                Instance = httpContext.Request.Path,
+            };
+            httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await httpContext.Response.WriteAsJsonAsync(problem400, cancellationToken);
+            return true;
+        }
+
         var (status, title) = exception switch
         {
             ValidationException => (StatusCodes.Status400BadRequest, "Validation failed"),

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -97,7 +97,11 @@ builder.Services.AddAndySettingsClient(builder.Configuration);
 builder.Services.AddScoped<IItemService, ItemService>();
 builder.Services.AddScoped<IPolicyService, PolicyService>();
 builder.Services.AddScoped<Andy.Policies.Application.Interfaces.ILifecycleTransitionService, Andy.Policies.Infrastructure.Services.LifecycleTransitionService>();
-builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IRationalePolicy, Andy.Policies.Infrastructure.Services.RequireNonEmptyRationalePolicy>();
+// P2.4 (#14): the rationale policy reads andy.policies.rationaleRequired from
+// the andy-settings snapshot on every check (fail-safe to required=true if the
+// snapshot has not yet observed the key). Registered as a singleton because it
+// owns the metric Meter; the underlying ISettingsSnapshot is also a singleton.
+builder.Services.AddSingleton<Andy.Policies.Application.Interfaces.IRationalePolicy, Andy.Policies.Infrastructure.Services.AndySettingsRationalePolicy>();
 builder.Services.AddSingleton<Andy.Policies.Application.Interfaces.IDomainEventDispatcher, Andy.Policies.Infrastructure.Services.InProcessDomainEventDispatcher>();
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddDataProtection();
@@ -123,7 +127,8 @@ builder.Services.AddOpenTelemetry()
     {
         metrics.AddAspNetCoreInstrumentation()
                .AddHttpClientInstrumentation()
-               .AddRuntimeInstrumentation();
+               .AddRuntimeInstrumentation()
+               .AddMeter(Andy.Policies.Infrastructure.Services.AndySettingsRationalePolicy.MeterName);
         if (!string.IsNullOrEmpty(otlpEndpoint))
             metrics.AddOtlpExporter(o => o.Endpoint = new Uri(otlpEndpoint));
     });

--- a/src/Andy.Policies.Application/Exceptions/RationaleRequiredException.cs
+++ b/src/Andy.Policies.Application/Exceptions/RationaleRequiredException.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.Exceptions;
+
+/// <summary>
+/// Thrown by <c>ILifecycleTransitionService.TransitionAsync</c> when the
+/// caller's rationale is null/empty/whitespace and the live setting
+/// <c>andy.policies.rationaleRequired</c> is on (P2.4, #14). Distinct from
+/// <see cref="ValidationException"/> so the API layer can emit a typed
+/// <c>ProblemDetails</c> with <c>type=/problems/rationale-required</c> and
+/// <c>errors.rationale</c> populated. Inherits from <see cref="ValidationException"/>
+/// so existing 400-mapping and unit tests that check for the base type keep
+/// working without churn.
+/// </summary>
+public sealed class RationaleRequiredException : ValidationException
+{
+    public RationaleRequiredException(string message) : base(message) { }
+
+    public RationaleRequiredException(string message, Exception inner) : base(message, inner) { }
+}

--- a/src/Andy.Policies.Application/Exceptions/ValidationException.cs
+++ b/src/Andy.Policies.Application/Exceptions/ValidationException.cs
@@ -8,7 +8,7 @@ namespace Andy.Policies.Application.Exceptions;
 /// value, scope wildcard, malformed JSON, oversized rules, etc.). API layer maps
 /// to HTTP 400 Bad Request.
 /// </summary>
-public sealed class ValidationException : Exception
+public class ValidationException : Exception
 {
     public ValidationException(string message) : base(message) { }
 

--- a/src/Andy.Policies.Application/Interfaces/IRationalePolicy.cs
+++ b/src/Andy.Policies.Application/Interfaces/IRationalePolicy.cs
@@ -4,18 +4,30 @@
 namespace Andy.Policies.Application.Interfaces;
 
 /// <summary>
-/// Decides whether a rationale string is valid for a lifecycle transition
-/// (P2.2). The default implementation rejects null/whitespace; P2.4 will
-/// replace it with a settings-driven implementation that reads
-/// <c>andy.policies.rationaleRequired</c> from andy-settings and relaxes
-/// the check accordingly.
+/// Decides whether a rationale string is valid for a lifecycle transition.
+/// P2.4 (#14) wires this to the andy-settings toggle
+/// <c>andy.policies.rationaleRequired</c>: when true (default),
+/// null/empty/whitespace rationale is rejected; when false, all rationale
+/// values pass through. The setting is read from <c>ISettingsSnapshot</c>
+/// on every check so a runtime flip from the andy-settings admin UI takes
+/// effect on the next transition without restarting the service. If the
+/// snapshot has not yet observed the key (cold start, andy-settings briefly
+/// unreachable), implementations MUST fail safe to <c>true</c>.
 /// </summary>
 public interface IRationalePolicy
 {
     /// <summary>
-    /// Validate <paramref name="rationale"/> for the given target transition.
+    /// True when the live setting <c>andy.policies.rationaleRequired</c> is
+    /// on (or unknown — fail-safe). Reads are snapshot-cheap; callers may
+    /// poll this for telemetry without rate-limiting.
+    /// </summary>
+    bool IsRequired { get; }
+
+    /// <summary>
+    /// Validate <paramref name="rationale"/> against the live toggle.
     /// Returns null on success; returns a human-readable error message on
-    /// failure (the calling service translates this to a 400-mapped exception).
+    /// failure. The calling service translates a non-null return into
+    /// <c>RationaleRequiredException</c>.
     /// </summary>
     string? ValidateRationale(string? rationale);
 }

--- a/src/Andy.Policies.Infrastructure/Services/AndySettingsRationalePolicy.cs
+++ b/src/Andy.Policies.Infrastructure/Services/AndySettingsRationalePolicy.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Diagnostics.Metrics;
+using Andy.Policies.Application.Interfaces;
+using Andy.Settings.Client;
+
+namespace Andy.Policies.Infrastructure.Services;
+
+/// <summary>
+/// Live <see cref="IRationalePolicy"/> backed by andy-settings (P2.4, #14).
+/// Reads <see cref="SettingKey"/> from <see cref="ISettingsSnapshot"/> on
+/// every check; the snapshot is refreshed by the package's hosted
+/// <c>SettingsRefreshService</c> on a configurable cadence (default 60s,
+/// per <c>AndySettings:Refresh</c>). A subsequent change to the toggle in
+/// the andy-settings admin UI therefore takes effect on the next transition
+/// after the next refresh, without an andy-policies restart.
+/// <para>
+/// Fail-safe: if the snapshot has not observed the key yet (cold start, or
+/// andy-settings briefly unreachable), <see cref="IsRequired"/> defaults to
+/// <c>true</c>. Operationally: a missing setting must never silently relax
+/// audit requirements.
+/// </para>
+/// </summary>
+public sealed class AndySettingsRationalePolicy : IRationalePolicy, IDisposable
+{
+    /// <summary>The andy-settings key, registered in
+    /// <c>config/registration.json</c> with default <c>"true"</c>.</summary>
+    public const string SettingKey = "andy.policies.rationaleRequired";
+
+    /// <summary>OpenTelemetry meter name. Program.cs adds this meter to the
+    /// metrics pipeline so the toggle value is exported to OTLP. Tests use
+    /// the same name with <c>MeterListener</c> to assert the gauge value.</summary>
+    public const string MeterName = "Andy.Policies";
+
+    private readonly ISettingsSnapshot _snapshot;
+    private readonly Meter _meter;
+
+    public AndySettingsRationalePolicy(ISettingsSnapshot snapshot)
+    {
+        _snapshot = snapshot;
+        _meter = new Meter(MeterName);
+
+        // Observable gauge reports 1 / 0 on every collection so operators can
+        // confirm the toggle reached the live process. The callback closes over
+        // _snapshot, so a runtime flip in andy-settings (visible via the next
+        // SettingsRefreshService tick) shows up on the next metrics scrape with
+        // no extra plumbing.
+        _meter.CreateObservableGauge(
+            name: "andy_policies_rationale_required_toggle_value",
+            observeValue: () => IsRequired ? 1 : 0,
+            description: "Current value of andy.policies.rationaleRequired (1 = on, 0 = off).");
+    }
+
+    public bool IsRequired => _snapshot.GetBool(SettingKey) ?? true;
+
+    public string? ValidateRationale(string? rationale)
+    {
+        if (!IsRequired)
+        {
+            return null;
+        }
+        if (string.IsNullOrWhiteSpace(rationale))
+        {
+            return "Rationale is required and may not be empty or whitespace.";
+        }
+        return null;
+    }
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/src/Andy.Policies.Infrastructure/Services/LifecycleTransitionService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/LifecycleTransitionService.cs
@@ -82,7 +82,7 @@ public sealed class LifecycleTransitionService : ILifecycleTransitionService
         var rationaleError = _rationale.ValidateRationale(rationale);
         if (rationaleError is not null)
         {
-            throw new ValidationException(rationaleError);
+            throw new RationaleRequiredException(rationaleError);
         }
 
         // Serializable on Postgres; SQLite EF maps Serializable to BEGIN IMMEDIATE

--- a/src/Andy.Policies.Infrastructure/Services/RequireNonEmptyRationalePolicy.cs
+++ b/src/Andy.Policies.Infrastructure/Services/RequireNonEmptyRationalePolicy.cs
@@ -6,13 +6,18 @@ using Andy.Policies.Application.Interfaces;
 namespace Andy.Policies.Infrastructure.Services;
 
 /// <summary>
-/// Default <see cref="IRationalePolicy"/> implementation: rejects null,
-/// empty, and whitespace-only rationale strings unconditionally. Stays in
-/// place until P2.4 (#14) replaces it with the settings-driven version
-/// that consults <c>andy.policies.rationaleRequired</c> from andy-settings.
+/// Always-on <see cref="IRationalePolicy"/> implementation: rejects null,
+/// empty, and whitespace-only rationale strings unconditionally. Production
+/// uses <see cref="AndySettingsRationalePolicy"/> (P2.4, #14) which consults
+/// the live <c>andy.policies.rationaleRequired</c> toggle in andy-settings;
+/// this class stays as a test convenience that does not depend on a live
+/// <c>ISettingsSnapshot</c>, and as the documented behavior shape for the
+/// settings-on (default) state.
 /// </summary>
 public sealed class RequireNonEmptyRationalePolicy : IRationalePolicy
 {
+    public bool IsRequired => true;
+
     public string? ValidateRationale(string? rationale)
     {
         if (string.IsNullOrWhiteSpace(rationale))

--- a/tests/Andy.Policies.Tests.Integration/Controllers/PolicyVersionsLifecycleControllerTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/PolicyVersionsLifecycleControllerTests.cs
@@ -110,7 +110,11 @@ public class PolicyVersionsLifecycleControllerTests : IClassFixture<PoliciesApiF
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
-        problem!.Title.Should().Be("Validation failed");
+        // P2.4 (#14) emits a typed `RationaleRequired` ProblemDetails — see
+        // RationaleEnforcementTests for the full shape (errors.rationale, type
+        // = /problems/rationale-required). This assertion just confirms the
+        // 400 path is reached for empty rationale.
+        problem!.Title.Should().Be("Rationale required");
     }
 
     [Fact]

--- a/tests/Andy.Policies.Tests.Integration/Controllers/RationaleEnforcementTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/RationaleEnforcementTests.cs
@@ -1,0 +1,204 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Infrastructure.Services;
+using Andy.Settings.Client;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Andy.Policies.Infrastructure.Data;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Controllers;
+
+/// <summary>
+/// Integration coverage for P2.4 (#14) — rationale enforcement wired to
+/// <c>andy.policies.rationaleRequired</c>. Stands up a parallel factory that
+/// substitutes a controllable stub for <see cref="ISettingsSnapshot"/> so the
+/// toggle state can be flipped from the test, then drives the lifecycle
+/// publish endpoint end-to-end.
+/// </summary>
+public class RationaleEnforcementTests
+{
+    private sealed class ControllableSnapshot : ISettingsSnapshot
+    {
+        public bool? RationaleRequired { get; set; } = true;
+
+        public bool? GetBool(string key) =>
+            key == AndySettingsRationalePolicy.SettingKey ? RationaleRequired : null;
+
+        public string? GetString(string key) => null;
+
+        public int? GetInt(string key) => null;
+
+        public IReadOnlyCollection<string> Keys => Array.Empty<string>();
+
+        public DateTimeOffset? LastRefreshedAt => DateTimeOffset.UtcNow;
+    }
+
+    private sealed class RationaleFactory : WebApplicationFactory<Program>
+    {
+        private readonly SqliteConnection _connection = new("DataSource=:memory:");
+
+        public ControllableSnapshot Snapshot { get; } = new();
+
+        public RationaleFactory()
+        {
+            _connection.Open();
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Testing");
+
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Database:Provider"] = "Sqlite",
+                    ["AndyAuth:Authority"] = "https://test-auth.invalid",
+                    ["AndySettings:ApiBaseUrl"] = "https://test-settings.invalid",
+                });
+            });
+
+            builder.ConfigureServices(services =>
+            {
+                var ctxDescriptor = services.SingleOrDefault(d =>
+                    d.ServiceType == typeof(DbContextOptions<AppDbContext>));
+                if (ctxDescriptor is not null) services.Remove(ctxDescriptor);
+                services.AddDbContext<AppDbContext>(opts => opts.UseSqlite(_connection));
+
+                // Replace the snapshot registered by AddAndySettingsClient with our
+                // controllable stub. The rationale policy injects ISettingsSnapshot
+                // and reads it on every check, so flipping `Snapshot.RationaleRequired`
+                // takes effect immediately without restarting the host.
+                var snapshotDescriptor = services.SingleOrDefault(d =>
+                    d.ServiceType == typeof(ISettingsSnapshot));
+                if (snapshotDescriptor is not null) services.Remove(snapshotDescriptor);
+                services.AddSingleton<ISettingsSnapshot>(Snapshot);
+
+                services.AddAuthentication(TestAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                        TestAuthHandler.SchemeName, _ => { });
+                services.PostConfigure<AuthorizationOptions>(opts =>
+                {
+                    opts.DefaultPolicy = new AuthorizationPolicyBuilder(TestAuthHandler.SchemeName)
+                        .RequireAuthenticatedUser()
+                        .Build();
+                });
+
+                using var sp = services.BuildServiceProvider();
+                using var scope = sp.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+                db.Database.EnsureCreated();
+            });
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) _connection.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+
+    private static CreatePolicyRequest MinimalCreate(string name) => new(
+        Name: name,
+        Description: null,
+        Summary: "summary",
+        Enforcement: "Must",
+        Severity: "Critical",
+        Scopes: Array.Empty<string>(),
+        RulesJson: "{}");
+
+    private static async Task<PolicyVersionDto> CreateDraftAsync(HttpClient client, string name)
+    {
+        var resp = await client.PostAsJsonAsync("/api/policies", MinimalCreate(name));
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
+    }
+
+    [Fact]
+    public async Task ToggleOn_EmptyRationale_Returns400_WithRationaleErrorsAndProblemType()
+    {
+        using var factory = new RationaleFactory { Snapshot = { RationaleRequired = true } };
+        var client = factory.CreateClient();
+        var draft = await CreateDraftAsync(client, "rationale-on");
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
+            new LifecycleTransitionRequest(""));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var raw = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(raw);
+        doc.RootElement.GetProperty("type").GetString().Should().Be("/problems/rationale-required");
+        doc.RootElement.GetProperty("title").GetString().Should().Be("Rationale required");
+        doc.RootElement.GetProperty("errors").GetProperty("rationale")
+            .EnumerateArray().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task ToggleOff_EmptyRationale_Returns200()
+    {
+        using var factory = new RationaleFactory { Snapshot = { RationaleRequired = false } };
+        var client = factory.CreateClient();
+        var draft = await CreateDraftAsync(client, "rationale-off");
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
+            new LifecycleTransitionRequest(""));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<PolicyVersionDto>();
+        dto!.State.Should().Be("Active");
+    }
+
+    [Fact]
+    public async Task RuntimeFlip_FromOnToOff_TakesEffectImmediately()
+    {
+        using var factory = new RationaleFactory { Snapshot = { RationaleRequired = true } };
+        var client = factory.CreateClient();
+        var draft = await CreateDraftAsync(client, "rationale-flip");
+
+        // First attempt with toggle on + empty rationale → 400.
+        var first = await client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
+            new LifecycleTransitionRequest(""));
+        first.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        // Operator flips the toggle in andy-settings — the next snapshot read
+        // returns false. AndySettingsRationalePolicy reads ISettingsSnapshot
+        // on every check, so the same client request now succeeds without a
+        // restart.
+        factory.Snapshot.RationaleRequired = false;
+        var second = await client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
+            new LifecycleTransitionRequest(""));
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ColdStart_SnapshotMissing_FailsSafe_To400()
+    {
+        using var factory = new RationaleFactory { Snapshot = { RationaleRequired = null } };
+        var client = factory.CreateClient();
+        var draft = await CreateDraftAsync(client, "rationale-coldstart");
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
+            new LifecycleTransitionRequest(""));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Settings/AndySettingsRationalePolicyTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Settings/AndySettingsRationalePolicyTests.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Diagnostics.Metrics;
+using Andy.Policies.Infrastructure.Services;
+using Andy.Settings.Client;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Settings;
+
+/// <summary>
+/// Unit coverage for <see cref="AndySettingsRationalePolicy"/> (P2.4, #14).
+/// Drives the policy with a stub <see cref="ISettingsSnapshot"/> so each
+/// toggle state — on, off, unknown — is tested without standing up the
+/// andy-settings client. Also asserts the
+/// <c>andy_policies_rationale_required_toggle_value</c> observable gauge
+/// reports 1/0 in lockstep with <c>IsRequired</c>.
+/// </summary>
+public class AndySettingsRationalePolicyTests
+{
+    private sealed class StubSnapshot : ISettingsSnapshot
+    {
+        public bool? Value { get; set; }
+
+        public bool? GetBool(string key) =>
+            key == AndySettingsRationalePolicy.SettingKey ? Value : null;
+
+        public string? GetString(string key) => null;
+
+        public int? GetInt(string key) => null;
+
+        public IReadOnlyCollection<string> Keys => Array.Empty<string>();
+
+        public DateTimeOffset? LastRefreshedAt => null;
+    }
+
+    [Fact]
+    public void IsRequired_True_RejectsNullEmptyAndWhitespace()
+    {
+        var policy = new AndySettingsRationalePolicy(new StubSnapshot { Value = true });
+
+        policy.IsRequired.Should().BeTrue();
+        policy.ValidateRationale(null).Should().NotBeNull();
+        policy.ValidateRationale("").Should().NotBeNull();
+        policy.ValidateRationale("  \t \n").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void IsRequired_True_AcceptsNonEmpty()
+    {
+        var policy = new AndySettingsRationalePolicy(new StubSnapshot { Value = true });
+
+        policy.ValidateRationale("because canary passed").Should().BeNull();
+    }
+
+    [Fact]
+    public void IsRequired_False_AcceptsAllInputsIncludingNull()
+    {
+        var policy = new AndySettingsRationalePolicy(new StubSnapshot { Value = false });
+
+        policy.IsRequired.Should().BeFalse();
+        policy.ValidateRationale(null).Should().BeNull();
+        policy.ValidateRationale("").Should().BeNull();
+        policy.ValidateRationale("anything").Should().BeNull();
+    }
+
+    [Fact]
+    public void IsRequired_FailSafe_DefaultsTrue_WhenSnapshotHasNoValue()
+    {
+        // Cold start (snapshot not refreshed yet) or andy-settings unreachable
+        // both surface as a null GetBool. Acceptance criterion: stricter audit
+        // wins by default.
+        var policy = new AndySettingsRationalePolicy(new StubSnapshot { Value = null });
+
+        policy.IsRequired.Should().BeTrue();
+        policy.ValidateRationale("").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Snapshot_Flip_TakesEffectOnNextValidate()
+    {
+        var snapshot = new StubSnapshot { Value = true };
+        var policy = new AndySettingsRationalePolicy(snapshot);
+
+        policy.ValidateRationale("").Should().NotBeNull();
+
+        snapshot.Value = false;
+        policy.IsRequired.Should().BeFalse();
+        policy.ValidateRationale("").Should().BeNull();
+    }
+
+    [Fact]
+    public void ToggleGauge_ReportsCurrentValue_AsOneOrZero()
+    {
+        var snapshot = new StubSnapshot { Value = true };
+        using var policy = new AndySettingsRationalePolicy(snapshot);
+
+        var observed = new Dictionary<string, long>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == AndySettingsRationalePolicy.MeterName
+                    && instrument.Name == "andy_policies_rationale_required_toggle_value")
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<int>((inst, v, _, _) => observed[inst.Name] = v);
+        listener.Start();
+
+        listener.RecordObservableInstruments();
+        observed["andy_policies_rationale_required_toggle_value"].Should().Be(1);
+
+        snapshot.Value = false;
+        listener.RecordObservableInstruments();
+        observed["andy_policies_rationale_required_toggle_value"].Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary
- `AndySettingsRationalePolicy` reads the live `andy.policies.rationaleRequired` value from `ISettingsSnapshot` on every check; flips in the andy-settings admin UI take effect on the next snapshot refresh (default 60s) without a restart.
- Fail-safe: when the snapshot has not observed the key yet (cold start, andy-settings briefly unreachable), `IsRequired` defaults to `true` so missing setting can never silently relax audit.
- New `RationaleRequiredException` (subclass of `ValidationException`) plus a typed `PolicyExceptionHandler` mapping that emits `ValidationProblemDetails` with `type=/problems/rationale-required` and `errors.rationale` populated.
- OpenTelemetry observable gauge `andy_policies_rationale_required_toggle_value` (1 = on, 0 = off) on the `Andy.Policies` meter, registered with the metrics pipeline so OTLP exports include it.
- `RequireNonEmptyRationalePolicy` remains as the always-on test convenience for unit tests that don't want to stand up an `ISettingsSnapshot`.

Closes #14.

## Test plan
- [x] `dotnet test` — 144 unit + 115 integration pass; 6 E2E skipped (`E2E_ENABLED=0`).
- [x] Unit coverage (`AndySettingsRationalePolicyTests`): toggle on/off/null code paths, runtime flip, observable-gauge values via `MeterListener`.
- [x] Integration coverage (`RationaleEnforcementTests`): 400 with `errors.rationale` + `type=/problems/rationale-required` when toggle on; 200 when toggle off; runtime flip from on→off takes effect on the next request without restart; cold-start (snapshot returns null) fails safe to 400.
- [x] Existing P2.3 `Publish_WithEmptyRationale` test updated to the new `Title="Rationale required"` shape.
- [x] OpenAPI snapshot regenerates clean (no controller-shape change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)