### PR TITLE
Implement P2.6 — gRPC LifecycleService (PublishVersion/TransitionVersion/GetMatrix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ read-only `policy.lifecycle.matrix`. All three delegate to the same
 rationale enforcement, the four-edge state matrix — is identical across
 surfaces.
 
+The gRPC `LifecycleService` (P2.6,
+[#16](https://github.com/rivoli-ai/andy-policies/issues/16)) lives in
+`lifecycle.proto` alongside the existing `policies.proto` (same
+`andy_policies` package + `Andy.Policies.Api.Protos` namespace) and exposes
+`PublishVersion`, `TransitionVersion`, and `GetMatrix` with the same
+delegation. Service exceptions map to gRPC status codes:
+`RationaleRequiredException`/`ValidationException` → `InvalidArgument`,
+`NotFoundException` → `NotFound`, `InvalidLifecycleTransitionException` →
+`FailedPrecondition`, `ConcurrentPublishException` → `Aborted`.
+
 ## Ports
 
 Per the ecosystem registry at [`../andy-service-template/docs/ports.md`](../andy-service-template/docs/ports.md). Three deployment modes; the same host can run any combination because each mode uses a distinct port range.

--- a/src/Andy.Policies.Api/Andy.Policies.Api.csproj
+++ b/src/Andy.Policies.Api/Andy.Policies.Api.csproj
@@ -39,6 +39,10 @@
     <!-- Both: integration tests reference the API project to drive the gRPC
          surface end-to-end; they need the generated client classes too. -->
     <Protobuf Include="Protos\policies.proto" GrpcServices="Both" />
+    <!-- lifecycle.proto imports policies.proto for PolicyVersionMessage; the
+         AdditionalImportDirs entry tells protoc where to resolve sibling
+         proto files (default search path is just the file's own directory). -->
+    <Protobuf Include="Protos\lifecycle.proto" GrpcServices="Both" AdditionalImportDirs="Protos" />
   </ItemGroup>
 
 </Project>

--- a/src/Andy.Policies.Api/GrpcServices/LifecycleGrpcService.cs
+++ b/src/Andy.Policies.Api/GrpcServices/LifecycleGrpcService.cs
@@ -1,0 +1,164 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Api.Protos;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Exceptions;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Enums;
+using Grpc.Core;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+
+namespace Andy.Policies.Api.GrpcServices;
+
+/// <summary>
+/// gRPC surface for lifecycle transitions on a <c>PolicyVersion</c> (P2.6,
+/// story rivoli-ai/andy-policies#16). Delegates to
+/// <see cref="ILifecycleTransitionService"/> — the same service powering REST
+/// (P2.3), MCP (P2.5), and CLI (P2.7). Service exceptions translate to gRPC
+/// status codes per the table below; the equivalent HTTP mappings live in
+/// <c>PolicyExceptionHandler</c>:
+///
+/// <list type="table">
+///   <listheader><term>Exception</term><description>gRPC status / HTTP equivalent</description></listheader>
+///   <item><term><see cref="RationaleRequiredException"/></term><description>InvalidArgument / 400</description></item>
+///   <item><term><see cref="ValidationException"/></term><description>InvalidArgument / 400</description></item>
+///   <item><term><see cref="NotFoundException"/></term><description>NotFound / 404</description></item>
+///   <item><term><see cref="InvalidLifecycleTransitionException"/></term><description>FailedPrecondition / 409</description></item>
+///   <item><term><see cref="ConcurrentPublishException"/></term><description>Aborted / 409</description></item>
+///   <item><term><see cref="ConflictException"/></term><description>AlreadyExists / 409</description></item>
+///   <item><term><see cref="DbUpdateConcurrencyException"/></term><description>Aborted / 412</description></item>
+/// </list>
+/// </summary>
+[Authorize]
+public class LifecycleGrpcService : Protos.LifecycleService.LifecycleServiceBase
+{
+    private readonly ILifecycleTransitionService _transitions;
+
+    public LifecycleGrpcService(ILifecycleTransitionService transitions)
+    {
+        _transitions = transitions;
+    }
+
+    public override async Task<PolicyVersionResponse> PublishVersion(
+        PublishVersionRequest request, ServerCallContext context)
+    {
+        var policyId = ParseGuidOrThrow(request.PolicyId, "policy_id");
+        var versionId = ParseGuidOrThrow(request.VersionId, "version_id");
+        try
+        {
+            var dto = await _transitions.TransitionAsync(
+                policyId, versionId, LifecycleState.Active,
+                request.Rationale ?? string.Empty,
+                ResolveSubjectId(context),
+                context.CancellationToken);
+            return new PolicyVersionResponse { Version = ToMessage(dto) };
+        }
+        catch (Exception ex) { throw MapToRpcException(ex); }
+    }
+
+    public override async Task<PolicyVersionResponse> TransitionVersion(
+        TransitionVersionRequest request, ServerCallContext context)
+    {
+        var policyId = ParseGuidOrThrow(request.PolicyId, "policy_id");
+        var versionId = ParseGuidOrThrow(request.VersionId, "version_id");
+        if (!Enum.TryParse<LifecycleState>(request.TargetState, ignoreCase: true, out var target)
+            || target == LifecycleState.Draft)
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument,
+                $"target_state '{request.TargetState}' is not valid. Use Active, WindingDown, or Retired."));
+        }
+
+        try
+        {
+            var dto = await _transitions.TransitionAsync(
+                policyId, versionId, target,
+                request.Rationale ?? string.Empty,
+                ResolveSubjectId(context),
+                context.CancellationToken);
+            return new PolicyVersionResponse { Version = ToMessage(dto) };
+        }
+        catch (Exception ex) { throw MapToRpcException(ex); }
+    }
+
+    public override Task<MatrixResponse> GetMatrix(GetMatrixRequest request, ServerCallContext context)
+    {
+        var rules = _transitions.GetMatrix();
+        var response = new MatrixResponse();
+        foreach (var rule in rules)
+        {
+            response.Rules.Add(new MatrixRule
+            {
+                From = rule.From.ToString(),
+                To = rule.To.ToString(),
+                Name = rule.Name,
+            });
+        }
+        return Task.FromResult(response);
+    }
+
+    // -- helpers --------------------------------------------------------------
+
+    private static Guid ParseGuidOrThrow(string raw, string field)
+    {
+        if (!Guid.TryParse(raw, out var guid))
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument,
+                $"{field} '{raw}' is not a valid GUID."));
+        }
+        return guid;
+    }
+
+    private static string ResolveSubjectId(ServerCallContext context)
+    {
+        // Mirrors the REST controller's actor-fallback firewall (#13): refuse to
+        // act when no subject id is on the principal rather than write a fallback
+        // string into the catalog. The MCP / gRPC paths share the same posture.
+        var http = context.GetHttpContext();
+        var sub = http?.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+            ?? http?.User.Identity?.Name;
+        if (string.IsNullOrEmpty(sub))
+        {
+            throw new RpcException(new Status(StatusCode.Unauthenticated,
+                "Authentication required: no subject id present on the caller's claims principal."));
+        }
+        return sub;
+    }
+
+    private static RpcException MapToRpcException(Exception ex) => ex switch
+    {
+        // RationaleRequiredException is a ValidationException — match the more
+        // specific type first so the message-shape stays clear in the trailer.
+        RationaleRequiredException r            => new RpcException(new Status(StatusCode.InvalidArgument, r.Message)),
+        ValidationException v                   => new RpcException(new Status(StatusCode.InvalidArgument, v.Message)),
+        NotFoundException n                     => new RpcException(new Status(StatusCode.NotFound, n.Message)),
+        InvalidLifecycleTransitionException l   => new RpcException(new Status(StatusCode.FailedPrecondition, l.Message)),
+        ConcurrentPublishException cp           => new RpcException(new Status(StatusCode.Aborted, cp.Message)),
+        ConflictException c                     => new RpcException(new Status(StatusCode.AlreadyExists, c.Message)),
+        DbUpdateConcurrencyException d          => new RpcException(new Status(StatusCode.Aborted, d.Message)),
+        RpcException existing                   => existing,
+        _ => throw new InvalidOperationException(
+            $"Unmapped exception in LifecycleGrpcService: {ex.GetType().Name}", ex),
+    };
+
+    private static PolicyVersionMessage ToMessage(PolicyVersionDto dto)
+    {
+        var msg = new PolicyVersionMessage
+        {
+            Id = dto.Id.ToString(),
+            PolicyId = dto.PolicyId.ToString(),
+            Version = dto.Version,
+            State = dto.State,
+            Enforcement = dto.Enforcement,
+            Severity = dto.Severity,
+            Summary = dto.Summary,
+            RulesJson = dto.RulesJson,
+            CreatedAt = dto.CreatedAt.ToString("o"),
+            CreatedBySubjectId = dto.CreatedBySubjectId,
+            ProposerSubjectId = dto.ProposerSubjectId,
+        };
+        msg.Scopes.AddRange(dto.Scopes);
+        return msg;
+    }
+}

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -276,6 +276,7 @@ app.MapControllers();
 // --- gRPC endpoint ---
 app.MapGrpcService<Andy.Policies.Api.GrpcServices.ItemsGrpcService>();
 app.MapGrpcService<Andy.Policies.Api.GrpcServices.PolicyGrpcService>();
