### PR TITLE
Implement P2.7 — andy-policies-cli versions {publish,wind-down,retire}

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,20 @@ delegation. Service exceptions map to gRPC status codes:
 `NotFoundException` → `NotFound`, `InvalidLifecycleTransitionException` →
 `FailedPrecondition`, `ConcurrentPublishException` → `Aborted`.
 
+The CLI (`andy-policies-cli versions {publish,wind-down,retire}`, P2.7,
+[#17](https://github.com/rivoli-ai/andy-policies/issues/17)) drives the same
+REST endpoints with a `--rationale` / `-r` flag:
+
+```bash
+andy-policies-cli versions publish   <policyIdOrName> <versionId> -r "promote v3"
+andy-policies-cli versions wind-down <policyIdOrName> <versionId> -r "sunset"
+andy-policies-cli versions retire    <policyIdOrName> <versionId> -r "tomb"
+```
+
+Exit codes follow the federated-CLI contract from Conductor Epic AN: `0`
+success, `1` transport / generic, `3` auth (401/403), `4` not found, `5`
+conflict (409/412 — covers invalid-transition).
+
 ## Ports
 
 Per the ecosystem registry at [`../andy-service-template/docs/ports.md`](../andy-service-template/docs/ports.md). Three deployment modes; the same host can run any combination because each mode uses a distinct port range.

--- a/tests/Andy.Policies.Tests.Integration/Andy.Policies.Tests.Integration.csproj
+++ b/tests/Andy.Policies.Tests.Integration/Andy.Policies.Tests.Integration.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Andy.Policies.Api\Andy.Policies.Api.csproj" />
+    <!-- P2.7 (#17): CliLifecycleEndToEndTests drives the CLI in-process. -->
+    <ProjectReference Include="..\..\tools\Andy.Policies.Cli\Andy.Policies.Cli.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Andy.Policies.Tests.Integration/Cli/CliLifecycleEndToEndTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Cli/CliLifecycleEndToEndTests.cs
@@ -1,0 +1,200 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.CommandLine;
+using System.Net.Http.Json;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Cli.Commands;
+using Andy.Policies.Cli.Http;
+using Andy.Policies.Tests.Integration.Controllers;
+using FluentAssertions;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Cli;
+
+/// <summary>
+/// Full-stack CLI tests for P2.7 (#17). Boots the API via
+/// <see cref="PoliciesApiFactory"/>, swaps the CLI's HTTP handler with the
+/// test server's via the internal <see cref="ClientFactory.UseHandlerForTesting"/>
+/// seam, and drives <c>versions {publish,wind-down,retire}</c> through
+/// <see cref="Command.InvokeAsync"/>. Verifies that the CLI lands on the
+/// REST surface from P2.3 with the expected exit codes and DB state.
+/// </summary>
+public class CliLifecycleEndToEndTests : IClassFixture<PoliciesApiFactory>
+{
+    private readonly PoliciesApiFactory _factory;
+
+    public CliLifecycleEndToEndTests(PoliciesApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    private Command BuildRootCommand()
+    {
+        var apiUrl = new Option<string>("--api-url", () => _factory.Server.BaseAddress.ToString());
+        var token = new Option<string?>("--token");
+        var output = new Option<string>("--output", () => "json");
+
+        var root = new RootCommand("test-cli");
+        root.AddGlobalOption(apiUrl);
+        root.AddGlobalOption(token);
+        root.AddGlobalOption(output);
+        var versions = new Command("versions", "Manage policy versions");
+        VersionCommands.Register(versions, apiUrl, token, output);
+        root.AddCommand(versions);
+        return root;
+    }
+
+    private async Task<PolicyVersionDto> CreateDraftAsync(string slug)
+    {
+        var client = _factory.CreateClient();
+        var resp = await client.PostAsJsonAsync("/api/policies", new
+        {
+            name = slug,
+            description = (string?)null,
+            summary = "summary",
+            enforcement = "Must",
+            severity = "Critical",
+            scopes = Array.Empty<string>(),
+            rulesJson = "{}",
+        });
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
+    }
+
+    [Fact]
+    public async Task PublishCommand_OnDraft_ReturnsExitZero_AndFlipsStateToActive()
+    {
+        using var _scope = ClientFactory.UseHandlerForTesting(_factory.Server.CreateHandler());
+        var draft = await CreateDraftAsync($"cli-publish-{Guid.NewGuid():N}".Substring(0, 16));
+
+        var root = BuildRootCommand();
+        var exit = await root.InvokeAsync(new[]
+        {
+            "versions", "publish",
+            draft.PolicyId.ToString(),
+            draft.Id.ToString(),
+            "--rationale", "ship-it",
+        });
+
+        exit.Should().Be(0);
+
+        var client = _factory.CreateClient();
+        var reloaded = await client.GetFromJsonAsync<PolicyVersionDto>(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}");
+        reloaded!.State.Should().Be("Active");
+    }
+
+    [Fact]
+    public async Task PublishCommand_WithEmptyRationale_ReturnsTransport_FromBadRequest()
+    {
+        // ExitCodes.FromStatus maps anything outside { 401/403/404/409/412/2xx }
+        // to ExitCodes.Transport (1). 400 is one of those — the CLI surfaces a
+        // generic "request failed" instead of a typed "bad arguments" code
+        // because System.CommandLine reserves exit 2 for parser-level errors.
+        // The acceptance criterion is that the binary exits non-zero and the
+        // DB stays untouched.
+        using var _scope = ClientFactory.UseHandlerForTesting(_factory.Server.CreateHandler());
+        var draft = await CreateDraftAsync($"cli-norat-{Guid.NewGuid():N}".Substring(0, 16));
+
+        var root = BuildRootCommand();
+        var exit = await root.InvokeAsync(new[]
+        {
+            "versions", "publish",
+            draft.PolicyId.ToString(),
+            draft.Id.ToString(),
+        });
+
+        exit.Should().Be(1);
+
+        var client = _factory.CreateClient();
+        var reloaded = await client.GetFromJsonAsync<PolicyVersionDto>(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}");
+        reloaded!.State.Should().Be("Draft");
+    }
+
+    [Fact]
+    public async Task LifecycleVerbs_Round_Trip_DraftToRetired()
+    {
+        using var _scope = ClientFactory.UseHandlerForTesting(_factory.Server.CreateHandler());
+        var draft = await CreateDraftAsync($"cli-rt-{Guid.NewGuid():N}".Substring(0, 16));
+        var root = BuildRootCommand();
+
+        (await root.InvokeAsync(new[]
+        {
+            "versions", "publish", draft.PolicyId.ToString(), draft.Id.ToString(), "-r", "live",
+        })).Should().Be(0);
+
+        (await root.InvokeAsync(new[]
+        {
+            "versions", "wind-down", draft.PolicyId.ToString(), draft.Id.ToString(), "-r", "sunset",
+        })).Should().Be(0);
+
+        (await root.InvokeAsync(new[]
+        {
+            "versions", "retire", draft.PolicyId.ToString(), draft.Id.ToString(), "-r", "tomb",
+        })).Should().Be(0);
+
+        var client = _factory.CreateClient();
+        var reloaded = await client.GetFromJsonAsync<PolicyVersionDto>(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}");
+        reloaded!.State.Should().Be("Retired");
+    }
+
+    [Fact]
+    public async Task PublishCommand_OnUnknownIds_ReturnsNotFoundExit()
+    {
+        using var _scope = ClientFactory.UseHandlerForTesting(_factory.Server.CreateHandler());
+        var root = BuildRootCommand();
+
+        var exit = await root.InvokeAsync(new[]
+        {
+            "versions", "publish",
+            Guid.NewGuid().ToString(),
+            Guid.NewGuid().ToString(),
+            "-r", "go",
+        });
+
+        // ExitCodes.NotFound = 4
+        exit.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task RetireCommand_OnDraft_ReturnsConflictExit_FromInvalidTransition()
+    {
+        using var _scope = ClientFactory.UseHandlerForTesting(_factory.Server.CreateHandler());
+        var draft = await CreateDraftAsync($"cli-bad-{Guid.NewGuid():N}".Substring(0, 16));
+        var root = BuildRootCommand();
+
+        var exit = await root.InvokeAsync(new[]
+        {
+            "versions", "retire",
+            draft.PolicyId.ToString(),
+            draft.Id.ToString(),
+            "-r", "skip",
+        });
+
+        // ExitCodes.Conflict = 5; Draft -> Retired isn't in the matrix.
+        exit.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task PublishCommand_AcceptsPolicyNameSlug_NotJustGuid()
+    {
+        using var _scope = ClientFactory.UseHandlerForTesting(_factory.Server.CreateHandler());
+        var slug = $"cli-slug-{Guid.NewGuid():N}".Substring(0, 16);
+        var draft = await CreateDraftAsync(slug);
+        var root = BuildRootCommand();
+
+        var exit = await root.InvokeAsync(new[]
+        {
+            "versions", "publish",
+            slug,                       // name slug, not GUID
+            draft.Id.ToString(),
+            "-r", "ship",
+        });
+
+        exit.Should().Be(0);
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Cli/VersionsLifecycleCommandsTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Cli/VersionsLifecycleCommandsTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.CommandLine;
+using Andy.Policies.Cli.Commands;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Cli;
+
+/// <summary>
+/// Command-tree shape tests for P2.7 (#17). Asserts that the
+/// <c>versions</c> noun gets <c>publish</c>, <c>wind-down</c>, and
+/// <c>retire</c> subcommands, each with the expected positional arguments
+/// and a <c>--rationale</c> / <c>-r</c> option. Catches accidental rename or
+/// option-removal during refactors before integration tests run.
+/// </summary>
+public class VersionsLifecycleCommandsTests
+{
+    private static Command BuildVersionsRoot()
+    {
+        var apiUrl = new Option<string>("--api-url", () => "https://test");
+        var token = new Option<string?>("--token");
+        var output = new Option<string>("--output", () => "table");
+        var versions = new Command("versions", "Manage policy versions");
+        VersionCommands.Register(versions, apiUrl, token, output);
+        return versions;
+    }
+
+    [Theory]
+    [InlineData("publish")]
+    [InlineData("wind-down")]
+    [InlineData("retire")]
+    public void Versions_RegistersLifecycleVerb(string verb)
+    {
+        var versions = BuildVersionsRoot();
+
+        var verbCmd = versions.Subcommands.FirstOrDefault(c => c.Name == verb);
+        verbCmd.Should().NotBeNull($"versions {verb} should be registered");
+    }
+
+    [Theory]
+    [InlineData("publish")]
+    [InlineData("wind-down")]
+    [InlineData("retire")]
+    public void LifecycleVerb_HasPolicyAndVersionArgs(string verb)
+    {
+        var versions = BuildVersionsRoot();
+        var verbCmd = versions.Subcommands.First(c => c.Name == verb);
+
+        verbCmd.Arguments.Should().HaveCount(2);
+        verbCmd.Arguments.Select(a => a.Name).Should()
+            .ContainInOrder("policyIdOrName", "versionId");
+    }
+
+    [Theory]
+    [InlineData("publish")]
+    [InlineData("wind-down")]
+    [InlineData("retire")]
+    public void LifecycleVerb_HasRationaleOption_WithShortAlias(string verb)
+    {
+        var versions = BuildVersionsRoot();
+        var verbCmd = versions.Subcommands.First(c => c.Name == verb);
+
+        var rationale = verbCmd.Options.FirstOrDefault(o => o.Name == "rationale");
+        rationale.Should().NotBeNull("--rationale must be defined");
+        rationale!.Aliases.Should().Contain("-r");
+        rationale.IsRequired.Should().BeFalse(
+            "rationale is server-side enforced via andy.policies.rationaleRequired (P2.4)");
+    }
+
+    [Theory]
+    [InlineData("publish", "Draft -> Active")]
+    [InlineData("wind-down", "Active -> WindingDown")]
+    [InlineData("retire", "-> Retired")]
+    public void LifecycleVerb_HasDescriptiveHelp(string verb, string expectedFragment)
+    {
+        var versions = BuildVersionsRoot();
+        var verbCmd = versions.Subcommands.First(c => c.Name == verb);
+
+        verbCmd.Description.Should().Contain(expectedFragment);
+    }
+}

--- a/tools/Andy.Policies.Cli/Andy.Policies.Cli.csproj
+++ b/tools/Andy.Policies.Cli/Andy.Policies.Cli.csproj
@@ -12,6 +12,10 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Andy.Policies.Tests.Unit" />
+    <!-- P2.7 (#17): integration tests drive the CLI command tree against a
+         WebApplicationFactory<Program>, swapping the production HttpClient
+         handler via ClientFactory.UseHandlerForTesting (an internal seam). -->
+    <InternalsVisibleTo Include="Andy.Policies.Tests.Integration" />
   </ItemGroup>
 
 </Project>

--- a/tools/Andy.Policies.Cli/Commands/VersionCommands.cs
+++ b/tools/Andy.Policies.Cli/Commands/VersionCommands.cs
@@ -29,6 +29,68 @@ internal static class VersionCommands
         parent.AddCommand(BuildDraftNew(apiUrlOption, tokenOption, outputOption));
         parent.AddCommand(BuildDraftEdit(apiUrlOption, tokenOption, outputOption));
         parent.AddCommand(BuildDraftBump(apiUrlOption, tokenOption, outputOption));
+        // P2.7 (#17): lifecycle transition verbs. Each posts to the matching
+        // REST endpoint introduced by P2.3 with a JSON body { rationale }.
+        parent.AddCommand(BuildTransition("publish",
+            "Publish a Draft (Draft -> Active). Auto-supersedes the previous Active.",
+            "publish", apiUrlOption, tokenOption, outputOption));
+        parent.AddCommand(BuildTransition("wind-down",
+            "Wind down an Active version (Active -> WindingDown).",
+            "winding-down", apiUrlOption, tokenOption, outputOption));
+        parent.AddCommand(BuildTransition("retire",
+            "Retire a version (Active or WindingDown -> Retired).",
+            "retire", apiUrlOption, tokenOption, outputOption));
+    }
+
+    private static Command BuildTransition(
+        string verb,
+        string description,
+        string urlSegment,
+        Option<string> apiUrl,
+        Option<string?> token,
+        Option<string> output)
+    {
+        var command = new Command(verb, description);
+        var policyArg = new Argument<string>("policyIdOrName", "Policy id (GUID) or name slug");
+        var versionArg = new Argument<Guid>("versionId", "PolicyVersion id (GUID)");
+        var rationaleOpt = new Option<string?>(
+            aliases: new[] { "--rationale", "-r" },
+            description: "Rationale recorded against the transition. " +
+                         "Required when andy.policies.rationaleRequired is true (default).");
+        command.AddArgument(policyArg);
+        command.AddArgument(versionArg);
+        command.AddOption(rationaleOpt);
+
+        command.SetHandler(async ctx =>
+        {
+            var api = ctx.ParseResult.GetValueForOption(apiUrl)!;
+            var tok = ctx.ParseResult.GetValueForOption(token);
+            var fmt = ctx.ParseResult.GetValueForOption(output) ?? "table";
+            var policyIdOrName = ctx.ParseResult.GetValueForArgument(policyArg);
+            var versionId = ctx.ParseResult.GetValueForArgument(versionArg);
+            var rationale = ctx.ParseResult.GetValueForOption(rationaleOpt) ?? string.Empty;
+            var ct = ctx.GetCancellationToken();
+
+            using var http = ClientFactory.Create(api, tok);
+            var policyId = await ResolvePolicyIdAsync(http, policyIdOrName, ctx, ct).ConfigureAwait(false);
+            if (policyId is null)
+            {
+                return;
+            }
+
+            var resp = await http.PostAsJsonAsync(
+                $"/api/policies/{policyId}/versions/{versionId}/{urlSegment}",
+                new { rationale },
+                ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+            {
+                ctx.ExitCode = await ExitCodes.HandleAsync(resp, ct).ConfigureAwait(false);
+                return;
+            }
+            var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            OutputRenderer.Write(body, fmt);
+        });
+        return command;
     }
 
     private static Command BuildList(Option<string> apiUrl, Option<string?> token, Option<string> output)

--- a/tools/Andy.Policies.Cli/Http/ClientFactory.cs
+++ b/tools/Andy.Policies.Cli/Http/ClientFactory.cs
@@ -13,17 +13,55 @@ namespace Andy.Policies.Cli.Http;
 /// </summary>
 internal static class ClientFactory
 {
+    /// <summary>
+    /// Test-only seam: when set, <see cref="Create"/> wraps this handler
+    /// instead of the production <see cref="HttpClientHandler"/>. Stored as
+    /// <see cref="AsyncLocal{T}"/> so parallel xUnit runs don't bleed handlers
+    /// across each other. Production callers never set this; production
+    /// callers also never disable the test value (it's null by default).
+    /// </summary>
+    private static readonly AsyncLocal<HttpMessageHandler?> _handlerOverride = new();
+
+    internal static IDisposable UseHandlerForTesting(HttpMessageHandler handler)
+    {
+        var previous = _handlerOverride.Value;
+        _handlerOverride.Value = handler;
+        return new HandlerScope(previous);
+    }
+
     public static HttpClient Create(string apiUrl, string? token)
     {
-        var handler = new HttpClientHandler
+        // ownsHandler: when an override is supplied (tests), the test owns the
+        // lifetime of the handler — disposing the HttpClient must not dispose
+        // it because the same handler is typically reused across calls.
+        HttpMessageHandler handler;
+        bool ownsHandler;
+        if (_handlerOverride.Value is { } injected)
         {
-            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
-        };
-        var client = new HttpClient(handler) { BaseAddress = new Uri(apiUrl) };
+            handler = injected;
+            ownsHandler = false;
+        }
+        else
+        {
+            handler = new HttpClientHandler
+            {
+                ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+            };
+            ownsHandler = true;
+        }
+
+        var client = new HttpClient(handler, disposeHandler: ownsHandler) { BaseAddress = new Uri(apiUrl) };
         if (!string.IsNullOrEmpty(token))
         {
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         }
         return client;
+    }
+
+    private sealed class HandlerScope : IDisposable
+    {
+        private readonly HttpMessageHandler? _previous;
+        public HandlerScope(HttpMessageHandler? previous) => _previous = previous;
+        public void Dispose() => _handlerOverride.Value = _previous;
     }
 }

--- a/tools/Andy.Policies.Cli/Program.cs
+++ b/tools/Andy.Policies.Cli/Program.cs
@@ -4,45 +4,62 @@
 using System.CommandLine;
 using Andy.Policies.Cli.Commands;
 
-var rootCommand = new RootCommand("Andy Policies CLI - Manage andy-policies resources");
+namespace Andy.Policies.Cli;
 
-var apiUrlOption = new Option<string>(
-    "--api-url",
-    getDefaultValue: () => "https://localhost:5112",
-    description: "The Andy Policies API base URL");
-rootCommand.AddGlobalOption(apiUrlOption);
+/// <summary>
+/// Entry point for <c>andy-policies-cli</c>. Lives in the
+/// <c>Andy.Policies.Cli</c> namespace (rather than the implicit global
+/// top-level-statements form) so the test-integration project can reference
+/// both <c>Andy.Policies.Cli</c> and <c>Andy.Policies.Api</c> without their
+/// global <c>Program</c> classes colliding (the API's
+/// <c>WebApplicationFactory&lt;Program&gt;</c> still resolves to the global
+/// type emitted by its top-level statements).
+/// </summary>
+internal static class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        var rootCommand = new RootCommand("Andy Policies CLI - Manage andy-policies resources");
 
-var tokenOption = new Option<string?>(
-    "--token",
-    description: "Bearer token for authentication");
-rootCommand.AddGlobalOption(tokenOption);
+        var apiUrlOption = new Option<string>(
+            "--api-url",
+            getDefaultValue: () => "https://localhost:5112",
+            description: "The Andy Policies API base URL");
+        rootCommand.AddGlobalOption(apiUrlOption);
 
-var outputOption = new Option<string>(
-    "--output",
-    getDefaultValue: () => "table",
-    description: "Output format: table | json | yaml");
-outputOption.FromAmong("table", "json", "yaml");
-rootCommand.AddGlobalOption(outputOption);
+        var tokenOption = new Option<string?>(
+            "--token",
+            description: "Bearer token for authentication");
+        rootCommand.AddGlobalOption(tokenOption);
 
-var noColorOption = new Option<bool>(
-    "--no-color",
-    getDefaultValue: () =>
-        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NO_COLOR"))
-        || Environment.GetEnvironmentVariable("TERM") == "dumb",
-    description: "Disable ANSI color in output");
-rootCommand.AddGlobalOption(noColorOption);
+        var outputOption = new Option<string>(
+            "--output",
+            getDefaultValue: () => "table",
+            description: "Output format: table | json | yaml");
+        outputOption.FromAmong("table", "json", "yaml");
+        rootCommand.AddGlobalOption(outputOption);
 
-// Item commands (template scaffolding — kept for backward compat)
-var itemsCommand = new Command("items", "Manage items");
-ItemCommands.Register(itemsCommand, apiUrlOption, tokenOption);
-rootCommand.AddCommand(itemsCommand);
+        var noColorOption = new Option<bool>(
+            "--no-color",
+            getDefaultValue: () =>
+                !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NO_COLOR"))
+                || Environment.GetEnvironmentVariable("TERM") == "dumb",
+            description: "Disable ANSI color in output");
+        rootCommand.AddGlobalOption(noColorOption);
 
-var policiesCommand = new Command("policies", "Manage the policy catalogue");
-PolicyCommands.Register(policiesCommand, apiUrlOption, tokenOption, outputOption);
-rootCommand.AddCommand(policiesCommand);
+        // Item commands (template scaffolding — kept for backward compat)
+        var itemsCommand = new Command("items", "Manage items");
+        ItemCommands.Register(itemsCommand, apiUrlOption, tokenOption);
+        rootCommand.AddCommand(itemsCommand);
 
-var versionsCommand = new Command("versions", "Manage policy versions");
-VersionCommands.Register(versionsCommand, apiUrlOption, tokenOption, outputOption);
-rootCommand.AddCommand(versionsCommand);
+        var policiesCommand = new Command("policies", "Manage the policy catalogue");
+        PolicyCommands.Register(policiesCommand, apiUrlOption, tokenOption, outputOption);
+        rootCommand.AddCommand(policiesCommand);
 
-return await rootCommand.InvokeAsync(args);
+        var versionsCommand = new Command("versions", "Manage policy versions");
+        VersionCommands.Register(versionsCommand, apiUrlOption, tokenOption, outputOption);
+        rootCommand.AddCommand(versionsCommand);
+
+        return await rootCommand.InvokeAsync(args);
+    }
+}


### PR DESCRIPTION
## Summary
- Three lifecycle verbs added to the existing `versions` CLI noun via a shared `BuildTransition` helper. Each posts to the matching REST endpoint introduced by P2.3 with body `{ rationale }`.
- Args: `<policyIdOrName>` (GUID or name slug; resolved through `GET /api/policies/by-name/{slug}`) and `<versionId>` (GUID). Option: `--rationale` / `-r` (server-side enforcement via `andy.policies.rationaleRequired` from P2.4 governs whether the value is required, so the parser stays permissive).
- Exit codes follow the federated-CLI contract from Conductor Epic AN: `0` success, `1` transport / generic, `3` auth (401/403), `4` not found, `5` conflict (409/412 — covers invalid-transition).
- `ClientFactory` grew an internal `AsyncLocal<HttpMessageHandler?>` test seam (`UseHandlerForTesting`) so `CliLifecycleEndToEndTests` can drive the CLI in-process against `WebApplicationFactory<Program>`. Production callers don't touch it; production `HttpClient`s still build their own `HttpClientHandler`.
- The CLI's top-level `Program` moved into the `Andy.Policies.Cli` namespace so the integration test project can `ProjectReference` both `Andy.Policies.Cli` and `Andy.Policies.Api` without their global `Program` classes colliding.

Closes #17.

## Test plan
- [x] `dotnet test` — 156 unit + 143 integration pass; 6 E2E skipped (`E2E_ENABLED=0`).
- [x] Unit (`VersionsLifecycleCommandsTests`): all three verbs registered, positional args ordered correctly, `--rationale` option present with `-r` alias, descriptive help.
- [x] Integration (`CliLifecycleEndToEndTests`): publish round-trip flips DB to Active; full Draft → Active → WindingDown → Retired round trip; empty rationale exits non-zero with DB unchanged; unknown ids exit `4`; retire-from-Draft exits `5`; name slug accepted in place of GUID.
- [x] Manual `dotnet run --project tools/Andy.Policies.Cli -- versions --help` shows the three new verbs with `--rationale`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)