### PR TITLE
Implement P3.3 — REST binding endpoints (create, delete, get, list-by-version, query-by-target)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,28 @@ invariant, the auto-supersede atomicity argument, and surface parity table
 serializable transactions, in-process events), see [ADR 0002 — Lifecycle
 states](docs/adr/0002-lifecycle-states.md).
 
+### Binding endpoints
+
+REST surface for `Binding` mutation, single-id read, and target-side query
+(P3.3, [#21](https://github.com/rivoli-ai/andy-policies/issues/21)).
+Bindings are metadata-only links between an immutable `PolicyVersion` and
+a foreign target (template, repo, scope node, tenant, org); andy-policies
+never resolves the target against the foreign system.
+
+```http
+POST   /api/bindings                                              # create
+GET    /api/bindings/{id}                                          # read
+DELETE /api/bindings/{id}?rationale=...                            # soft-delete
+GET    /api/bindings?targetType=Repo&targetRef=repo:org/name       # exact-match query
+GET    /api/policies/{id}/versions/{vId}/bindings?includeDeleted=  # version-rooted list
+```
+
+Create returns 201 with `Location: /api/bindings/{id}`. Bindings to a
+`Retired` version are refused with 409 (P3.2 service contract). Delete is
+soft — the row stays for the audit chain (P6); a second delete returns
+404. Target-side query is exact-equality on `(targetType, targetRef)`,
+no case-folding.
+
 ## Ports
 
 Per the ecosystem registry at [`../andy-service-template/docs/ports.md`](../andy-service-template/docs/ports.md). Three deployment modes; the same host can run any combination because each mode uses a distinct port range.

--- a/docs/openapi/andy-policies-v1.yaml
+++ b/docs/openapi/andy-policies-v1.yaml
@@ -18,6 +18,140 @@ paths:
       responses:
         '200':
           description: OK
+  /api/bindings:
+    post:
+      tags:
+        - Bindings
+      summary: "Create a new binding. Body: Andy.Policies.Application.Dtos.CreateBindingRequest.\r\nReturns 201 with a `Location` header pointing at the new\r\nresource. Refuses bindings to Retired versions with 409 Conflict;\r\nmissing target version returns 404; oversized/empty\r\n`targetRef` returns 400."
+      operationId: Bindings_Create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateBindingRequest'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/CreateBindingRequest'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/CreateBindingRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BindingDto'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+    get:
+      tags:
+        - Bindings
+      summary: "List active bindings for a target — exact-equality match on\r\n`(targetType, targetRef)`, no prefix or case-folding (P3.2\r\nservice contract). Tombstoned bindings are excluded; a separate\r\nversion-rooted endpoint is available for inspection of deleted\r\nrows."
+      operationId: Bindings_Query
+      parameters:
+        - name: targetType
+          in: query
+          schema:
+            $ref: '#/components/schemas/BindingTargetType'
+        - name: targetRef
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BindingDto'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+  '/api/bindings/{id}':
+    get:
+      tags:
+        - Bindings
+      summary: "Get a single binding by id. Returns 404 if the binding does not\r\nexist; tombstoned bindings are still visible here so audit\r\ninvestigators can inspect their `DeletedAt` stamp."
+      operationId: Bindings_Get
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BindingDto'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+    delete:
+      tags:
+        - Bindings
+      summary: "Soft-delete a binding. Returns 204 on success; calling delete on an\r\nalready-tombstoned binding returns 404 (the row is treated as\r\nnot-found). Accepts optional `?rationale=...` propagated to\r\nthe audit record."
+      operationId: Bindings_Delete
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: rationale
+          in: query
+          schema:
+            type: string
+      responses:
+        '204':
+          description: No Content
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
   /api/Help/topics:
     get:
       tags:
@@ -512,6 +646,38 @@ paths:
             text/json:
               schema:
                 $ref: '#/components/schemas/PolicyVersionDto'
+  '/api/policies/{policyId}/versions/{versionId}/bindings':
+    get:
+      tags:
+        - PolicyVersionBindings
+      summary: "List bindings against the given `PolicyVersion`, ordered by\r\nmost-recently-created first. `?includeDeleted=true` includes\r\ntombstoned rows; default `false` hides them."
+      operationId: PolicyVersionBindings_List
+      parameters:
+        - name: policyId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: versionId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: includeDeleted
+          in: query
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BindingDto'
   '/api/policies/{id}/versions/{versionId}/publish':
     post:
       tags:
@@ -697,6 +863,65 @@ paths:
                 $ref: '#/components/schemas/ProblemDetails'
 components:
   schemas:
+    BindStrength:
+      enum:
+        - Mandatory
+        - Recommended
+      type: string
+    BindingDto:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        policyVersionId:
+          type: string
+          format: uuid
+        targetType:
+          $ref: '#/components/schemas/BindingTargetType'
+        targetRef:
+          type: string
+          nullable: true
+        bindStrength:
+          $ref: '#/components/schemas/BindStrength'
+        createdAt:
+          type: string
+          format: date-time
+        createdBySubjectId:
+          type: string
+          nullable: true
+        deletedAt:
+          type: string
+          format: date-time
+          nullable: true
+        deletedBySubjectId:
+          type: string
+          nullable: true
+      additionalProperties: false
+      description: "Wire-format projection of a `Binding` (P3.2, story\r\nrivoli-ai/andy-policies#20). Surface controllers (REST, MCP, gRPC, CLI)\r\nemit this shape directly so wire behavior stays uniform.\r\nAndy.Policies.Application.Dtos.BindingDto.DeletedAt is non-null when the binding has been\r\nsoft-deleted; service-layer reads filter tombstoned rows by default."
+    BindingTargetType:
+      enum:
+        - Template
+        - Repo
+        - ScopeNode
+        - Tenant
+        - Org
+      type: string
+    CreateBindingRequest:
+      type: object
+      properties:
+        policyVersionId:
+          type: string
+          format: uuid
+        targetType:
+          $ref: '#/components/schemas/BindingTargetType'
+        targetRef:
+          type: string
+          nullable: true
+        bindStrength:
+          $ref: '#/components/schemas/BindStrength'
+      additionalProperties: false
+      description: "Request payload for `IBindingService.CreateAsync` (P3.2, story\r\nrivoli-ai/andy-policies#20). The target version must exist and not be in\r\n`LifecycleState.Retired`; the service throws\r\n`BindingRetiredVersionException` on a retired target."
     CreateItemRequest:
       type: object
       properties:
@@ -958,9 +1183,13 @@ components:
 security:
   - Bearer: [ ]
 tags:
+  - name: Bindings
+    description: "REST surface for `Binding` mutation, single-id read, and target-side\r\nquery (P3.3, story rivoli-ai/andy-policies#21). Delegates to\r\nAndy.Policies.Application.Interfaces.IBindingService from P3.2 — same service powering MCP\r\n(P3.5), gRPC (P3.6), and CLI (P3.7). Service exceptions are mapped by\r\nthe global `PolicyExceptionHandler` (already covers\r\nAndy.Policies.Application.Exceptions.NotFoundException,\r\nAndy.Policies.Application.Exceptions.ConflictException, and\r\nAndy.Policies.Application.Exceptions.ValidationException; the\r\nAndy.Policies.Application.Exceptions.BindingRetiredVersionException\r\ninherits from Andy.Policies.Application.Exceptions.ConflictException so\r\nthe existing 409 mapping catches it)."
   - name: Help
     description: "Serves help content from markdown files in content/help/.\r\nConsumable by any client: Angular, Swift (Conductor), CLI, MCP."
   - name: Policies
     description: "REST surface for the policy catalog (P1.5, story rivoli-ai/andy-policies#75).\r\nAll endpoints delegate to Andy.Policies.Application.Interfaces.IPolicyService; service exceptions are\r\nmapped to status codes by `PolicyExceptionHandler` (registered globally)."
+  - name: PolicyVersionBindings
+    description: "Version-rooted enumeration of `Binding`s (P3.3, story\r\nrivoli-ai/andy-policies#21). Sits next to the version resource so\r\nHATEOAS-style clients can discover bindings without a separate\r\nquery. Delegates to Andy.Policies.Application.Interfaces.IBindingService; the controller is\r\npurely a wire-format adapter."
   - name: PolicyVersionsLifecycle
     description: "REST surface for lifecycle transitions on a `PolicyVersion` (P2.3, story\r\nrivoli-ai/andy-policies#13). Three action-shaped endpoints — `publish`,\r\n`winding-down`, `retire` — sit on top of\r\nAndy.Policies.Application.Interfaces.ILifecycleTransitionService. Auto-supersede of the previous\r\nActive happens inside the service's serializable transaction; the controller\r\nis a thin wire-format adapter and never re-implements state-machine logic.\r\nService exceptions map to status codes via `PolicyExceptionHandler`:\r\nAndy.Policies.Application.Exceptions.ValidationException → 400 (rationale\r\nmissing), Andy.Policies.Application.Exceptions.NotFoundException → 404\r\n(unknown id), Andy.Policies.Application.Exceptions.InvalidLifecycleTransitionException\r\nand Andy.Policies.Application.Exceptions.ConcurrentPublishException → 409."

--- a/src/Andy.Policies.Api/Controllers/BindingsController.cs
+++ b/src/Andy.Policies.Api/Controllers/BindingsController.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Claims;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Enums;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Andy.Policies.Api.Controllers;
+
+/// <summary>
+/// REST surface for <c>Binding</c> mutation, single-id read, and target-side
+/// query (P3.3, story rivoli-ai/andy-policies#21). Delegates to
+/// <see cref="IBindingService"/> from P3.2 — same service powering MCP
+/// (P3.5), gRPC (P3.6), and CLI (P3.7). Service exceptions are mapped by
+/// the global <c>PolicyExceptionHandler</c> (already covers
+/// <see cref="Application.Exceptions.NotFoundException"/>,
+/// <see cref="Application.Exceptions.ConflictException"/>, and
+/// <see cref="Application.Exceptions.ValidationException"/>; the
+/// <see cref="Application.Exceptions.BindingRetiredVersionException"/>
+/// inherits from <see cref="Application.Exceptions.ConflictException"/> so
+/// the existing 409 mapping catches it).
+/// </summary>
+[ApiController]
+[Authorize]
+[Route("api/bindings")]
+[Produces("application/json")]
+public sealed class BindingsController : ControllerBase
+{
+    private readonly IBindingService _bindings;
+
+    public BindingsController(IBindingService bindings)
+    {
+        _bindings = bindings;
+    }
+
+    /// <summary>
+    /// Create a new binding. Body: <see cref="CreateBindingRequest"/>.
+    /// Returns 201 with a <c>Location</c> header pointing at the new
+    /// resource. Refuses bindings to Retired versions with 409 Conflict;
+    /// missing target version returns 404; oversized/empty
+    /// <c>targetRef</c> returns 400.
+    /// </summary>
+    [HttpPost]
+    [ProducesResponseType(typeof(BindingDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<BindingDto>> Create(
+        [FromBody] CreateBindingRequest request,
+        CancellationToken ct)
+    {
+        var actor = ResolveActor();
+        if (actor is null) return Unauthorized();
+
+        var dto = await _bindings.CreateAsync(request, actor, ct);
+        return CreatedAtAction(nameof(Get), new { id = dto.Id }, dto);
+    }
+
+    /// <summary>
+    /// Get a single binding by id. Returns 404 if the binding does not
+    /// exist; tombstoned bindings are still visible here so audit
+    /// investigators can inspect their <c>DeletedAt</c> stamp.
+    /// </summary>
+    [HttpGet("{id:guid}")]
+    [ProducesResponseType(typeof(BindingDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<BindingDto>> Get(Guid id, CancellationToken ct)
+    {
+        var dto = await _bindings.GetAsync(id, ct);
+        return dto is null ? NotFound() : Ok(dto);
+    }
+
+    /// <summary>
+    /// Soft-delete a binding. Returns 204 on success; calling delete on an
+    /// already-tombstoned binding returns 404 (the row is treated as
+    /// not-found). Accepts optional <c>?rationale=...</c> propagated to
+    /// the audit record.
+    /// </summary>
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Delete(
+        Guid id,
+        [FromQuery] string? rationale,
+        CancellationToken ct)
+    {
+        var actor = ResolveActor();
+        if (actor is null) return Unauthorized();
+
+        await _bindings.DeleteAsync(id, actor, rationale, ct);
+        return NoContent();
+    }
+
+    /// <summary>
+    /// List active bindings for a target — exact-equality match on
+    /// <c>(targetType, targetRef)</c>, no prefix or case-folding (P3.2
+    /// service contract). Tombstoned bindings are excluded; a separate
+    /// version-rooted endpoint is available for inspection of deleted
+    /// rows.
+    /// </summary>
+    [HttpGet("")]
+    [ProducesResponseType(typeof(IReadOnlyList<BindingDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<IReadOnlyList<BindingDto>>> Query(
+        [FromQuery] BindingTargetType targetType,
+        [FromQuery] string targetRef,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrEmpty(targetRef))
+        {
+            return ValidationProblem("targetRef query parameter is required.");
+        }
+        var results = await _bindings.ListByTargetAsync(targetType, targetRef, ct);
+        return Ok(results);
+    }
+
+    private string? ResolveActor()
+    {
+        // Mirrors the lifecycle controller's actor-fallback firewall (#13):
+        // never write a fallback subject id into the catalog. JwtBearer
+        // maps `sub` to NameIdentifier; TestAuthHandler sets the Name
+        // claim. If neither is present, [Authorize] should already have
+        // returned 401 — this is the belt to the framework's braces.
+        var sub = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? User.Identity?.Name;
+        return string.IsNullOrEmpty(sub) ? null : sub;
+    }
+}

--- a/src/Andy.Policies.Api/Controllers/PolicyVersionBindingsController.cs
+++ b/src/Andy.Policies.Api/Controllers/PolicyVersionBindingsController.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Andy.Policies.Api.Controllers;
+
+/// <summary>
+/// Version-rooted enumeration of <c>Binding</c>s (P3.3, story
+/// rivoli-ai/andy-policies#21). Sits next to the version resource so
+/// HATEOAS-style clients can discover bindings without a separate
+/// query. Delegates to <see cref="IBindingService"/>; the controller is
+/// purely a wire-format adapter.
+/// </summary>
+[ApiController]
+[Authorize]
+[Route("api/policies/{policyId:guid}/versions/{versionId:guid}/bindings")]
+[Produces("application/json")]
+public sealed class PolicyVersionBindingsController : ControllerBase
+{
+    private readonly IBindingService _bindings;
+
+    public PolicyVersionBindingsController(IBindingService bindings)
+    {
+        _bindings = bindings;
+    }
+
+    /// <summary>
+    /// List bindings against the given <c>PolicyVersion</c>, ordered by
+    /// most-recently-created first. <c>?includeDeleted=true</c> includes
+    /// tombstoned rows; default <c>false</c> hides them.
+    /// </summary>
+    [HttpGet("")]
+    [ProducesResponseType(typeof(IReadOnlyList<BindingDto>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IReadOnlyList<BindingDto>>> List(
+        Guid policyId,
+        Guid versionId,
+        [FromQuery] bool includeDeleted,
+        CancellationToken ct)
+    {
+        var results = await _bindings.ListByPolicyVersionAsync(versionId, includeDeleted, ct);
+        return Ok(results);
+    }
+}

--- a/src/Andy.Policies.Infrastructure/Services/BindingService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BindingService.cs
@@ -134,11 +134,18 @@ public sealed class BindingService : IBindingService
         {
             query = query.Where(b => b.DeletedAt == null);
         }
+        // SQLite does not support ORDER BY on DateTimeOffset (the binary
+        // form is opaque to the provider's collation), so we materialise
+        // and sort client-side. Result sets are bounded by the binding
+        // count for a single version (small in practice — a handful per
+        // version), so the cost is negligible compared to the round-trip.
         var rows = await query
-            .OrderByDescending(b => b.CreatedAt)
             .ToListAsync(ct)
             .ConfigureAwait(false);
-        return rows.Select(ToDto).ToList();
+        return rows
+            .OrderByDescending(b => b.CreatedAt)
+            .Select(ToDto)
+            .ToList();
     }
 
     public async Task<IReadOnlyList<BindingDto>> ListByTargetAsync(
@@ -150,16 +157,19 @@ public sealed class BindingService : IBindingService
 
         // Exact-equality match — consumer resolution semantics in P3.4
         // (resolve) and P4 (hierarchy walk) require byte-exact (TargetType,
-        // TargetRef) lookups. No prefix / case-folding here.
+        // TargetRef) lookups. No prefix / case-folding here. Client-side
+        // sort for SQLite parity (see ListByPolicyVersionAsync above).
         var rows = await _db.Bindings
             .AsNoTracking()
             .Where(b => b.TargetType == targetType
                         && b.TargetRef == targetRef
                         && b.DeletedAt == null)
-            .OrderByDescending(b => b.CreatedAt)
             .ToListAsync(ct)
             .ConfigureAwait(false);
-        return rows.Select(ToDto).ToList();
+        return rows
+            .OrderByDescending(b => b.CreatedAt)
+            .Select(ToDto)
+            .ToList();
     }
 
     private static BindingDto ToDto(Binding b) => new(

--- a/tests/Andy.Policies.Tests.Integration/Controllers/BindingsControllerTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/BindingsControllerTests.cs
@@ -1,0 +1,210 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Domain.Enums;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Controllers;
+
+/// <summary>
+/// Integration tests for the binding REST surface (P3.3, story
+/// rivoli-ai/andy-policies#21). Exercises every route end-to-end against
+/// the SQLite-backed factory: create round-trip, retired-version refusal,
+/// soft-delete tombstone semantics, exact-match target query, and the
+/// version-rooted enumeration.
+/// </summary>
+public class BindingsControllerTests : IClassFixture<PoliciesApiFactory>
+{
+    private readonly HttpClient _client;
+
+    /// <summary>
+    /// API serializes enums as strings via the global
+    /// <see cref="JsonStringEnumConverter"/> registered in Program.cs.
+    /// Tests need the same converter to deserialize <see cref="BindingDto"/>
+    /// back into <see cref="BindingTargetType"/> / <see cref="BindStrength"/>.
+    /// </summary>
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    public BindingsControllerTests(PoliciesApiFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    private static CreatePolicyRequest MinimalCreatePolicy(string name) => new(
+        Name: name,
+        Description: null,
+        Summary: "summary",
+        Enforcement: "Must",
+        Severity: "Critical",
+        Scopes: Array.Empty<string>(),
+        RulesJson: "{}");
+
+    private async Task<PolicyVersionDto> CreateDraftAsync(string slug)
+    {
+        var resp = await _client.PostAsJsonAsync("/api/policies", MinimalCreatePolicy(slug));
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
+    }
+
+    private async Task<PolicyVersionDto> PublishAsync(PolicyVersionDto draft)
+    {
+        var resp = await _client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
+            new LifecycleTransitionRequest("ship-it"));
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
+    }
+
+    private static CreateBindingRequest BindingFor(Guid versionId, string targetRef = "repo:rivoli-ai/policy-x")
+        => new(versionId, BindingTargetType.Repo, targetRef, BindStrength.Mandatory);
+
+    private static string Slug(string prefix) =>
+        $"{prefix}-{Guid.NewGuid():N}".Substring(0, 16);
+
+    private async Task<List<BindingDto>?> GetListAsync(string url)
+    {
+        var resp = await _client.GetAsync(url);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<List<BindingDto>>(JsonOptions);
+    }
+
+    [Fact]
+    public async Task Create_Returns201_WithLocationHeaderAndDto()
+    {
+        var draft = await CreateDraftAsync(Slug("bind-create"));
+
+        var resp = await _client.PostAsJsonAsync("/api/bindings", BindingFor(draft.Id));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+        resp.Headers.Location.Should().NotBeNull();
+        resp.Headers.Location!.AbsolutePath.Should().StartWith("/api/bindings/");
+
+        var dto = await resp.Content.ReadFromJsonAsync<BindingDto>(JsonOptions);
+        dto!.PolicyVersionId.Should().Be(draft.Id);
+        dto.TargetType.Should().Be(BindingTargetType.Repo);
+        dto.BindStrength.Should().Be(BindStrength.Mandatory);
+        dto.DeletedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Create_OnRetiredVersion_Returns409()
+    {
+        var draft = await CreateDraftAsync(Slug("bind-retired"));
+        var active = await PublishAsync(draft);
+        // Active -> Retired is a valid transition (emergency recall path).
+        var retire = await _client.PostAsJsonAsync(
+            $"/api/policies/{active.PolicyId}/versions/{active.Id}/retire",
+            new LifecycleTransitionRequest("recall"));
+        retire.EnsureSuccessStatusCode();
+
+        var resp = await _client.PostAsJsonAsync("/api/bindings", BindingFor(active.Id));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Create_OnUnknownVersion_Returns404()
+    {
+        var resp = await _client.PostAsJsonAsync(
+            "/api/bindings", BindingFor(Guid.NewGuid()));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Create_WithEmptyTargetRef_Returns400()
+    {
+        var draft = await CreateDraftAsync(Slug("bind-empty"));
+
+        var resp = await _client.PostAsJsonAsync(
+            "/api/bindings", BindingFor(draft.Id, targetRef: "  "));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Get_RoundTripsAfterCreate_AndReturns404ForUnknownId()
+    {
+        var draft = await CreateDraftAsync(Slug("bind-get"));
+        var created = await _client.PostAsJsonAsync("/api/bindings", BindingFor(draft.Id));
+        created.EnsureSuccessStatusCode();
+        var dto = (await created.Content.ReadFromJsonAsync<BindingDto>(JsonOptions))!;
+
+        var ok = await _client.GetAsync($"/api/bindings/{dto.Id}");
+        ok.StatusCode.Should().Be(HttpStatusCode.OK);
+        var reloaded = await ok.Content.ReadFromJsonAsync<BindingDto>(JsonOptions);
+        reloaded!.Id.Should().Be(dto.Id);
+
+        var missing = await _client.GetAsync($"/api/bindings/{Guid.NewGuid()}");
+        missing.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Delete_Returns204_AndSecondDeleteReturns404()
+    {
+        var draft = await CreateDraftAsync(Slug("bind-del"));
+        var created = await _client.PostAsJsonAsync("/api/bindings", BindingFor(draft.Id));
+        var dto = (await created.Content.ReadFromJsonAsync<BindingDto>(JsonOptions))!;
+
+        var first = await _client.DeleteAsync($"/api/bindings/{dto.Id}?rationale=no-longer-needed");
+        first.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Tombstoned rows are treated as not-found by the service contract.
+        var second = await _client.DeleteAsync($"/api/bindings/{dto.Id}");
+        second.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Query_ByTarget_ReturnsExactMatchOnly()
+    {
+        var draft = await CreateDraftAsync(Slug("bind-q"));
+        var lower = $"repo:rivoli-ai/q-{Guid.NewGuid():N}".Substring(0, 30);
+        var upper = lower.ToUpperInvariant();
+        await _client.PostAsJsonAsync("/api/bindings", BindingFor(draft.Id, lower));
+        await _client.PostAsJsonAsync("/api/bindings", BindingFor(draft.Id, upper));
+
+        var lowerResp = await GetListAsync(
+            $"/api/bindings?targetType=Repo&targetRef={Uri.EscapeDataString(lower)}");
+        lowerResp.Should().ContainSingle().Which.TargetRef.Should().Be(lower);
+
+        var upperResp = await GetListAsync(
+            $"/api/bindings?targetType=Repo&targetRef={Uri.EscapeDataString(upper)}");
+        upperResp.Should().ContainSingle().Which.TargetRef.Should().Be(upper);
+    }
+
+    [Fact]
+    public async Task Query_WithMissingTargetRef_Returns400()
+    {
+        var resp = await _client.GetAsync("/api/bindings?targetType=Repo");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ListByPolicyVersion_HonoursIncludeDeletedFlag()
+    {
+        var draft = await CreateDraftAsync(Slug("bind-list"));
+        var aliveResp = await _client.PostAsJsonAsync("/api/bindings", BindingFor(draft.Id, "repo:a/alive"));
+        var deadResp = await _client.PostAsJsonAsync("/api/bindings", BindingFor(draft.Id, "repo:a/dead"));
+        var dead = (await deadResp.Content.ReadFromJsonAsync<BindingDto>(JsonOptions))!;
+        await _client.DeleteAsync($"/api/bindings/{dead.Id}");
+
+        var visible = await GetListAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/bindings?includeDeleted=false");
+        visible.Should().ContainSingle();
+        visible![0].DeletedAt.Should().BeNull();
+
+        var all = await GetListAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/bindings?includeDeleted=true");
+        all.Should().HaveCount(2);
+    }
+}


### PR DESCRIPTION
## Summary

Two new controllers wire the binding REST surface on top of `IBindingService` (P3.2):

**`BindingsController`:**
- `POST /api/bindings` — 201 + `Location: /api/bindings/{id}`
- `GET /api/bindings/{id}` — 200 / 404 (tombstoned rows still visible for audit investigators)
- `DELETE /api/bindings/{id}?rationale=...` — 204 / 404 (soft-delete; second delete returns 404)
- `GET /api/bindings?targetType=&targetRef=` — exact-match list

**`PolicyVersionBindingsController`:**
- `GET /api/policies/{policyId}/versions/{versionId}/bindings?includeDeleted=<bool>` — version-rooted enumeration; `includeDeleted` controls whether tombstoned rows are returned.

All routes `[Authorize]`'d; mutating routes require a `NameIdentifier` or `Name` claim and short-circuit to 401 if neither is present (same actor-fallback firewall as P2.3 lifecycle and P3.2 service). Service exceptions (`NotFoundException`, `ConflictException` including `BindingRetiredVersionException`, `ValidationException`) are mapped by the existing `PolicyExceptionHandler` — no new mapping needed.

## Bonus fix
`BindingService.ListByPolicyVersionAsync` and `ListByTargetAsync` used to `ORDER BY` `DateTimeOffset`, which SQLite refuses (`NotSupportedException`: "SQLite does not support expressions of type 'DateTimeOffset' in ORDER BY clauses"). Now sorts client-side after materialisation. Result sets are bounded per version/target so the cost is negligible.

Closes #21.

## Test plan
- [x] `dotnet test` — 183 unit + 165 integration pass; 6 E2E skipped (`E2E_ENABLED=0`).
- [x] 9 new integration tests in `BindingsControllerTests`: 201 + Location round-trip, retired-version 409, unknown-version 404, empty-targetRef 400, get round-trip, double-delete returns 404, exact-match query (case-sensitive verification), missing-targetRef returns 400, `includeDeleted` flag honoured.
- [x] OpenAPI snapshot regenerated with the five new operations (+229 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)