### PR TITLE
Implement P3.1 — Binding entity + EF migration with target + policy-version indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The docker-compose in this repo binds Mode 2 ports so it can coexist with a nati
 
 | Layer | Project | Entities / responsibilities |
 |-------|---------|-----------------------------|
-| Domain | `src/Andy.Policies.Domain` | `Policy`, `PolicyVersion`, dimension enums (`EnforcementLevel`, `Severity`, `LifecycleState`); `Binding` (P3), `ScopeNode` (P4), `Override` (P5), `AuditEvent` (P6), `Bundle` (P8) land with their respective epics |
+| Domain | `src/Andy.Policies.Domain` | `Policy`, `PolicyVersion`, `Binding` (P3.1, [#19](https://github.com/rivoli-ai/andy-policies/issues/19)), dimension enums (`EnforcementLevel`, `Severity`, `LifecycleState`, `BindingTargetType`, `BindStrength`); `ScopeNode` (P4), `Override` (P5), `AuditEvent` (P6), `Bundle` (P8) land with their respective epics |
 | Application | `src/Andy.Policies.Application` | `IPolicyService`; per-epic interfaces (`IBindingService`, `IScopeService`, `IOverrideService`, `IAuditChain`, `IBundleService`) added by later stories |
 | Infrastructure | `src/Andy.Policies.Infrastructure` | EF Core (`AppDbContext` + migrations), `PolicyService` implementation, `PolicySeeder` for the six stock policies, andy-rbac / andy-settings adapters |
 | API | `src/Andy.Policies.Api` | REST controllers, MCP tools, gRPC services, OIDC/JWT auth, OpenAPI generation, OpenTelemetry wiring |

--- a/src/Andy.Policies.Domain/Entities/Binding.cs
+++ b/src/Andy.Policies.Domain/Entities/Binding.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Domain.Enums;
+
+namespace Andy.Policies.Domain.Entities;
+
+/// <summary>
+/// Metadata link between an immutable <see cref="PolicyVersion"/> and a
+/// foreign target (template, repo, scope node, tenant, org). P3.1 (story
+/// rivoli-ai/andy-policies#19) introduces the entity; mutation services
+/// land in P3.2 and the four parity surfaces (REST/MCP/gRPC/CLI) follow.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Bindings are <b>metadata only</b>. <see cref="TargetRef"/> is an opaque
+/// foreign-system reference handed to us by a consumer (andy-issues,
+/// andy-tasks, etc.); andy-policies never resolves it against the foreign
+/// system. Cross-service consistency of the target is the consumer's
+/// contract — see Epic P3 (rivoli-ai/andy-policies#3) Non-goals.
+/// </para>
+/// <para>
+/// <b>Canonical TargetRef shapes</b> (validated in P3.2 BindingService):
+/// <list type="bullet">
+///   <item><c>template:{guid}</c></item>
+///   <item><c>repo:{org}/{name}</c></item>
+///   <item><c>scope:{guid}</c> — the <c>ScopeNode.Id</c>, not the
+///     materialised path; P4.2 resolves path → id when callers want
+///     path-based lookup.</item>
+///   <item><c>tenant:{guid}</c></item>
+///   <item><c>org:{guid}</c></item>
+/// </list>
+/// Keeping a single canonical shape per <see cref="TargetType"/> lets P4's
+/// hierarchy walk and P8's bundle resolve share the same join key without
+/// string parsing heuristics.
+/// </para>
+/// <para>
+/// <b>Soft-delete</b>: P3.2 sets <see cref="DeletedAt"/> rather than
+/// hard-deleting rows so P6's audit chain has an append-only history of
+/// every mutation. Read endpoints (P3.3, P3.4, P4) filter
+/// <c>DeletedAt IS NULL</c>.
+/// </para>
+/// </remarks>
+public class Binding
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid PolicyVersionId { get; set; }
+
+    public PolicyVersion? PolicyVersion { get; set; }
+
+    public BindingTargetType TargetType { get; set; }
+
+    /// <summary>
+    /// Opaque foreign reference matching one of the canonical shapes per
+    /// <see cref="TargetType"/> (see remarks). Capped at 512 chars; longer
+    /// values fail validation in P3.2.
+    /// </summary>
+    public string TargetRef { get; set; } = string.Empty;
+
+    public BindStrength BindStrength { get; set; } = BindStrength.Recommended;
+
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    public string CreatedBySubjectId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Soft-delete tombstone. Null while the binding is active; set by P3.2
+    /// <c>BindingService.DeleteAsync</c>. Indexed via
+    /// <c>ix_bindings_deleted_at</c> for fast active-only filtering.
+    /// </summary>
+    public DateTimeOffset? DeletedAt { get; set; }
+
+    public string? DeletedBySubjectId { get; set; }
+}

--- a/src/Andy.Policies.Domain/Enums/BindStrength.cs
+++ b/src/Andy.Policies.Domain/Enums/BindStrength.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Domain.Enums;
+
+/// <summary>
+/// How strongly a <see cref="Entities.Binding"/> applies to its target.
+/// Consumers (Conductor's ActionBus, andy-tasks per-task gates) interpret
+/// the strength to decide whether to block or warn — this service stores
+/// the value but does not enforce it (see Epic P3 Non-goals).
+/// Persisted as <c>int</c>; values 1 / 2 are load-bearing on disk.
+/// </summary>
+public enum BindStrength
+{
+    /// <summary>The binding's policy must apply; consumers reject runs that violate it.</summary>
+    Mandatory = 1,
+
+    /// <summary>The binding's policy applies as guidance; consumers warn but do not block.</summary>
+    Recommended = 2,
+}

--- a/src/Andy.Policies.Domain/Enums/BindingTargetType.cs
+++ b/src/Andy.Policies.Domain/Enums/BindingTargetType.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Domain.Enums;
+
+/// <summary>
+/// The kind of foreign target a <see cref="Entities.Binding"/> attaches a
+/// <see cref="Entities.PolicyVersion"/> to (P3.1, story
+/// rivoli-ai/andy-policies#19). The enum is persisted by ordinal to
+/// <c>int</c> via EF's <c>HasConversion&lt;int&gt;</c>, so the numeric values
+/// MUST stay stable across renames — existing rows on disk depend on
+/// <c>1..5</c>.
+/// </summary>
+public enum BindingTargetType
+{
+    /// <summary>Template id from andy-tasks (canonical TargetRef shape <c>"template:{guid}"</c>).</summary>
+    Template = 1,
+
+    /// <summary>Source repository (canonical TargetRef shape <c>"repo:{org}/{name}"</c>).</summary>
+    Repo = 2,
+
+    /// <summary>
+    /// Hierarchical scope node (canonical TargetRef shape <c>"scope:{guid}"</c>
+    /// where the GUID is <c>ScopeNode.Id</c>). P4.3 joins on the id, not the
+    /// materialised path; callers wanting path-based lookup resolve via
+    /// <c>IScopeService</c> first.
+    /// </summary>
+    ScopeNode = 3,
+
+    /// <summary>Tenant id (canonical TargetRef shape <c>"tenant:{guid}"</c>).</summary>
+    Tenant = 4,
+
+    /// <summary>Organisation id (canonical TargetRef shape <c>"org:{guid}"</c>).</summary>
+    Org = 5,
+}

--- a/src/Andy.Policies.Infrastructure/Data/AppDbContext.cs
+++ b/src/Andy.Policies.Infrastructure/Data/AppDbContext.cs
@@ -19,6 +19,8 @@ public class AppDbContext : DbContext
 
     public DbSet<PolicyVersion> PolicyVersions => Set<PolicyVersion>();
 
+    public DbSet<Binding> Bindings => Set<Binding>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -158,6 +160,47 @@ public class AppDbContext : DbContext
         modelBuilder.Entity<PolicyVersion>()
             .Property(v => v.Revision)
             .IsConcurrencyToken();
+
+        // P3.1 (rivoli-ai/andy-policies#19) — Binding metadata table.
+        // - HasConversion<int> on the two enums so persisted ordinals match the
+        //   enum definitions (load-bearing on disk).
+        // - FK Restrict on PolicyVersionId: deleting a version with active
+        //   bindings is rejected at the DB layer; consumers must soft-delete
+        //   the bindings first.
+        // - Three indexes:
+        //     ix_bindings_target — every target-side lookup (P3.3, P3.4, P4
+        //       hierarchy walk) is `WHERE TargetType = ? AND TargetRef = ?`,
+        //       so a covering composite index keeps the hot path off table
+        //       scans.
+        //     ix_bindings_policy_version — version-side reads (list-by-version,
+        //       cascade refusal in P3.2 when a version transitions to Retired).
+        //     ix_bindings_deleted_at — partial-style filter for active-only
+        //       queries; we keep it as a plain index on both providers since
+        //       SQLite's partial-index syntax differs and the column has low
+        //       cardinality.
+        modelBuilder.Entity<Binding>(entity =>
+        {
+            entity.ToTable("bindings");
+            entity.HasKey(b => b.Id);
+
+            entity.Property(b => b.TargetType).HasConversion<int>().IsRequired();
+            entity.Property(b => b.BindStrength).HasConversion<int>().IsRequired();
+            entity.Property(b => b.TargetRef).IsRequired().HasMaxLength(512);
+            entity.Property(b => b.CreatedBySubjectId).IsRequired().HasMaxLength(256);
+            entity.Property(b => b.DeletedBySubjectId).HasMaxLength(256);
+
+            entity.HasOne(b => b.PolicyVersion)
+                .WithMany()
+                .HasForeignKey(b => b.PolicyVersionId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasIndex(b => new { b.TargetType, b.TargetRef })
+                .HasDatabaseName("ix_bindings_target");
+            entity.HasIndex(b => b.PolicyVersionId)
+                .HasDatabaseName("ix_bindings_policy_version");
+            entity.HasIndex(b => b.DeletedAt)
+                .HasDatabaseName("ix_bindings_deleted_at");
+        });
     }
 
     // Override only the `bool`-flavoured routing entry points. EF routes `SaveChanges()` →

--- a/src/Andy.Policies.Infrastructure/Migrations/20260428025309_AddBindings.Designer.cs
+++ b/src/Andy.Policies.Infrastructure/Migrations/20260428025309_AddBindings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Andy.Policies.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Policies.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428025309_AddBindings")]
+    partial class AddBindings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Policies.Infrastructure/Migrations/20260428025309_AddBindings.cs
+++ b/src/Andy.Policies.Infrastructure/Migrations/20260428025309_AddBindings.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Policies.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBindings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "bindings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    PolicyVersionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TargetType = table.Column<int>(type: "integer", nullable: false),
+                    TargetRef = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    BindStrength = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    CreatedBySubjectId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    DeletedBySubjectId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_bindings", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_bindings_policy_versions_PolicyVersionId",
+                        column: x => x.PolicyVersionId,
+                        principalTable: "policy_versions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_bindings_deleted_at",
+                table: "bindings",
+                column: "DeletedAt");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_bindings_policy_version",
+                table: "bindings",
+                column: "PolicyVersionId");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_bindings_target",
+                table: "bindings",
+                columns: new[] { "TargetType", "TargetRef" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "bindings");
+        }
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Migration/SqliteMigrationTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Migration/SqliteMigrationTests.cs
@@ -56,6 +56,7 @@ public class SqliteMigrationTests : IDisposable
             "20260422031628_AddPolicyDimensions",
             "20260427000816_AddRetiredAtToPolicyVersion",
         });
