### PR TITLE
Implement P2.5 — MCP lifecycle tools (publish, transition, matrix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ and rationale is empty, the API returns
 populated; the current toggle value is exported as the OpenTelemetry gauge
 `andy_policies_rationale_required_toggle_value` (1 = on, 0 = off).
 
+The same lifecycle operations are exposed to LLM agents through the MCP
+endpoint at `/mcp` (P2.5,
+[#15](https://github.com/rivoli-ai/andy-policies/issues/15)):
+`policy.version.publish` (Draft → Active shortcut),
+`policy.version.transition` with a case-insensitive `targetState`, and the
+read-only `policy.lifecycle.matrix`. All three delegate to the same
+`ILifecycleTransitionService` as REST, so wire behavior — auto-supersede,
+rationale enforcement, the four-edge state matrix — is identical across
+surfaces.
+
 ## Ports
 
 Per the ecosystem registry at [`../andy-service-template/docs/ports.md`](../andy-service-template/docs/ports.md). Three deployment modes; the same host can run any combination because each mode uses a distinct port range.

--- a/src/Andy.Policies.Api/Mcp/PolicyLifecycleTools.cs
+++ b/src/Andy.Policies.Api/Mcp/PolicyLifecycleTools.cs
@@ -1,0 +1,167 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.ComponentModel;
+using System.Security.Claims;
+using System.Text;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Exceptions;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Enums;
+using Microsoft.AspNetCore.Http;
+using ModelContextProtocol.Server;
+
+namespace Andy.Policies.Api.Mcp;
+
+/// <summary>
+/// MCP tools driving lifecycle transitions on a <c>PolicyVersion</c> (P2.5,
+/// story rivoli-ai/andy-policies#15). Three tools, all delegating to the
+/// shared <see cref="ILifecycleTransitionService"/> from P2.2 — same service
+/// powering REST (P2.3), gRPC (P2.6), and CLI (P2.7), so wire behaviour
+/// stays identical across surfaces:
+/// <list type="bullet">
+///   <item><c>policy.version.publish</c> — Draft -&gt; Active shortcut for the
+///     dominant LLM use case (auto-supersedes the previous Active in the
+///     same DB transaction).</item>
+///   <item><c>policy.version.transition</c> — generalised <c>(targetState)</c>
+///     form that LLMs can compose into multi-step plans.</item>
+///   <item><c>policy.lifecycle.matrix</c> — read-only introspection so an
+///     agent can reason about valid transitions before choosing an action.</item>
+/// </list>
+/// Following the established <see cref="PolicyTools"/> contract: tools take
+/// string GUIDs (parsed internally), return formatted strings, and never
+/// duplicate state-machine logic. Mutating tools require an authenticated
+/// caller — when the MCP request reaches the tool with no <c>sub</c> /
+/// <c>name</c> claim, the tool returns an error string rather than writing
+/// a fallback subject id into the catalog (mirrors the REST actor-fallback
+/// firewall — see #13).
+/// </summary>
+[McpServerToolType]
+public static class PolicyLifecycleTools
+{
+    [McpServerTool(Name = "policy.version.publish"), Description(
+        "Publishes a Draft PolicyVersion (Draft -> Active). Auto-supersedes the previous " +
+        "Active version of the same policy in the same DB transaction. Requires a " +
+        "non-empty rationale when andy.policies.rationaleRequired is true (default). " +
+        "Returns the updated version on success or a human-readable error string.")]
+    public static Task<string> Publish(
+        ILifecycleTransitionService transitions,
+        IHttpContextAccessor httpContext,
+        [Description("Policy id (GUID)")] string policyId,
+        [Description("PolicyVersion id (GUID) of the Draft to publish")] string versionId,
+        [Description("Human-readable reason recorded against the publish event")] string rationale,
+        CancellationToken ct = default)
+        => TransitionAsync(transitions, httpContext, policyId, versionId,
+            LifecycleState.Active.ToString(), rationale, ct);
+
+    [McpServerTool(Name = "policy.version.transition"), Description(
+        "Transitions a PolicyVersion to the supplied target state. Allowed transitions: " +
+        "Draft -> Active, Active -> WindingDown, Active -> Retired, WindingDown -> Retired. " +
+        "Any other (from, to) pair returns INVALID_TRANSITION. targetState is parsed " +
+        "case-insensitively; targetState=Draft is rejected because the matrix has no edge " +
+        "into Draft. Use policy.lifecycle.matrix to introspect allowed transitions.")]
+    public static async Task<string> Transition(
+        ILifecycleTransitionService transitions,
+        IHttpContextAccessor httpContext,
+        [Description("Policy id (GUID)")] string policyId,
+        [Description("PolicyVersion id (GUID)")] string versionId,
+        [Description("One of: Active, WindingDown, Retired (case-insensitive)")] string targetState,
+        [Description("Human-readable reason recorded against the transition event")] string rationale,
+        CancellationToken ct = default)
+        => await TransitionAsync(transitions, httpContext, policyId, versionId, targetState, rationale, ct);
+
+    [McpServerTool(Name = "policy.lifecycle.matrix"), Description(
+        "Returns the canonical lifecycle transition matrix as one rule per line. " +
+        "Read-only and side-effect free; safe to call from agent planning loops.")]
+    public static string Matrix(ILifecycleTransitionService transitions)
+    {
+        var rules = transitions.GetMatrix();
+        var sb = new StringBuilder();
+        sb.AppendLine($"{rules.Count} allowed transition{(rules.Count == 1 ? "" : "s")}:");
+        foreach (var r in rules)
+        {
+            sb.AppendLine($"- {r.From} -> {r.To} ({r.Name})");
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    // -- shared executor -----------------------------------------------------
+
+    private static async Task<string> TransitionAsync(
+        ILifecycleTransitionService transitions,
+        IHttpContextAccessor httpContext,
+        string policyId,
+        string versionId,
+        string targetState,
+        string rationale,
+        CancellationToken ct)
+    {
+        if (!Guid.TryParse(policyId, out var pid))
+        {
+            return $"Invalid policy id: '{policyId}' is not a valid GUID.";
+        }
+        if (!Guid.TryParse(versionId, out var vid))
+        {
+            return $"Invalid version id: '{versionId}' is not a valid GUID.";
+        }
+        if (!Enum.TryParse<LifecycleState>(targetState, ignoreCase: true, out var target)
+            || target == LifecycleState.Draft)
+        {
+            return $"Invalid target state: '{targetState}'. Use Active, WindingDown, or Retired.";
+        }
+
+        var subjectId = ResolveSubjectId(httpContext);
+        if (subjectId is null)
+        {
+            // The MCP endpoint is RequireAuthorization()-gated so a missing claim
+            // here means the tool was wired without auth (or a custom transport
+            // bypassed it). Fail loud rather than write a fallback subject id.
+            return "Authentication required: no subject id present on the caller's claims principal.";
+        }
+
+        try
+        {
+            var dto = await transitions.TransitionAsync(pid, vid, target, rationale, subjectId, ct);
+            return FormatVersionDetail(dto);
+        }
+        catch (RationaleRequiredException ex)
+        {
+            return $"RATIONALE_REQUIRED: {ex.Message}";
+        }
+        catch (InvalidLifecycleTransitionException ex)
+        {
+            return $"INVALID_TRANSITION: {ex.Message} See policy.lifecycle.matrix for allowed transitions.";
+        }
+        catch (ConcurrentPublishException ex)
+        {
+            return $"CONFLICT: {ex.Message} Re-fetch the active version and retry.";
+        }
+        catch (NotFoundException ex)
+        {
+            return $"NOT_FOUND: {ex.Message}";
+        }
+        catch (ValidationException ex)
+        {
+            return $"VALIDATION_ERROR: {ex.Message}";
+        }
+    }
+
+    private static string? ResolveSubjectId(IHttpContextAccessor accessor)
+    {
+        var user = accessor.HttpContext?.User;
+        if (user is null) return null;
+        var sub = user.FindFirstValue(ClaimTypes.NameIdentifier) ?? user.Identity?.Name;
+        return string.IsNullOrEmpty(sub) ? null : sub;
+    }
+
+    private static string FormatVersionDetail(PolicyVersionDto v)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Version: v{v.Version} of policy {v.PolicyId}");
+        sb.AppendLine($"Id: {v.Id}");
+        sb.AppendLine($"State: {v.State}");
+        sb.AppendLine($"Enforcement: {v.Enforcement}");
+        sb.AppendLine($"Severity: {v.Severity}");
+        return sb.ToString().TrimEnd();
+    }
+}

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -238,6 +238,12 @@ builder.Services.AddCors(options =>
 // --- gRPC ---
 builder.Services.AddGrpc();
 
+// P2.5 (#15) — MCP lifecycle tools read the caller subject id from the
+// HttpContext claims (same source as REST, gRPC, CLI). Without this
+// registration `IHttpContextAccessor.HttpContext` is always null and the
+// tools can't authenticate the actor.
+builder.Services.AddHttpContextAccessor();
+
 // --- MCP Server ---
 builder.Services
     .AddMcpServer()

--- a/tests/Andy.Policies.Tests.Integration/Mcp/PolicyLifecycleToolsTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/PolicyLifecycleToolsTests.cs
@@ -1,0 +1,231 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Claims;
+using Andy.Policies.Api.Mcp;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Infrastructure.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Mcp;
+
+/// <summary>
+/// Tests for <see cref="PolicyLifecycleTools"/> (P2.5, #15). Drives the
+/// static tool methods directly against a real
+/// <see cref="LifecycleTransitionService"/> backed by EF Core InMemory plus a
+/// real <see cref="PolicyService"/> for seeding. Verifies the wire contract
+/// returned to MCP agents: formatted strings on success, prefixed error
+/// codes (RATIONALE_REQUIRED, INVALID_TRANSITION, NOT_FOUND, etc.) on
+/// failure, and that the actor-fallback firewall rejects callers without a
+/// subject claim.
+/// </summary>
+public class PolicyLifecycleToolsTests
+{
+    private static AppDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private sealed class NoopDispatcher : IDomainEventDispatcher
+    {
+        public Task DispatchAsync<TEvent>(TEvent e, CancellationToken ct = default)
+            where TEvent : notnull => Task.CompletedTask;
+    }
+
+    private static (PolicyService policies, LifecycleTransitionService lifecycle, AppDbContext db)
+        NewServices()
+    {
+        var db = NewDb();
+        var lifecycle = new LifecycleTransitionService(
+            db,
+            new RequireNonEmptyRationalePolicy(),
+            new NoopDispatcher(),
+            TimeProvider.System);
+        return (new PolicyService(db), lifecycle, db);
+    }
+
+    private static IHttpContextAccessor AccessorFor(string? subjectId)
+    {
+        var ctx = new DefaultHttpContext();
+        if (subjectId is not null)
+        {
+            ctx.User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, subjectId),
+            }, authenticationType: "Test"));
+        }
+        return new HttpContextAccessor { HttpContext = ctx };
+    }
+
+    private static CreatePolicyRequest MinimalCreate(string name) => new(
+        Name: name,
+        Description: null,
+        Summary: "summary",
+        Enforcement: "Must",
+        Severity: "Critical",
+        Scopes: Array.Empty<string>(),
+        RulesJson: "{}");
+
+    [Fact]
+    public async Task Publish_OnDraft_ReturnsActiveDetail()
+    {
+        var (policies, lifecycle, db) = NewServices();
+        var draft = await policies.CreateDraftAsync(MinimalCreate("publish-tool"), "sam");
+
+        var output = await PolicyLifecycleTools.Publish(
+            lifecycle, AccessorFor("agent-1"),
+            draft.PolicyId.ToString(), draft.Id.ToString(), "promote v1");
+
+        output.Should().Contain("State: Active");
+        output.Should().Contain($"Id: {draft.Id}");
+
+        var reloaded = await db.PolicyVersions.AsNoTracking().FirstAsync(v => v.Id == draft.Id);
+        reloaded.State.Should().Be(LifecycleState.Active);
+        reloaded.PublishedBySubjectId.Should().Be("agent-1");
+    }
+
+    [Fact]
+    public async Task Transition_TargetRetired_FromActive_Succeeds()
+    {
+        var (policies, lifecycle, _) = NewServices();
+        var draft = await policies.CreateDraftAsync(MinimalCreate("transition-tool"), "sam");
+        await PolicyLifecycleTools.Publish(lifecycle, AccessorFor("agent-1"),
+            draft.PolicyId.ToString(), draft.Id.ToString(), "live");
+
+        var output = await PolicyLifecycleTools.Transition(
+            lifecycle, AccessorFor("agent-1"),
+            draft.PolicyId.ToString(), draft.Id.ToString(), "Retired", "tomb");
+
+        output.Should().Contain("State: Retired");
+    }
+
+    [Fact]
+    public async Task Transition_AcceptsCaseInsensitiveTargetState()
+    {
+        var (policies, lifecycle, _) = NewServices();
+        var draft = await policies.CreateDraftAsync(MinimalCreate("case-insensitive"), "sam");
+
+        var output = await PolicyLifecycleTools.Transition(
+            lifecycle, AccessorFor("agent-1"),
+            draft.PolicyId.ToString(), draft.Id.ToString(), "active", "go");
+
+        output.Should().Contain("State: Active");
+    }
+
+    [Fact]
+    public async Task Transition_RejectsTargetDraft()
+    {
+        var (policies, lifecycle, _) = NewServices();
+        var draft = await policies.CreateDraftAsync(MinimalCreate("reject-draft"), "sam");
+
+        var output = await PolicyLifecycleTools.Transition(
+            lifecycle, AccessorFor("agent-1"),
+            draft.PolicyId.ToString(), draft.Id.ToString(), "Draft", "no");
+
+        output.Should().Contain("Invalid target state");
+    }
+
+    [Fact]
+    public async Task Transition_RejectsUnknownTargetState()
+    {
+        var (policies, lifecycle, _) = NewServices();
+        var draft = await policies.CreateDraftAsync(MinimalCreate("unknown-target"), "sam");
+
+        var output = await PolicyLifecycleTools.Transition(
+            lifecycle, AccessorFor("agent-1"),
+            draft.PolicyId.ToString(), draft.Id.ToString(), "Unicorn", "?");
+
+        output.Should().Contain("Invalid target state");
+    }
+
+    [Fact]
+    public async Task Transition_DisallowedTransition_ReturnsInvalidTransition()
+    {
+        // Draft -> Retired is not in the matrix.
+        var (policies, lifecycle, _) = NewServices();
+        var draft = await policies.CreateDraftAsync(MinimalCreate("draft-to-retired"), "sam");
+
+        var output = await PolicyLifecycleTools.Transition(
+            lifecycle, AccessorFor("agent-1"),
+            draft.PolicyId.ToString(), draft.Id.ToString(), "Retired", "skip");
+
+        output.Should().StartWith("INVALID_TRANSITION:");
+    }
+
+    [Fact]
+    public async Task Publish_EmptyRationale_ReturnsRationaleRequired()
+    {
+        var (policies, lifecycle, _) = NewServices();
+        var draft = await policies.CreateDraftAsync(MinimalCreate("rationale-required"), "sam");
+
+        var output = await PolicyLifecycleTools.Publish(
+            lifecycle, AccessorFor("agent-1"),
+            draft.PolicyId.ToString(), draft.Id.ToString(), "  ");
+
+        output.Should().StartWith("RATIONALE_REQUIRED:");
+    }
+
+    [Fact]
+    public async Task Publish_NoSubjectId_ReturnsAuthRequired_AndDoesNotMutate()
+    {
+        var (policies, lifecycle, db) = NewServices();
+        var draft = await policies.CreateDraftAsync(MinimalCreate("no-subject"), "sam");
+
+        var output = await PolicyLifecycleTools.Publish(
+            lifecycle, AccessorFor(subjectId: null),
+            draft.PolicyId.ToString(), draft.Id.ToString(), "publish");
+
+        output.Should().Contain("Authentication required");
+        var reloaded = await db.PolicyVersions.AsNoTracking().FirstAsync(v => v.Id == draft.Id);
+        reloaded.State.Should().Be(LifecycleState.Draft);
+    }
+
+    [Fact]
+    public async Task Publish_InvalidPolicyId_ReturnsErrorString()
+    {
+        var (_, lifecycle, _) = NewServices();
+
+        var output = await PolicyLifecycleTools.Publish(
+            lifecycle, AccessorFor("agent-1"),
+            "not-a-guid", Guid.NewGuid().ToString(), "go");
+
+        output.Should().StartWith("Invalid policy id:");
+    }
+
+    [Fact]
+    public async Task Publish_UnknownIds_ReturnsNotFound()
+    {
+        var (_, lifecycle, _) = NewServices();
+
+        var output = await PolicyLifecycleTools.Publish(
+            lifecycle, AccessorFor("agent-1"),
+            Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "go");
+
+        output.Should().StartWith("NOT_FOUND:");
+    }
+
+    [Fact]
+    public void Matrix_ReturnsTheFourCanonicalRules()
+    {
+        var (_, lifecycle, _) = NewServices();
+
+        var output = PolicyLifecycleTools.Matrix(lifecycle);
+
+        output.Should().Contain("4 allowed transitions:");
+        output.Should().Contain("Draft -> Active (Publish)");
+        output.Should().Contain("Active -> WindingDown (WindDown)");
+        output.Should().Contain("Active -> Retired (Retire)");
+        output.Should().Contain("WindingDown -> Retired (Retire)");
+    }
+}


### PR DESCRIPTION
## Summary
- Three new MCP tools in `PolicyLifecycleTools` delegate to `ILifecycleTransitionService` (P2.2) — same service powering REST/gRPC/CLI, so auto-supersede, rationale enforcement, and the four-edge state matrix behave identically across surfaces.
  - `policy.version.publish` — Draft → Active shortcut.
  - `policy.version.transition` — generalised `(targetState)` form; case-insensitive parse, rejects `targetState=Draft`.
  - `policy.lifecycle.matrix` — read-only introspection of allowed transitions.
- Tools follow the existing `PolicyTools` pattern: string GUIDs (parsed internally), formatted-string returns, prefixed error codes (`RATIONALE_REQUIRED`, `INVALID_TRANSITION`, `NOT_FOUND`, `CONFLICT`, `VALIDATION_ERROR`).
- Mutating tools read caller subject id from `HttpContext` claims (`NameIdentifier` → `Name` fallback) via `IHttpContextAccessor` and refuse to act when neither is present — same actor-fallback firewall as the REST controller.
- Registers `AddHttpContextAccessor()` (was missing) so the tools' claims principal is available.

Closes #15.

## Test plan
- [x] `dotnet test` — 144 unit + 126 integration pass; 6 E2E skipped.
- [x] 11 new tests in `PolicyLifecycleToolsTests.cs` covering: happy-path publish, retire from active, case-insensitive `targetState`, rejection of `targetState=Draft` and unknowns, `INVALID_TRANSITION` for matrix-disallowed pair, `RATIONALE_REQUIRED` for empty rationale, no-subject-id firewall, invalid GUID input, `NOT_FOUND` for unknown ids, and the matrix-readout shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)