+app.MapGrpcService<Andy.Policies.Api.GrpcServices.LifecycleGrpcService>();
 
 // --- MCP endpoint ---
 app.MapMcp("/mcp")

--- a/src/Andy.Policies.Api/Protos/lifecycle.proto
+++ b/src/Andy.Policies.Api/Protos/lifecycle.proto
@@ -1,0 +1,65 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+//
+// gRPC contract for lifecycle transitions on a PolicyVersion (P2.6,
+// rivoli-ai/andy-policies#16). Sits alongside policies.proto in the same
+// `andy_policies` package + `Andy.Policies.Api.Protos` C# namespace so
+// existing consumers that already imported the package for the policy
+// catalog get lifecycle calls without a second stub generation.
+//
+// Wire format follows the same conventions as policies.proto:
+//   - state and target_state are strings (PascalCase per ADR 0001 §6 —
+//     Draft / Active / WindingDown / Retired). target_state on input is
+//     parsed case-insensitively to match REST/MCP/CLI behaviour.
+//   - Ids are UUID strings. Timestamps land in PolicyVersionMessage as
+//     ISO 8601 strings (delegated to policies.proto's PolicyVersionMessage).
+
+syntax = "proto3";
+
+option csharp_namespace = "Andy.Policies.Api.Protos";
+
+package andy_policies;
+
+import "policies.proto";   // reuse PolicyVersionMessage from P1.7
+
+service LifecycleService {
+  // Promote a Draft to Active. Auto-supersedes the existing Active version
+  // (if any) within the same DB transaction. Equivalent to REST
+  // POST /api/policies/{id}/versions/{vId}/publish.
+  rpc PublishVersion (PublishVersionRequest) returns (PolicyVersionResponse);
+
+  // Generalised transition. target_state is one of Active / WindingDown /
+  // Retired, case-insensitive. Disallowed transitions return FailedPrecondition.
+  rpc TransitionVersion (TransitionVersionRequest) returns (PolicyVersionResponse);
+
+  // Read-only: returns the canonical (from, to, name) tuples so a client can
+  // reason about valid transitions before issuing a TransitionVersion call.
+  rpc GetMatrix (GetMatrixRequest) returns (MatrixResponse);
+}
+
+// -- request / response messages ------------------------------------------
+
+message PublishVersionRequest {
+  string policy_id  = 1;   // UUID string
+  string version_id = 2;   // UUID string
+  string rationale  = 3;   // required when andy.policies.rationaleRequired = true
+}
+
+message TransitionVersionRequest {
+  string policy_id    = 1;
+  string version_id   = 2;
+  string target_state = 3;  // case-insensitive: Active | WindingDown | Retired
+  string rationale    = 4;
+}
+
+message GetMatrixRequest {}
+
+message MatrixRule {
+  string from = 1;   // PascalCase per ADR 0001 §6
+  string to   = 2;
+  string name = 3;   // human-readable transition label (Publish / WindDown / Retire)
+}
+
+message MatrixResponse {
+  repeated MatrixRule rules = 1;
+}