+        applied.Should().Contain(name => name.EndsWith("_AddBindings"));
     }
 
     [Fact]
@@ -87,7 +88,7 @@ public class SqliteMigrationTests : IDisposable
                 "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name <> '__EFMigrationsHistory'")
             .ToListAsync();
 
-        tables.Should().Contain(new[] { "policies", "policy_versions" });
+        tables.Should().Contain(new[] { "policies", "policy_versions", "bindings" });
     }
 
     [Fact]

--- a/tests/Andy.Policies.Tests.Integration/Persistence/BindingMigrationTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Persistence/BindingMigrationTests.cs
@@ -1,0 +1,167 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Persistence;
+
+/// <summary>
+/// P3.1 (#19) integration tests for the <see cref="Binding"/> table:
+/// migration applies cleanly on Sqlite, the foreign key restricts inserts
+/// against unknown <c>PolicyVersion</c> rows, and the three indexes
+/// (<c>ix_bindings_target</c>, <c>ix_bindings_policy_version</c>,
+/// <c>ix_bindings_deleted_at</c>) are physically present so target-side
+/// lookups (P3.3, P3.4, P4) hit covering indexes.
+/// </summary>
+public class BindingMigrationTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly SqliteConnection _connection;
+
+    public BindingMigrationTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"andy-policies-bindmig-{Guid.NewGuid():N}.db");
+        _connection = new SqliteConnection($"Data Source={_dbPath};Foreign Keys=true");
+        _connection.Open();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        if (File.Exists(_dbPath)) File.Delete(_dbPath);
+    }
+
+    private DbContextOptions<AppDbContext> NewOptions() =>
+        new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+    private async Task<(Guid policyId, Guid versionId)> SeedPolicyAndDraftAsync(AppDbContext db)
+    {
+        var policy = new Policy
+        {
+            Id = Guid.NewGuid(),
+            Name = $"binding-fixture-{Guid.NewGuid():N}".Substring(0, 24),
+            CreatedBySubjectId = "test",
+        };
+        var version = new PolicyVersion
+        {
+            Id = Guid.NewGuid(),
+            PolicyId = policy.Id,
+            Version = 1,
+            State = LifecycleState.Draft,
+            Enforcement = EnforcementLevel.Should,
+            Severity = Severity.Moderate,
+            Scopes = new List<string>(),
+            Summary = "fixture",
+            RulesJson = "{}",
+            CreatedBySubjectId = "test",
+            ProposerSubjectId = "test",
+        };
+        db.Policies.Add(policy);
+        db.PolicyVersions.Add(version);
+        await db.SaveChangesAsync();
+        return (policy.Id, version.Id);
+    }
+
+    [Fact]
+    public async Task Migration_CreatesBindingsTable_WithExpectedIndexes()
+    {
+        await using var db = new AppDbContext(NewOptions());
+        await db.Database.MigrateAsync();
+
+        var indexes = await db.Database.SqlQueryRaw<string>(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='bindings'")
+            .ToListAsync();
+
+        indexes.Should().Contain(new[]
+        {
+            "ix_bindings_target",
+            "ix_bindings_policy_version",
+            "ix_bindings_deleted_at",
+        });
+    }
+
+    [Fact]
+    public async Task Insert_Binding_WithKnownPolicyVersion_RoundTripsAllFields()
+    {
+        await using var db = new AppDbContext(NewOptions());
+        await db.Database.MigrateAsync();
+        var (_, versionId) = await SeedPolicyAndDraftAsync(db);
+
+        var binding = new Binding
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = versionId,
+            TargetType = BindingTargetType.Repo,
+            TargetRef = "repo:rivoli-ai/andy-policies",
+            BindStrength = BindStrength.Mandatory,
+            CreatedBySubjectId = "sam",
+        };
+        db.Bindings.Add(binding);
+        await db.SaveChangesAsync();
+
+        var reloaded = await db.Bindings.AsNoTracking().FirstAsync(b => b.Id == binding.Id);
+        reloaded.PolicyVersionId.Should().Be(versionId);
+        reloaded.TargetType.Should().Be(BindingTargetType.Repo);
+        reloaded.TargetRef.Should().Be("repo:rivoli-ai/andy-policies");
+        reloaded.BindStrength.Should().Be(BindStrength.Mandatory);
+        reloaded.CreatedBySubjectId.Should().Be("sam");
+        reloaded.DeletedAt.Should().BeNull();
+        reloaded.DeletedBySubjectId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Insert_Binding_WithUnknownPolicyVersionId_ThrowsDbUpdateException()
+    {
+        await using var db = new AppDbContext(NewOptions());
+        await db.Database.MigrateAsync();
+
+        db.Bindings.Add(new Binding
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = Guid.NewGuid(),  // never seeded
+            TargetType = BindingTargetType.Template,
+            TargetRef = "template:00000000-0000-0000-0000-000000000000",
+            CreatedBySubjectId = "test",
+        });
+
+        var act = async () => await db.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    [Fact]
+    public async Task SoftDelete_StampsDeletedAtAndDeletedBy_WithoutLosingRow()
+    {
+        await using var db = new AppDbContext(NewOptions());
+        await db.Database.MigrateAsync();
+        var (_, versionId) = await SeedPolicyAndDraftAsync(db);
+
+        var binding = new Binding
+        {
+            PolicyVersionId = versionId,
+            TargetType = BindingTargetType.Tenant,
+            TargetRef = $"tenant:{Guid.NewGuid()}",
+            CreatedBySubjectId = "sam",
+        };
+        db.Bindings.Add(binding);
+        await db.SaveChangesAsync();
+
+        // P3.2 service implementation will do this; here we just exercise
+        // the column shape so future writes can rely on it.
+        binding.DeletedAt = DateTimeOffset.UtcNow;
+        binding.DeletedBySubjectId = "sam";
+        await db.SaveChangesAsync();
+
+        var reloaded = await db.Bindings.AsNoTracking().FirstAsync(b => b.Id == binding.Id);
+        reloaded.DeletedAt.Should().NotBeNull();
+        reloaded.DeletedBySubjectId.Should().Be("sam");
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Domain/BindingTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Domain/BindingTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Domain;
+
+/// <summary>
+/// P3.1 (#19) acceptance for the <see cref="Binding"/> entity. Locks down
+/// the default-field initialisers, the persisted-ordinal stability of
+/// <see cref="BindingTargetType"/> and <see cref="BindStrength"/> (existing
+/// rows on disk depend on these numerics), and the soft-delete tombstone
+/// shape.
+/// </summary>
+public class BindingTests
+{
+    [Fact]
+    public void New_Binding_HasNonEmptyId()
+    {
+        var binding = new Binding();
+
+        binding.Id.Should().NotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public void New_Binding_HasUtcCreatedAt()
+    {
+        var before = DateTimeOffset.UtcNow.AddSeconds(-1);
+        var binding = new Binding();
+        var after = DateTimeOffset.UtcNow.AddSeconds(1);
+
+        binding.CreatedAt.Should().BeOnOrAfter(before);
+        binding.CreatedAt.Should().BeOnOrBefore(after);
+        binding.CreatedAt.Offset.Should().Be(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void New_Binding_DefaultsBindStrengthToRecommended()
+    {
+        var binding = new Binding();
+
+        binding.BindStrength.Should().Be(BindStrength.Recommended);
+    }
+
+    [Fact]
+    public void New_Binding_HasNullDeletedAtAndDeletedBy()
+    {
+        var binding = new Binding();
+
+        binding.DeletedAt.Should().BeNull();
+        binding.DeletedBySubjectId.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(BindingTargetType.Template, 1)]
+    [InlineData(BindingTargetType.Repo, 2)]
+    [InlineData(BindingTargetType.ScopeNode, 3)]
+    [InlineData(BindingTargetType.Tenant, 4)]
+    [InlineData(BindingTargetType.Org, 5)]
+    public void BindingTargetType_HasStablePersistedOrdinal(BindingTargetType value, int expected)
+    {
+        // EF persists via HasConversion<int>; renaming the enum members is
+        // safe but reordering them would silently corrupt every row on disk.
+        ((int)value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(BindStrength.Mandatory, 1)]
+    [InlineData(BindStrength.Recommended, 2)]
+    public void BindStrength_HasStablePersistedOrdinal(BindStrength value, int expected)
+    {
+        ((int)value).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Summary

Lays down the third governance-catalog entity: the `Binding` — metadata that links a specific immutable `PolicyVersion` to a target (template, repo, scope node, tenant, org) with a bind-strength.

**Domain:**
- `BindingTargetType` enum (`Template=1`, `Repo=2`, `ScopeNode=3`, `Tenant=4`, `Org=5`) — ordinals are load-bearing on disk via `HasConversion<int>`.
- `BindStrength` enum (`Mandatory=1`, `Recommended=2`).
- `Binding` entity with `PolicyVersionId` FK (Restrict on delete), `TargetType`, `TargetRef` (capped at 512 chars; canonical shapes documented in XML doc), `BindStrength` (defaults `Recommended`), `CreatedAt/By`, and soft-delete tombstone fields so P6's audit chain has an append-only history.

**Infrastructure:**
- `DbSet<Binding>` on `AppDbContext`.
- `OnModelCreating` registers the table, FK, and three indexes:
  - `ix_bindings_target` (composite `TargetType, TargetRef`) — every target-side lookup in P3.3, P3.4, P4 hierarchy walks.
  - `ix_bindings_policy_version` — version-side reads.
  - `ix_bindings_deleted_at` — active-only filtering.
- `AddBindings` EF migration (PostgreSQL + SQLite).

Bindings are **metadata only** — `TargetRef` is opaque; andy-policies never resolves it against the foreign system (Epic P3 firewall).

Surface mutations and the four parity surfaces land in P3.2–P3.7.

Closes #19.

## Test plan
- [x] `dotnet test` — 167 unit + 156 integration pass; 6 E2E skipped (`E2E_ENABLED=0`).
- [x] `BindingTests` (unit, +6): default-field initialisers, enum ordinal stability via `[Theory]`.
- [x] `BindingMigrationTests` (integration, +4): migration applies on SQLite, three indexes physically present, FK Restrict throws on unknown `PolicyVersionId`, soft-delete column shape round-trips.
- [x] `SqliteMigrationTests` extended to assert the `bindings` table + `AddBindings` migration apply.
- [x] EF migration generated cleanly with proper `Restrict` FK action and three composite/single-column indexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)