### PR TITLE
Implement P3.2 — IBindingService + BindingService with retired-version refusal + soft-delete

### DIFF
--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -96,6 +96,12 @@ builder.Services.AddAndySettingsClient(builder.Configuration);
 // --- Services ---
 builder.Services.AddScoped<IItemService, ItemService>();
 builder.Services.AddScoped<IPolicyService, PolicyService>();
+builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBindingService, Andy.Policies.Infrastructure.Services.BindingService>();
+// P3.2 (#20): Binding mutations call IAuditWriter — Epic P6
+// (rivoli-ai/andy-policies#6) replaces the no-op with the real
+// hash-chained writer. Singleton because the P6 implementation will own a
+// content-addressed sequence pointer.
+builder.Services.AddSingleton<Andy.Policies.Application.Interfaces.IAuditWriter, Andy.Policies.Infrastructure.Services.NoopAuditWriter>();
 builder.Services.AddScoped<Andy.Policies.Application.Interfaces.ILifecycleTransitionService, Andy.Policies.Infrastructure.Services.LifecycleTransitionService>();
 // P2.4 (#14): the rationale policy reads andy.policies.rationaleRequired from
 // the andy-settings snapshot on every check (fail-safe to required=true if the

--- a/src/Andy.Policies.Application/Dtos/BindingDto.cs
+++ b/src/Andy.Policies.Application/Dtos/BindingDto.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Domain.Enums;
+
+namespace Andy.Policies.Application.Dtos;
+
+/// <summary>
+/// Wire-format projection of a <c>Binding</c> (P3.2, story
+/// rivoli-ai/andy-policies#20). Surface controllers (REST, MCP, gRPC, CLI)
+/// emit this shape directly so wire behavior stays uniform.
+/// <see cref="DeletedAt"/> is non-null when the binding has been
+/// soft-deleted; service-layer reads filter tombstoned rows by default.
+/// </summary>
+public sealed record BindingDto(
+    Guid Id,
+    Guid PolicyVersionId,
+    BindingTargetType TargetType,
+    string TargetRef,
+    BindStrength BindStrength,
+    DateTimeOffset CreatedAt,
+    string CreatedBySubjectId,
+    DateTimeOffset? DeletedAt,
+    string? DeletedBySubjectId);

--- a/src/Andy.Policies.Application/Dtos/CreateBindingRequest.cs
+++ b/src/Andy.Policies.Application/Dtos/CreateBindingRequest.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Domain.Enums;
+
+namespace Andy.Policies.Application.Dtos;
+
+/// <summary>
+/// Request payload for <c>IBindingService.CreateAsync</c> (P3.2, story
+/// rivoli-ai/andy-policies#20). The target version must exist and not be in
+/// <c>LifecycleState.Retired</c>; the service throws
+/// <c>BindingRetiredVersionException</c> on a retired target.
+/// </summary>
+public sealed record CreateBindingRequest(
+    Guid PolicyVersionId,
+    BindingTargetType TargetType,
+    string TargetRef,
+    BindStrength BindStrength);

--- a/src/Andy.Policies.Application/Exceptions/BindingRetiredVersionException.cs
+++ b/src/Andy.Policies.Application/Exceptions/BindingRetiredVersionException.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.Exceptions;
+
+/// <summary>
+/// Thrown by <c>IBindingService.CreateAsync</c> when the target
+/// <c>PolicyVersion</c> is in <c>LifecycleState.Retired</c> (P3.2, story
+/// rivoli-ai/andy-policies#20). API layer maps to HTTP 409 Conflict; gRPC
+/// to <c>FailedPrecondition</c>. Active and WindingDown versions are
+/// bindable — only Retired refuses new bindings.
+/// </summary>
+public sealed class BindingRetiredVersionException : ConflictException
+{
+    public Guid PolicyVersionId { get; }
+
+    public BindingRetiredVersionException(Guid policyVersionId)
+        : base($"Cannot create binding: PolicyVersion {policyVersionId} is Retired.")
+    {
+        PolicyVersionId = policyVersionId;
+    }
+}