--- a/tests/Andy.Policies.Tests.Integration/GrpcServices/LifecycleGrpcServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/GrpcServices/LifecycleGrpcServiceTests.cs
@@ -1,0 +1,273 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Api.Protos;
+using Andy.Policies.Tests.Integration.Controllers;
+using FluentAssertions;
+using Grpc.Core;
+using Grpc.Net.Client;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.GrpcServices;
+
+/// <summary>
+/// End-to-end gRPC tests for the lifecycle surface (P2.6, story
+/// rivoli-ai/andy-policies#16). Exercises every RPC over a real HTTP/2
+/// channel against the test server, verifying the proto contract,
+/// generated stubs, exception → status-code mapping, and parity with the
+/// REST/MCP surfaces (auto-supersede, rationale enforcement, the
+/// four-edge state matrix).
+/// </summary>
+public class LifecycleGrpcServiceTests : IClassFixture<PoliciesApiFactory>, IDisposable
+{
+    private readonly GrpcChannel _channel;
+    private readonly LifecycleService.LifecycleServiceClient _lifecycle;
+    private readonly Andy.Policies.Api.Protos.PolicyService.PolicyServiceClient _policies;
+
+    public LifecycleGrpcServiceTests(PoliciesApiFactory factory)
+    {
+        var handler = factory.Server.CreateHandler();
+        _channel = GrpcChannel.ForAddress(factory.Server.BaseAddress, new GrpcChannelOptions
+        {
+            HttpHandler = handler,
+        });
+        _lifecycle = new LifecycleService.LifecycleServiceClient(_channel);
+        _policies = new Andy.Policies.Api.Protos.PolicyService.PolicyServiceClient(_channel);
+    }
+
+    public void Dispose() => _channel.Dispose();
+
+    private static CreateDraftRequest MinimalCreate(string name) => new()
+    {
+        Name = name,
+        Description = "",
+        Summary = "summary",
+        Enforcement = "Must",
+        Severity = "Critical",
+        RulesJson = "{}",
+    };
+
+    private async Task<PolicyVersionMessage> CreateDraftAsync(string slug)
+    {
+        var draft = await _policies.CreateDraftAsync(MinimalCreate(slug));
+        return draft.Version;
+    }
+
+    private static string Slug(string prefix) =>
+        $"grpc-{prefix}-{Guid.NewGuid():N}".Substring(0, 16);
+
+    [Fact]
+    public async Task PublishVersion_OnDraft_ReturnsActiveVersion()
+    {
+        var draft = await CreateDraftAsync(Slug("pub"));
+
+        var response = await _lifecycle.PublishVersionAsync(new PublishVersionRequest
+        {
+            PolicyId = draft.PolicyId,
+            VersionId = draft.Id,
+            Rationale = "promote v1",
+        });
+
+        response.Version.State.Should().Be("Active");
+        response.Version.Id.Should().Be(draft.Id);
+    }
+
+    [Fact]
+    public async Task PublishVersion_AutoSupersedesPreviousActive()
+    {
+        var v1 = await CreateDraftAsync(Slug("auto"));
+        await _lifecycle.PublishVersionAsync(new PublishVersionRequest
+        {
+            PolicyId = v1.PolicyId,
+            VersionId = v1.Id,
+            Rationale = "v1-live",
+        });
+
+        // Bump v1 to mint v2 Draft under the same policy.
+        var v2Resp = await _policies.BumpDraftAsync(new BumpDraftRequest
+        {
+            PolicyId = v1.PolicyId,
+            SourceVersionId = v1.Id,
+        });
+        var v2 = v2Resp.Version;
+
+        await _lifecycle.PublishVersionAsync(new PublishVersionRequest
+        {
+            PolicyId = v2.PolicyId,
+            VersionId = v2.Id,
+            Rationale = "v2-live",
+        });
+
+        var v1After = await _policies.GetVersionAsync(new GetVersionRequest
+        {
+            PolicyId = v1.PolicyId,
+            VersionId = v1.Id,
+        });
+        v1After.Version.State.Should().Be("WindingDown");
+
+        var active = await _policies.GetActiveVersionAsync(new GetActiveVersionRequest
+        {
+            PolicyId = v1.PolicyId,
+        });
+        active.Version.Id.Should().Be(v2.Id);
+    }
+
+    [Fact]
+    public async Task PublishVersion_EmptyRationale_ThrowsInvalidArgument()
+    {
+        var draft = await CreateDraftAsync(Slug("nora"));
+
+        var ex = await Assert.ThrowsAsync<RpcException>(() =>
+            _lifecycle.PublishVersionAsync(new PublishVersionRequest
+            {
+                PolicyId = draft.PolicyId,
+                VersionId = draft.Id,
+                Rationale = "  ",
+            }).ResponseAsync);
+
+        ex.StatusCode.Should().Be(StatusCode.InvalidArgument);
+        ex.Status.Detail.Should().Contain("Rationale");
+    }
+
+    [Fact]
+    public async Task PublishVersion_UnknownIds_ThrowsNotFound()
+    {
+        var ex = await Assert.ThrowsAsync<RpcException>(() =>
+            _lifecycle.PublishVersionAsync(new PublishVersionRequest
+            {
+                PolicyId = Guid.NewGuid().ToString(),
+                VersionId = Guid.NewGuid().ToString(),
+                Rationale = "go",
+            }).ResponseAsync);
+
+        ex.StatusCode.Should().Be(StatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task PublishVersion_InvalidGuid_ThrowsInvalidArgument()
+    {
+        var ex = await Assert.ThrowsAsync<RpcException>(() =>
+            _lifecycle.PublishVersionAsync(new PublishVersionRequest
+            {
+                PolicyId = "not-a-guid",
+                VersionId = Guid.NewGuid().ToString(),
+                Rationale = "go",
+            }).ResponseAsync);
+
+        ex.StatusCode.Should().Be(StatusCode.InvalidArgument);
+        ex.Status.Detail.Should().Contain("policy_id");
+    }
+
+    [Fact]
+    public async Task TransitionVersion_DisallowedTransition_ThrowsFailedPrecondition()
+    {
+        // Draft -> Retired is not in the matrix.
+        var draft = await CreateDraftAsync(Slug("badtran"));
+
+        var ex = await Assert.ThrowsAsync<RpcException>(() =>
+            _lifecycle.TransitionVersionAsync(new TransitionVersionRequest
+            {
+                PolicyId = draft.PolicyId,
+                VersionId = draft.Id,
+                TargetState = "Retired",
+                Rationale = "skip",
+            }).ResponseAsync);
+
+        ex.StatusCode.Should().Be(StatusCode.FailedPrecondition);
+    }
+
+    [Fact]
+    public async Task TransitionVersion_AcceptsCaseInsensitiveTargetState()
+    {
+        var draft = await CreateDraftAsync(Slug("case"));
+
+        var response = await _lifecycle.TransitionVersionAsync(new TransitionVersionRequest
+        {
+            PolicyId = draft.PolicyId,
+            VersionId = draft.Id,
+            TargetState = "active",
+            Rationale = "ship",
+        });
+
+        response.Version.State.Should().Be("Active");
+    }
+
+    [Fact]
+    public async Task TransitionVersion_TargetDraft_ThrowsInvalidArgument()
+    {
+        var draft = await CreateDraftAsync(Slug("draft"));
+
+        var ex = await Assert.ThrowsAsync<RpcException>(() =>
+            _lifecycle.TransitionVersionAsync(new TransitionVersionRequest
+            {
+                PolicyId = draft.PolicyId,
+                VersionId = draft.Id,
+                TargetState = "Draft",
+                Rationale = "no",
+            }).ResponseAsync);
+
+        ex.StatusCode.Should().Be(StatusCode.InvalidArgument);
+    }
+
+    [Fact]
+    public async Task TransitionVersion_UnknownTargetState_ThrowsInvalidArgument()
+    {
+        var draft = await CreateDraftAsync(Slug("unk"));
+
+        var ex = await Assert.ThrowsAsync<RpcException>(() =>
+            _lifecycle.TransitionVersionAsync(new TransitionVersionRequest
+            {
+                PolicyId = draft.PolicyId,
+                VersionId = draft.Id,
+                TargetState = "Unicorn",
+                Rationale = "?",
+            }).ResponseAsync);
+
+        ex.StatusCode.Should().Be(StatusCode.InvalidArgument);
+    }
+
+    [Fact]
+    public async Task TransitionVersion_RetireFromWindingDown_StampsRetired()
+    {
+        var draft = await CreateDraftAsync(Slug("retire"));
+        await _lifecycle.PublishVersionAsync(new PublishVersionRequest
+        {
+            PolicyId = draft.PolicyId,
+            VersionId = draft.Id,
+            Rationale = "live",
+        });
+        await _lifecycle.TransitionVersionAsync(new TransitionVersionRequest
+        {
+            PolicyId = draft.PolicyId,
+            VersionId = draft.Id,
+            TargetState = "WindingDown",
+            Rationale = "sunset",
+        });
+
+        var response = await _lifecycle.TransitionVersionAsync(new TransitionVersionRequest
+        {
+            PolicyId = draft.PolicyId,
+            VersionId = draft.Id,
+            TargetState = "Retired",
+            Rationale = "tomb",
+        });
+
+        response.Version.State.Should().Be("Retired");
+    }
+
+    [Fact]
+    public async Task GetMatrix_ReturnsTheFourCanonicalRules()
+    {
+        var response = await _lifecycle.GetMatrixAsync(new GetMatrixRequest());
+
+        response.Rules.Should().HaveCount(4);
+        response.Rules.Select(r => (r.From, r.To, r.Name)).Should().BeEquivalentTo(new[]
+        {
+            ("Draft", "Active", "Publish"),
+            ("Active", "WindingDown", "WindDown"),
+            ("Active", "Retired", "Retire"),
+            ("WindingDown", "Retired", "Retire"),
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- New `Protos/lifecycle.proto` extends the existing `andy_policies` package + `Andy.Policies.Api.Protos` C# namespace via `import "policies.proto"`; consumers that already imported the package for `PolicyService` get lifecycle calls without a second stub generation.
- `LifecycleGrpcService` exposes three RPCs delegating to `ILifecycleTransitionService` (P2.2), the same service powering REST/MCP/CLI:
  - `PublishVersion` — Draft → Active shortcut.
  - `TransitionVersion` — generalised `(target_state)` form; case-insensitive parse, rejects `target_state=Draft`.
  - `GetMatrix` — read-only introspection of the four canonical `(from, to, name)` tuples.
- Exception mapping: `RationaleRequiredException` / `ValidationException` → `InvalidArgument`; `NotFoundException` → `NotFound`; `InvalidLifecycleTransitionException` → `FailedPrecondition`; `ConcurrentPublishException` → `Aborted`.
- `ResolveSubjectId` mirrors the REST controller's actor-fallback firewall: when no `NameIdentifier`/`Name` claim is present the RPC throws `Unauthenticated` rather than write a fallback subject id into the catalog.

Closes #16.

## Test plan
- [x] `dotnet test` — 144 unit + 137 integration pass; 6 E2E skipped (`E2E_ENABLED=0`).
- [x] 11 new tests in `LifecycleGrpcServiceTests`: happy-path publish, auto-supersede end-to-end, rationale `InvalidArgument`, unknown ids `NotFound`, invalid GUID `InvalidArgument`, disallowed transition `FailedPrecondition`, case-insensitive target state, `Draft`/unknown target state rejected, retire from `WindingDown`, matrix readout shape.
- [x] OpenAPI snapshot unchanged (proto-only addition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)