--- a/src/Andy.Policies.Application/Exceptions/ConflictException.cs
+++ b/src/Andy.Policies.Application/Exceptions/ConflictException.cs
@@ -7,7 +7,7 @@ namespace Andy.Policies.Application.Exceptions;
 /// Thrown when a request would violate a uniqueness invariant (duplicate slug,
 /// concurrent open draft, etc.). API layer maps to HTTP 409 Conflict.
 /// </summary>
-public sealed class ConflictException : Exception
+public class ConflictException : Exception
 {
     public ConflictException(string message) : base(message) { }
 

--- a/src/Andy.Policies.Application/Interfaces/IAuditWriter.cs
+++ b/src/Andy.Policies.Application/Interfaces/IAuditWriter.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.Interfaces;
+
+/// <summary>
+/// Append-only audit writer hook (P3.2, story rivoli-ai/andy-policies#20).
+/// Per-mutation services call this to record an audit row; the real
+/// hash-chained implementation lands in Epic P6
+/// (rivoli-ai/andy-policies#6). A no-op implementation in Infrastructure
+/// keeps DI satisfied until then.
+/// </summary>
+public interface IAuditWriter
+{
+    /// <summary>
+    /// Append an audit envelope. <paramref name="action"/> is a stable
+    /// dotted identifier such as <c>"binding.created"</c> or
+    /// <c>"binding.deleted"</c>; <paramref name="entityId"/> is the row id
+    /// being mutated; <paramref name="rationale"/> is required by P6 for
+    /// transitions but optional for plain creates/deletes.
+    /// </summary>
+    Task AppendAsync(
+        string action,
+        Guid entityId,
+        string actorSubjectId,
+        string? rationale,
+        CancellationToken ct = default);
+}

--- a/src/Andy.Policies.Application/Interfaces/IBindingService.cs
+++ b/src/Andy.Policies.Application/Interfaces/IBindingService.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Domain.Enums;
+
+namespace Andy.Policies.Application.Interfaces;
+
+/// <summary>
+/// Application service for <c>Binding</c> mutation and query (P3.2, story
+/// rivoli-ai/andy-policies#20). REST (P3.3), MCP (P3.5), gRPC (P3.6), and
+/// CLI (P3.7) all delegate to this single interface — controllers and
+/// tools never duplicate validation, retired-version refusal, or
+/// soft-delete logic.
+/// </summary>
+public interface IBindingService
+{
+    /// <summary>
+    /// Create a new binding. Throws
+    /// <see cref="Exceptions.NotFoundException"/> when the target version
+    /// does not exist, <see cref="Exceptions.BindingRetiredVersionException"/>
+    /// when the target version is Retired, and
+    /// <see cref="Exceptions.ValidationException"/> on empty / oversized
+    /// <c>TargetRef</c>.
+    /// </summary>
+    Task<BindingDto> CreateAsync(
+        CreateBindingRequest request,
+        string actorSubjectId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Soft-delete the binding. Stamps <c>DeletedAt</c> and
+    /// <c>DeletedBySubjectId</c> rather than removing the row so P6's audit
+    /// chain has an append-only history. Throws
+    /// <see cref="Exceptions.NotFoundException"/> when the binding does not
+    /// exist or is already deleted.
+    /// </summary>
+    Task DeleteAsync(
+        Guid bindingId,
+        string actorSubjectId,
+        string? rationale,
+        CancellationToken ct = default);
+
+    /// <summary>Get a single binding by id, or <c>null</c> if not found.</summary>
+    Task<BindingDto?> GetAsync(Guid bindingId, CancellationToken ct = default);
+
+    /// <summary>
+    /// List all bindings against a given <c>PolicyVersion</c> ordered by
+    /// most-recently-created first. <paramref name="includeDeleted"/>
+    /// controls whether tombstoned rows are returned.
+    /// </summary>
+    Task<IReadOnlyList<BindingDto>> ListByPolicyVersionAsync(
+        Guid policyVersionId,
+        bool includeDeleted,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// List active (non-deleted) bindings for a given target, ordered by
+    /// most-recently-created first. Match is exact-equality on
+    /// <c>(TargetType, TargetRef)</c> — no prefix or case-folding —
+    /// because consumer-side resolution semantics rely on byte-exact match.
+    /// </summary>
+    Task<IReadOnlyList<BindingDto>> ListByTargetAsync(
+        BindingTargetType targetType,
+        string targetRef,
+        CancellationToken ct = default);
+}

--- a/src/Andy.Policies.Infrastructure/Services/BindingService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BindingService.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Exceptions;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Andy.Policies.Infrastructure.Services;
+
+/// <summary>
+/// Application-layer service for <c>Binding</c> mutation and query (P3.2,
+/// story rivoli-ai/andy-policies#20). All four parity surfaces (REST P3.3,
+/// MCP P3.5, gRPC P3.6, CLI P3.7) delegate here so retired-version
+/// refusal, soft-delete semantics, and target-side query shape stay
+/// uniform.
+/// </summary>
+public sealed class BindingService : IBindingService
+{
+    private const int MaxTargetRefLength = 512;
+
+    private readonly AppDbContext _db;
+    private readonly IAuditWriter _audit;
+    private readonly TimeProvider _clock;
+
+    public BindingService(AppDbContext db, IAuditWriter audit, TimeProvider clock)
+    {
+        _db = db;
+        _audit = audit;
+        _clock = clock;
+    }
+
+    public async Task<BindingDto> CreateAsync(
+        CreateBindingRequest request,
+        string actorSubjectId,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrEmpty(actorSubjectId);
+
+        var targetRef = (request.TargetRef ?? string.Empty).Trim();
+        if (string.IsNullOrEmpty(targetRef))
+        {
+            throw new ValidationException("TargetRef is required and may not be empty or whitespace.");
+        }
+        if (targetRef.Length > MaxTargetRefLength)
+        {
+            throw new ValidationException(
+                $"TargetRef length {targetRef.Length} exceeds the {MaxTargetRefLength}-char limit.");
+        }
+
+        // Reject bindings to a Retired version. Active and WindingDown are
+        // bindable — only Retired refuses (the P2 lifecycle guard for P3).
+        var version = await _db.PolicyVersions
+            .AsNoTracking()
+            .FirstOrDefaultAsync(v => v.Id == request.PolicyVersionId, ct)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException(
+                $"PolicyVersion {request.PolicyVersionId} not found.");
+        if (version.State == LifecycleState.Retired)
+        {
+            throw new BindingRetiredVersionException(version.Id);
+        }
+
+        var binding = new Binding
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = version.Id,
+            TargetType = request.TargetType,
+            TargetRef = targetRef,
+            BindStrength = request.BindStrength,
+            CreatedAt = _clock.GetUtcNow(),
+            CreatedBySubjectId = actorSubjectId,
+        };
+        _db.Bindings.Add(binding);
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        await _audit.AppendAsync(
+            "binding.created", binding.Id, actorSubjectId, rationale: null, ct)
+            .ConfigureAwait(false);
+
+        return ToDto(binding);
+    }
+
+    public async Task DeleteAsync(
+        Guid bindingId,
+        string actorSubjectId,
+        string? rationale,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(actorSubjectId);
+
+        var binding = await _db.Bindings
+            .FirstOrDefaultAsync(b => b.Id == bindingId, ct)
+            .ConfigureAwait(false);
+        if (binding is null || binding.DeletedAt is not null)
+        {
+            // Already-deleted is treated as not-found so callers can't
+            // distinguish "never existed" from "tombstoned" — both mean
+            // "no live binding by this id".
+            throw new NotFoundException($"Binding {bindingId} not found.");
+        }
+
+        binding.DeletedAt = _clock.GetUtcNow();
+        binding.DeletedBySubjectId = actorSubjectId;
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        await _audit.AppendAsync(
+            "binding.deleted", binding.Id, actorSubjectId, rationale, ct)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<BindingDto?> GetAsync(Guid bindingId, CancellationToken ct = default)
+    {
+        var binding = await _db.Bindings
+            .AsNoTracking()
+            .FirstOrDefaultAsync(b => b.Id == bindingId, ct)
+            .ConfigureAwait(false);
+        return binding is null ? null : ToDto(binding);
+    }
+
+    public async Task<IReadOnlyList<BindingDto>> ListByPolicyVersionAsync(
+        Guid policyVersionId,
+        bool includeDeleted,
+        CancellationToken ct = default)
+    {
+        var query = _db.Bindings
+            .AsNoTracking()
+            .Where(b => b.PolicyVersionId == policyVersionId);
+        if (!includeDeleted)
+        {
+            query = query.Where(b => b.DeletedAt == null);
+        }
+        var rows = await query
+            .OrderByDescending(b => b.CreatedAt)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+        return rows.Select(ToDto).ToList();
+    }
+
+    public async Task<IReadOnlyList<BindingDto>> ListByTargetAsync(
+        BindingTargetType targetType,
+        string targetRef,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(targetRef);
+
+        // Exact-equality match — consumer resolution semantics in P3.4
+        // (resolve) and P4 (hierarchy walk) require byte-exact (TargetType,
+        // TargetRef) lookups. No prefix / case-folding here.
+        var rows = await _db.Bindings
+            .AsNoTracking()
+            .Where(b => b.TargetType == targetType
+                        && b.TargetRef == targetRef
+                        && b.DeletedAt == null)
+            .OrderByDescending(b => b.CreatedAt)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+        return rows.Select(ToDto).ToList();
+    }
+
+    private static BindingDto ToDto(Binding b) => new(
+        b.Id,
+        b.PolicyVersionId,
+        b.TargetType,
+        b.TargetRef,
+        b.BindStrength,
+        b.CreatedAt,
+        b.CreatedBySubjectId,
+        b.DeletedAt,
+        b.DeletedBySubjectId);
+}

--- a/src/Andy.Policies.Infrastructure/Services/NoopAuditWriter.cs
+++ b/src/Andy.Policies.Infrastructure/Services/NoopAuditWriter.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Policies.Infrastructure.Services;
+
+/// <summary>
+/// Placeholder <see cref="IAuditWriter"/> until Epic P6 (audit hash chain,
+/// rivoli-ai/andy-policies#6) replaces it with the real DB-backed
+/// implementation. Logs each call at <c>Debug</c> so operators can confirm
+/// the call sites are wired correctly even before P6 lands.
+/// </summary>
+public sealed class NoopAuditWriter : IAuditWriter
+{
+    private readonly ILogger<NoopAuditWriter> _log;
+
+    public NoopAuditWriter(ILogger<NoopAuditWriter> log)
+    {
+        _log = log;
+    }
+
+    public Task AppendAsync(
+        string action,
+        Guid entityId,
+        string actorSubjectId,
+        string? rationale,
+        CancellationToken ct = default)
+    {
+        _log.LogDebug(
+            "Audit (no-op until P6): action={Action} entity={EntityId} actor={Actor} rationale={Rationale}",
+            action, entityId, actorSubjectId, rationale ?? "(none)");
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Services/BindingServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/BindingServiceTests.cs
@@ -1,0 +1,246 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Exceptions;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Infrastructure.Services;
+using Andy.Policies.Tests.Unit.Fixtures;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Services;
+
+/// <summary>
+/// Unit tests for <see cref="BindingService"/> (P3.2, story
+/// rivoli-ai/andy-policies#20). Drives the service over EF Core InMemory
+/// to lock down: retired-version refusal, validation of <c>TargetRef</c>
+/// length and emptiness, soft-delete tombstone shape, target-side query
+/// case-sensitivity, and the audit-writer call sites.
+/// </summary>
+public class BindingServiceTests
+{
+    private sealed class RecordingAuditWriter : IAuditWriter
+    {
+        public List<(string Action, Guid EntityId, string Actor, string? Rationale)> Calls { get; } = new();
+
+        public Task AppendAsync(string action, Guid entityId, string actorSubjectId, string? rationale, CancellationToken ct = default)
+        {
+            Calls.Add((action, entityId, actorSubjectId, rationale));
+            return Task.CompletedTask;
+        }
+    }
+
+    private static (BindingService service, AppDbContext db, RecordingAuditWriter audit) NewService()
+    {
+        var db = InMemoryDbFixture.Create();
+        var audit = new RecordingAuditWriter();
+        var service = new BindingService(db, audit, TimeProvider.System);
+        return (service, db, audit);
+    }
+
+    private static async Task<PolicyVersion> SeedVersionAsync(AppDbContext db, LifecycleState state)
+    {
+        var policy = PolicyBuilders.APolicy(name: $"binding-{Guid.NewGuid():N}".Substring(0, 16));
+        var version = PolicyBuilders.AVersion(policy.Id, number: 1, state: state);
+        db.Policies.Add(policy);
+        db.PolicyVersions.Add(version);
+        await db.SaveChangesAsync();
+        return version;
+    }
+
+    private static CreateBindingRequest MinimalRequest(Guid versionId, string targetRef = "repo:rivoli-ai/andy-policies")
+        => new(versionId, BindingTargetType.Repo, targetRef, BindStrength.Mandatory);
+
+    [Fact]
+    public async Task CreateAsync_OnDraftVersion_Succeeds_AndRecordsAudit()
+    {
+        var (svc, db, audit) = NewService();
+        var version = await SeedVersionAsync(db, LifecycleState.Draft);
+
+        var dto = await svc.CreateAsync(MinimalRequest(version.Id), "sam");
+
+        dto.PolicyVersionId.Should().Be(version.Id);
+        dto.TargetType.Should().Be(BindingTargetType.Repo);
+        dto.TargetRef.Should().Be("repo:rivoli-ai/andy-policies");
+        dto.BindStrength.Should().Be(BindStrength.Mandatory);
+        dto.CreatedBySubjectId.Should().Be("sam");
+        dto.DeletedAt.Should().BeNull();
+
+        audit.Calls.Should().ContainSingle()
+            .Which.Should().Match<(string Action, Guid EntityId, string Actor, string? Rationale)>(c =>
+                c.Action == "binding.created" && c.EntityId == dto.Id && c.Actor == "sam");
+    }
+
+    [Theory]
+    [InlineData(LifecycleState.Active)]
+    [InlineData(LifecycleState.WindingDown)]
+    public async Task CreateAsync_OnActiveOrWindingDownVersion_Succeeds(LifecycleState state)
+    {
+        // Only Retired refuses new bindings — Active and WindingDown both
+        // accept binds (Active is the dominant case; WindingDown is allowed
+        // so consumers can still author bindings during a sunset window).
+        var (svc, db, _) = NewService();
+        var version = await SeedVersionAsync(db, state);
+
+        var dto = await svc.CreateAsync(MinimalRequest(version.Id), "sam");
+
+        dto.PolicyVersionId.Should().Be(version.Id);
+    }
+
+    [Fact]
+    public async Task CreateAsync_OnRetiredVersion_ThrowsBindingRetiredVersionException()
+    {
+        var (svc, db, audit) = NewService();
+        var version = await SeedVersionAsync(db, LifecycleState.Retired);
+
+        var act = async () => await svc.CreateAsync(MinimalRequest(version.Id), "sam");
+
+        var thrown = await act.Should().ThrowAsync<BindingRetiredVersionException>();
+        thrown.Which.PolicyVersionId.Should().Be(version.Id);
+        audit.Calls.Should().BeEmpty("no audit row when the create failed validation");
+    }
+
+    [Fact]
+    public async Task CreateAsync_OnUnknownVersionId_ThrowsNotFound()
+    {
+        var (svc, _, _) = NewService();
+
+        var act = async () => await svc.CreateAsync(MinimalRequest(Guid.NewGuid()), "sam");
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t \n")]
+    public async Task CreateAsync_WithEmptyOrWhitespaceTargetRef_ThrowsValidation(string ref_)
+    {
+        var (svc, db, _) = NewService();
+        var version = await SeedVersionAsync(db, LifecycleState.Draft);
+
+        var act = async () => await svc.CreateAsync(MinimalRequest(version.Id, ref_), "sam");
+
+        await act.Should().ThrowAsync<ValidationException>();
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithOversizedTargetRef_ThrowsValidation()
+    {
+        var (svc, db, _) = NewService();
+        var version = await SeedVersionAsync(db, LifecycleState.Draft);
+        var oversized = new string('a', 513);
+
+        var act = async () => await svc.CreateAsync(MinimalRequest(version.Id, oversized), "sam");
+
+        await act.Should().ThrowAsync<ValidationException>()
+            .WithMessage("*512*");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_StampsTombstoneAndRecordsAudit()
+    {
+        var (svc, db, audit) = NewService();
+        var version = await SeedVersionAsync(db, LifecycleState.Active);
+        var binding = await svc.CreateAsync(MinimalRequest(version.Id), "sam");
+        audit.Calls.Clear();
+
+        await svc.DeleteAsync(binding.Id, "sam", rationale: "no longer applies");
+
+        var reloaded = await db.Bindings.AsNoTracking().FirstAsync(b => b.Id == binding.Id);
+        reloaded.DeletedAt.Should().NotBeNull();
+        reloaded.DeletedBySubjectId.Should().Be("sam");
+
+        audit.Calls.Should().ContainSingle()
+            .Which.Should().Match<(string Action, Guid EntityId, string Actor, string? Rationale)>(c =>
+                c.Action == "binding.deleted" && c.EntityId == binding.Id
+                && c.Actor == "sam" && c.Rationale == "no longer applies");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_OnAlreadyDeletedBinding_ThrowsNotFound()
+    {
+        var (svc, db, _) = NewService();
+        var version = await SeedVersionAsync(db, LifecycleState.Active);
+        var binding = await svc.CreateAsync(MinimalRequest(version.Id), "sam");
+        await svc.DeleteAsync(binding.Id, "sam", rationale: null);
+
+        var act = async () => await svc.DeleteAsync(binding.Id, "sam", rationale: null);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_OnUnknownId_ThrowsNotFound()
+    {
+        var (svc, _, _) = NewService();
+
+        var act = async () => await svc.DeleteAsync(Guid.NewGuid(), "sam", rationale: null);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task ListByPolicyVersionAsync_ExcludesTombstonedRows_WhenIncludeDeletedFalse()
+    {
+        var (svc, db, _) = NewService();
+        var version = await SeedVersionAsync(db, LifecycleState.Active);
+        var alive = await svc.CreateAsync(MinimalRequest(version.Id, "repo:a/b"), "sam");
+        var dead  = await svc.CreateAsync(MinimalRequest(version.Id, "repo:c/d"), "sam");
+        await svc.DeleteAsync(dead.Id, "sam", rationale: null);
+
+        var visible = await svc.ListByPolicyVersionAsync(version.Id, includeDeleted: false);
+        visible.Should().ContainSingle().Which.Id.Should().Be(alive.Id);
+
+        var all = await svc.ListByPolicyVersionAsync(version.Id, includeDeleted: true);
+        all.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ListByTargetAsync_ExactMatchOnly_NoCaseFolding()
+    {
+        var (svc, db, _) = NewService();
+        var version = await SeedVersionAsync(db, LifecycleState.Active);
+        await svc.CreateAsync(
+            new CreateBindingRequest(version.Id, BindingTargetType.Repo, "repo:rivoli-ai/policy-x", BindStrength.Recommended),
+            "sam");
+        await svc.CreateAsync(
+            new CreateBindingRequest(version.Id, BindingTargetType.Repo, "repo:RIVOLI-AI/POLICY-X", BindStrength.Recommended),
+            "sam");
+
+        var lower = await svc.ListByTargetAsync(BindingTargetType.Repo, "repo:rivoli-ai/policy-x");
+        var upper = await svc.ListByTargetAsync(BindingTargetType.Repo, "repo:RIVOLI-AI/POLICY-X");
+
+        lower.Should().ContainSingle().Which.TargetRef.Should().Be("repo:rivoli-ai/policy-x");
+        upper.Should().ContainSingle().Which.TargetRef.Should().Be("repo:RIVOLI-AI/POLICY-X");
+    }
+
+    [Fact]
+    public async Task ListByTargetAsync_FiltersOutDeletedBindings()
+    {
+        var (svc, db, _) = NewService();
+        var version = await SeedVersionAsync(db, LifecycleState.Active);
+        var alive = await svc.CreateAsync(MinimalRequest(version.Id, "tenant:abc"), "sam");
+        var dead  = await svc.CreateAsync(MinimalRequest(version.Id, "tenant:abc"), "sam");
+        await svc.DeleteAsync(dead.Id, "sam", rationale: null);
+
+        var results = await svc.ListByTargetAsync(BindingTargetType.Repo, "tenant:abc");
+
+        results.Should().ContainSingle().Which.Id.Should().Be(alive.Id);
+    }
+
+    [Fact]
+    public async Task GetAsync_ReturnsNullForUnknownId()
+    {
+        var (svc, _, _) = NewService();
+
+        var dto = await svc.GetAsync(Guid.NewGuid());
+
+        dto.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Adds the application-layer service for `Binding` mutation and query. All four parity surfaces — REST (P3.3), MCP (P3.5), gRPC (P3.6), CLI (P3.7) — will delegate here, so retired-version refusal, soft-delete semantics, and target-side query shape stay uniform.

**Application layer:**
- `BindingDto`, `CreateBindingRequest`.
- `IBindingService` with five methods: `CreateAsync`, `DeleteAsync`, `GetAsync`, `ListByPolicyVersionAsync`, `ListByTargetAsync`.
- `BindingRetiredVersionException` (subclass of `ConflictException` → 409).
- `IAuditWriter` hook so `Binding` mutations record audit rows; the real hash-chained implementation lands in Epic P6 (#6).

**Infrastructure:**
- `BindingService` validates `TargetRef` (non-empty, ≤512 chars), refuses bindings to Retired versions (Active and WindingDown both bind), inserts via the existing `ix_bindings_target` / `ix_bindings_policy_version` indexes (P3.1), and emits `IAuditWriter` calls on every create/delete.
- `DeleteAsync` soft-deletes (`DeletedAt` + `DeletedBySubjectId`) instead of removing the row so P6's audit chain has an append-only history.
- `NoopAuditWriter` placeholder until P6 lands; logs at Debug so operators can see call sites are wired correctly.
- Made `ConflictException` non-sealed so `BindingRetiredVersionException` can derive from it (same pattern as `ValidationException` + `RationaleRequiredException` from P2.4).

Closes #20.

## Test plan
- [x] `dotnet test` — 183 unit + 156 integration pass; 6 E2E skipped (`E2E_ENABLED=0`).
- [x] 16 new tests in `BindingServiceTests`: retired-version refusal, Active/WindingDown both bind, empty/whitespace/oversized `TargetRef` validation, soft-delete tombstone shape, double-delete returns 404, target-side query is exact-match only (no case-folding), tombstone exclusion in `ListByPolicyVersionAsync` / `ListByTargetAsync`, audit-writer call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)