### PR TITLE
Implement P3.4 — GET /api/bindings/resolve (exact-match, no hierarchy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,21 @@ soft — the row stays for the audit chain (P6); a second delete returns
 404. Target-side query is exact-equality on `(targetType, targetRef)`,
 no case-folding.
 
+#### Resolving bindings (exact match)
+
+```http
+GET /api/bindings/resolve?targetType=Template&targetRef=template:abc
+```
+
+`resolve` is the consumer-facing read for "what policies apply to this
+target?" (P3.4, [#22](https://github.com/rivoli-ai/andy-policies/issues/22)).
+It joins each binding to its `Policy` and `PolicyVersion` so callers get
+policy name, version state, enforcement, severity, and scopes in one
+round-trip. Retired versions are filtered out; same-target/same-version
+duplicates dedup with `Mandatory > Recommended` (tiebreak earliest
+`CreatedAt`); the result is ordered by policy name ASC, then version
+number DESC. **Exact-match only — no hierarchy walk.** That lands in P4.
+
 ## Ports
 
 Per the ecosystem registry at [`../andy-service-template/docs/ports.md`](../andy-service-template/docs/ports.md). Three deployment modes; the same host can run any combination because each mode uses a distinct port range.

--- a/docs/openapi/andy-policies-v1.yaml
+++ b/docs/openapi/andy-policies-v1.yaml
@@ -152,6 +152,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
+  /api/bindings/resolve:
+    get:
+      tags:
+        - Bindings
+      summary: "Resolve bindings for a target (P3.4, story\r\nrivoli-ai/andy-policies#22). Distinct from M:Andy.Policies.Api.Controllers.BindingsController.Query(Andy.Policies.Domain.Enums.BindingTargetType,System.String,System.Threading.CancellationToken):\r\njoins each row to its `Policy` and `PolicyVersion` so\r\ncallers get policy name, version state, enforcement, severity, and\r\nscopes without a second round-trip; filters out bindings whose\r\ntarget version is Retired; dedups same-target/same-version pairs\r\npreferring `Mandatory` over `Recommended`; orders the\r\nresult deterministically (policy name ASC, then version number\r\nDESC). Exact-match only — no hierarchy walk; that's P4. An\r\nunknown target returns 200 with `count = 0`, never 404."
+      operationId: Bindings_Resolve
+      parameters:
+        - name: targetType
+          in: query
+          schema:
+            $ref: '#/components/schemas/BindingTargetType'
+        - name: targetRef
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResolveBindingsResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
   /api/Help/topics:
     get:
       tags:
@@ -1144,6 +1172,68 @@ components:
           type: string
           nullable: true
       additionalProperties: { }
+    ResolveBindingsResponse:
+      type: object
+      properties:
+        targetType:
+          $ref: '#/components/schemas/BindingTargetType'
+        targetRef:
+          type: string
+          nullable: true
+        bindings:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResolvedBindingDto'
+          nullable: true
+        count:
+          type: integer
+          format: int32
+      additionalProperties: false
+      description: "Response envelope for `GET /api/bindings/resolve` (P3.4, story\r\nrivoli-ai/andy-policies#22). Carries the requested target so callers\r\ncaching the response can key on `(TargetType, TargetRef)`\r\nwithout re-parsing their own input. Andy.Policies.Application.Dtos.ResolveBindingsResponse.Count mirrors\r\n`Bindings.Count` for paginating callers that read the count\r\nheader field before the array."
+    ResolvedBindingDto:
+      type: object
+      properties:
+        bindingId:
+          type: string
+          format: uuid
+        policyId:
+          type: string
+          format: uuid
+        policyName:
+          type: string
+          nullable: true
+        policyVersionId:
+          type: string
+          format: uuid
+        versionNumber:
+          type: integer
+          format: int32
+        versionState:
+          type: string
+          nullable: true
+        enforcement:
+          enum:
+            - MUST
+            - SHOULD
+            - MAY
+          type: string
+          nullable: true
+        severity:
+          enum:
+            - info
+            - moderate
+            - critical
+          type: string
+          nullable: true
+        scopes:
+          type: array
+          items:
+            type: string
+          nullable: true
+        bindStrength:
+          $ref: '#/components/schemas/BindStrength'
+      additionalProperties: false
+      description: "A consumer-ready binding projection (P3.4, story\r\nrivoli-ai/andy-policies#22). Joins the live `Binding` row to its\r\ntarget `PolicyVersion` and stable `Policy` identity so a\r\ncaller (Conductor's ActionBus, andy-tasks per-task gates) gets enough\r\ncontext to decide what to do without a second round-trip. Wire-format\r\ncasing follows ADR 0001 §6: `Enforcement` uppercase RFC 2119\r\ntokens, `Severity` lowercase, `VersionState` PascalCase."
     UpdatePolicyVersionRequest:
       type: object
       properties:

--- a/src/Andy.Policies.Api/Controllers/BindingsController.cs
+++ b/src/Andy.Policies.Api/Controllers/BindingsController.cs
@@ -119,6 +119,35 @@ public sealed class BindingsController : ControllerBase
         return Ok(results);
     }
 
+    /// <summary>
+    /// Resolve bindings for a target (P3.4, story
+    /// rivoli-ai/andy-policies#22). Distinct from <see cref="Query"/>:
+    /// joins each row to its <c>Policy</c> and <c>PolicyVersion</c> so
+    /// callers get policy name, version state, enforcement, severity, and
+    /// scopes without a second round-trip; filters out bindings whose
+    /// target version is Retired; dedups same-target/same-version pairs
+    /// preferring <c>Mandatory</c> over <c>Recommended</c>; orders the
+    /// result deterministically (policy name ASC, then version number
+    /// DESC). Exact-match only — no hierarchy walk; that's P4. An
+    /// unknown target returns 200 with <c>count = 0</c>, never 404.
+    /// </summary>
+    [HttpGet("resolve")]
+    [ProducesResponseType(typeof(ResolveBindingsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<ResolveBindingsResponse>> Resolve(
+        [FromQuery] BindingTargetType targetType,
+        [FromQuery] string targetRef,
+        [FromServices] IBindingResolver resolver,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(targetRef))
+        {
+            return ValidationProblem("targetRef query parameter is required.");
+        }
+        var response = await resolver.ResolveExactAsync(targetType, targetRef, ct);
+        return Ok(response);
+    }
+
     private string? ResolveActor()
     {
         // Mirrors the lifecycle controller's actor-fallback firewall (#13):

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -97,6 +97,7 @@ builder.Services.AddAndySettingsClient(builder.Configuration);
 builder.Services.AddScoped<IItemService, ItemService>();
 builder.Services.AddScoped<IPolicyService, PolicyService>();
 builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBindingService, Andy.Policies.Infrastructure.Services.BindingService>();
+builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBindingResolver, Andy.Policies.Infrastructure.Services.BindingResolver>();
 // P3.2 (#20): Binding mutations call IAuditWriter — Epic P6
 // (rivoli-ai/andy-policies#6) replaces the no-op with the real
 // hash-chained writer. Singleton because the P6 implementation will own a

--- a/src/Andy.Policies.Application/Dtos/ResolveBindingsResponse.cs
+++ b/src/Andy.Policies.Application/Dtos/ResolveBindingsResponse.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Domain.Enums;
+
+namespace Andy.Policies.Application.Dtos;
+
+/// <summary>
+/// Response envelope for <c>GET /api/bindings/resolve</c> (P3.4, story
+/// rivoli-ai/andy-policies#22). Carries the requested target so callers
+/// caching the response can key on <c>(TargetType, TargetRef)</c>
+/// without re-parsing their own input. <see cref="Count"/> mirrors
+/// <c>Bindings.Count</c> for paginating callers that read the count
+/// header field before the array.
+/// </summary>
+public sealed record ResolveBindingsResponse(
+    BindingTargetType TargetType,
+    string TargetRef,
+    IReadOnlyList<ResolvedBindingDto> Bindings,
+    int Count);

--- a/src/Andy.Policies.Application/Dtos/ResolvedBindingDto.cs
+++ b/src/Andy.Policies.Application/Dtos/ResolvedBindingDto.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Domain.Enums;
+
+namespace Andy.Policies.Application.Dtos;
+
+/// <summary>
+/// A consumer-ready binding projection (P3.4, story
+/// rivoli-ai/andy-policies#22). Joins the live <c>Binding</c> row to its
+/// target <c>PolicyVersion</c> and stable <c>Policy</c> identity so a
+/// caller (Conductor's ActionBus, andy-tasks per-task gates) gets enough
+/// context to decide what to do without a second round-trip. Wire-format
+/// casing follows ADR 0001 §6: <c>Enforcement</c> uppercase RFC 2119
+/// tokens, <c>Severity</c> lowercase, <c>VersionState</c> PascalCase.
+/// </summary>
+public sealed record ResolvedBindingDto(
+    Guid BindingId,
+    Guid PolicyId,
+    string PolicyName,
+    Guid PolicyVersionId,
+    int VersionNumber,
+    string VersionState,
+    string Enforcement,
+    string Severity,
+    IReadOnlyList<string> Scopes,
+    BindStrength BindStrength);

--- a/src/Andy.Policies.Application/Interfaces/IBindingResolver.cs
+++ b/src/Andy.Policies.Application/Interfaces/IBindingResolver.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Domain.Enums;
+
+namespace Andy.Policies.Application.Interfaces;
+
+/// <summary>
+/// Resolution-shaped read over the binding table (P3.4, story
+/// rivoli-ai/andy-policies#22). Distinct from
+/// <c>IBindingService.ListByTargetAsync</c> in three ways:
+/// <list type="bullet">
+///   <item>Joins to <c>PolicyVersion</c> + <c>Policy</c> so callers get
+///     the policy name, version state/dimension fields, and scopes
+///     without a second round-trip.</item>
+///   <item>Filters out bindings whose target version is in
+///     <c>LifecycleState.Retired</c> — retired versions never appear in
+///     resolve.</item>
+///   <item>Dedups on <c>(PolicyVersionId)</c> when a single target has
+///     multiple bindings to the same version: <c>Mandatory</c> wins over
+///     <c>Recommended</c>; ties go to the earliest <c>CreatedAt</c>.</item>
+/// </list>
+/// <para>
+/// Exact-match mode only in this story — no hierarchy walk. P4
+/// (rivoli-ai/andy-policies#4) extends the resolver with stricter-tightens-only
+/// hierarchy semantics behind a <c>?mode=hierarchy</c> flag.
+/// </para>
+/// </summary>
+public interface IBindingResolver
+{
+    Task<ResolveBindingsResponse> ResolveExactAsync(
+        BindingTargetType targetType,
+        string targetRef,
+        CancellationToken ct = default);
+}

--- a/src/Andy.Policies.Infrastructure/Services/BindingResolver.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BindingResolver.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Andy.Policies.Infrastructure.Services;
+
+/// <summary>
+/// Exact-match resolver for the <c>GET /api/bindings/resolve</c> endpoint
+/// (P3.4, story rivoli-ai/andy-policies#22). Joins the live binding rows
+/// to <c>PolicyVersion</c> and <c>Policy</c>, filters Retired versions,
+/// dedups same-target/same-version pairs by preferring <c>Mandatory</c>
+/// over <c>Recommended</c>, and emits a deterministic ordering (policy
+/// name ASC, then version number DESC).
+/// </summary>
+public sealed class BindingResolver : IBindingResolver
+{
+    private readonly AppDbContext _db;
+
+    public BindingResolver(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<ResolveBindingsResponse> ResolveExactAsync(
+        BindingTargetType targetType,
+        string targetRef,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(targetRef);
+
+        // Pull the rows we need with a single JOIN and let the in-memory
+        // dedup + ordering happen client-side. Result sets are bounded by
+        // the binding count for one target — handfuls in practice — so the
+        // hot path is the indexed (TargetType, TargetRef) lookup.
+        // Client-side ordering also keeps the query SQLite-safe (the
+        // provider can't ORDER BY DateTimeOffset; see the BindingService
+        // notes from P3.3).
+        var query =
+            from b in _db.Bindings.AsNoTracking()
+            where b.TargetType == targetType
+                  && b.TargetRef == targetRef
+                  && b.DeletedAt == null
+            join v in _db.PolicyVersions.AsNoTracking() on b.PolicyVersionId equals v.Id
+            where v.State != LifecycleState.Retired
+            join p in _db.Policies.AsNoTracking() on v.PolicyId equals p.Id
+            select new
+            {
+                BindingId = b.Id,
+                b.CreatedAt,
+                BindStrength = b.BindStrength,
+                PolicyId = p.Id,
+                p.Name,
+                PolicyVersionId = v.Id,
+                v.Version,
+                v.State,
+                v.Enforcement,
+                v.Severity,
+                v.Scopes,
+            };
+
+        var rows = await query.ToListAsync(ct).ConfigureAwait(false);
+
+        // Dedup by PolicyVersionId: Mandatory wins over Recommended; tiebreak
+        // earliest CreatedAt. The administrative duplicate this guards
+        // against ("oops, two bindings for the same target and version")
+        // would otherwise show up to consumers as redundant rows.
+        var deduped = rows
+            .GroupBy(r => r.PolicyVersionId)
+            .Select(g => g
+                .OrderBy(r => r.BindStrength)         // Mandatory=1 < Recommended=2
+                .ThenBy(r => r.CreatedAt)
+                .First())
+            .ToList();
+
+        // Deterministic ordering for callers that snapshot the response.
+        var ordered = deduped
+            .OrderBy(r => r.Name, StringComparer.Ordinal)
+            .ThenByDescending(r => r.Version)
+            .Select(r => new ResolvedBindingDto(
+                BindingId: r.BindingId,
+                PolicyId: r.PolicyId,
+                PolicyName: r.Name,
+                PolicyVersionId: r.PolicyVersionId,
+                VersionNumber: r.Version,
+                VersionState: r.State.ToString(),
+                Enforcement: ToEnforcementWire(r.Enforcement),
+                Severity: ToSeverityWire(r.Severity),
+                Scopes: r.Scopes.ToArray(),
+                BindStrength: r.BindStrength))
+            .ToList();
+
+        return new ResolveBindingsResponse(targetType, targetRef, ordered, ordered.Count);
+    }
+
+    private static string ToEnforcementWire(EnforcementLevel level) => level switch
+    {
+        EnforcementLevel.May => "MAY",
+        EnforcementLevel.Should => "SHOULD",
+        EnforcementLevel.Must => "MUST",
+        _ => throw new InvalidOperationException($"Unknown EnforcementLevel: {level}"),
+    };
+
+    private static string ToSeverityWire(Severity severity) => severity switch
+    {
+        Severity.Info => "info",
+        Severity.Moderate => "moderate",
+        Severity.Critical => "critical",
+        _ => throw new InvalidOperationException($"Unknown Severity: {severity}"),
+    };
+}

--- a/tests/Andy.Policies.Tests.Integration/Controllers/BindingsResolveTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/BindingsResolveTests.cs
@@ -1,0 +1,168 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Domain.Enums;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Controllers;
+
+/// <summary>
+/// Integration tests for <c>GET /api/bindings/resolve</c> (P3.4, story
+/// rivoli-ai/andy-policies#22). Exercises the endpoint over HTTP with a
+/// real seed (publish + bind through the live REST surface) and asserts
+/// the resolve contract: Retired filtered out, dedup prefers Mandatory,
+/// missing/whitespace targetRef returns 400, unknown targets return 200
+/// with empty list.
+/// </summary>
+public class BindingsResolveTests : IClassFixture<PoliciesApiFactory>
+{
+    private readonly HttpClient _client;
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    public BindingsResolveTests(PoliciesApiFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    private static CreatePolicyRequest MinimalCreatePolicy(string name) => new(
+        Name: name,
+        Description: null,
+        Summary: "summary",
+        Enforcement: "Must",
+        Severity: "Critical",
+        Scopes: Array.Empty<string>(),
+        RulesJson: "{}");
+
+    private async Task<PolicyVersionDto> CreateAndPublishAsync(string slug)
+    {
+        var draft = await _client.PostAsJsonAsync("/api/policies", MinimalCreatePolicy(slug));
+        draft.EnsureSuccessStatusCode();
+        var created = (await draft.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
+        var publish = await _client.PostAsJsonAsync(
+            $"/api/policies/{created.PolicyId}/versions/{created.Id}/publish",
+            new LifecycleTransitionRequest("ship"));
+        publish.EnsureSuccessStatusCode();
+        return (await publish.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
+    }
+
+    private async Task<BindingDto> CreateBindingAsync(
+        Guid policyVersionId, BindingTargetType targetType, string targetRef, BindStrength strength)
+    {
+        var resp = await _client.PostAsJsonAsync(
+            "/api/bindings",
+            new CreateBindingRequest(policyVersionId, targetType, targetRef, strength));
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<BindingDto>(JsonOptions))!;
+    }
+
+    private static string Slug(string prefix) =>
+        $"{prefix}-{Guid.NewGuid():N}".Substring(0, 16);
+
+    [Fact]
+    public async Task Resolve_OnEmptyTarget_Returns200_WithEmptyList()
+    {
+        var resp = await _client.GetAsync(
+            $"/api/bindings/resolve?targetType=Repo&targetRef={Uri.EscapeDataString($"repo:none/missing-{Guid.NewGuid():N}")}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<ResolveBindingsResponse>(JsonOptions);
+        body!.Count.Should().Be(0);
+        body.Bindings.Should().BeEmpty();
+        body.TargetType.Should().Be(BindingTargetType.Repo);
+    }
+
+    [Fact]
+    public async Task Resolve_WithWhitespaceTargetRef_Returns400()
+    {
+        var resp = await _client.GetAsync("/api/bindings/resolve?targetType=Repo&targetRef=%20%20");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Resolve_HappyPath_ReturnsActiveBindings()
+    {
+        var version = await CreateAndPublishAsync(Slug("res-happy"));
+        var target = $"template:{Guid.NewGuid()}";
+        await CreateBindingAsync(version.Id, BindingTargetType.Template, target, BindStrength.Mandatory);
+
+        var resp = await _client.GetAsync(
+            $"/api/bindings/resolve?targetType=Template&targetRef={Uri.EscapeDataString(target)}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<ResolveBindingsResponse>(JsonOptions);
+        body!.Count.Should().Be(1);
+        var only = body.Bindings.Single();
+        only.PolicyVersionId.Should().Be(version.Id);
+        only.PolicyId.Should().Be(version.PolicyId);
+        only.VersionNumber.Should().Be(1);
+        only.VersionState.Should().Be("Active");
+        only.Enforcement.Should().Be("MUST");
+        only.Severity.Should().Be("critical");
+        only.BindStrength.Should().Be(BindStrength.Mandatory);
+    }
+
+    [Fact]
+    public async Task Resolve_FiltersOutRetiredVersion()
+    {
+        var version = await CreateAndPublishAsync(Slug("res-retired"));
+        var target = $"template:{Guid.NewGuid()}";
+        await CreateBindingAsync(version.Id, BindingTargetType.Template, target, BindStrength.Mandatory);
+        // Retire the version (Active -> Retired is the emergency path).
+        var retire = await _client.PostAsJsonAsync(
+            $"/api/policies/{version.PolicyId}/versions/{version.Id}/retire",
+            new LifecycleTransitionRequest("recall"));
+        retire.EnsureSuccessStatusCode();
+
+        var resp = await _client.GetAsync(
+            $"/api/bindings/resolve?targetType=Template&targetRef={Uri.EscapeDataString(target)}");
+        var body = await resp.Content.ReadFromJsonAsync<ResolveBindingsResponse>(JsonOptions);
+
+        body!.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Resolve_DedupsSameVersion_PrefersMandatory()
+    {
+        var version = await CreateAndPublishAsync(Slug("res-dedup"));
+        var target = $"tenant:{Guid.NewGuid()}";
+        await CreateBindingAsync(version.Id, BindingTargetType.Tenant, target, BindStrength.Recommended);
+        await CreateBindingAsync(version.Id, BindingTargetType.Tenant, target, BindStrength.Mandatory);
+
+        var resp = await _client.GetAsync(
+            $"/api/bindings/resolve?targetType=Tenant&targetRef={Uri.EscapeDataString(target)}");
+        var body = await resp.Content.ReadFromJsonAsync<ResolveBindingsResponse>(JsonOptions);
+
+        body!.Bindings.Should().ContainSingle()
+            .Which.BindStrength.Should().Be(BindStrength.Mandatory);
+    }
+
+    [Fact]
+    public async Task Resolve_AfterDelete_DropsBindingFromResponse()
+    {
+        var version = await CreateAndPublishAsync(Slug("res-del"));
+        var target = $"org:{Guid.NewGuid()}";
+        var binding = await CreateBindingAsync(version.Id, BindingTargetType.Org, target, BindStrength.Mandatory);
+
+        var preDelete = await _client.GetFromJsonAsync<ResolveBindingsResponse>(
+            $"/api/bindings/resolve?targetType=Org&targetRef={Uri.EscapeDataString(target)}", JsonOptions);
+        preDelete!.Count.Should().Be(1);
+
+        var del = await _client.DeleteAsync($"/api/bindings/{binding.Id}");
+        del.EnsureSuccessStatusCode();
+
+        var postDelete = await _client.GetFromJsonAsync<ResolveBindingsResponse>(
+            $"/api/bindings/resolve?targetType=Org&targetRef={Uri.EscapeDataString(target)}", JsonOptions);
+        postDelete!.Count.Should().Be(0);
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Services/BindingResolverTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/BindingResolverTests.cs
@@ -1,0 +1,218 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Infrastructure.Services;
+using Andy.Policies.Tests.Unit.Fixtures;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Services;
+
+/// <summary>
+/// Unit tests for <see cref="BindingResolver"/> (P3.4, story
+/// rivoli-ai/andy-policies#22). Drives the resolver over EF Core InMemory
+/// to lock down the four headline rules:
+/// <list type="bullet">
+///   <item>Retired versions are filtered out of the response.</item>
+///   <item>Same-target/same-version dedup picks the stronger
+///     <see cref="BindStrength"/> (Mandatory wins).</item>
+///   <item>Match is byte-exact on <c>(TargetType, TargetRef)</c>.</item>
+///   <item>Result ordering is deterministic: policy name ASC, then
+///     version number DESC.</item>
+/// </list>
+/// </summary>
+public class BindingResolverTests
+{
+    private static readonly TimeProvider Clock = TimeProvider.System;
+
+    private static (BindingResolver resolver, AppDbContext db) NewResolver()
+    {
+        var db = InMemoryDbFixture.Create();
+        return (new BindingResolver(db), db);
+    }
+
+    private static async Task<PolicyVersion> SeedVersionAsync(
+        AppDbContext db,
+        string policyName,
+        int versionNumber,
+        LifecycleState state)
+    {
+        // Cache lookup by Name; reusing the same Policy across versions
+        // mirrors the production aggregate shape (one Policy → many
+        // PolicyVersions).
+        var policy = await db.Policies.FirstOrDefaultAsync(p => p.Name == policyName);
+        if (policy is null)
+        {
+            policy = PolicyBuilders.APolicy(name: policyName);
+            db.Policies.Add(policy);
+        }
+        var version = PolicyBuilders.AVersion(policy.Id, number: versionNumber, state: state);
+        db.PolicyVersions.Add(version);
+        await db.SaveChangesAsync();
+        return version;
+    }
+
+    private static async Task<Binding> SeedBindingAsync(
+        AppDbContext db,
+        Guid policyVersionId,
+        BindingTargetType targetType,
+        string targetRef,
+        BindStrength strength,
+        DateTimeOffset? createdAt = null)
+    {
+        var binding = new Binding
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = policyVersionId,
+            TargetType = targetType,
+            TargetRef = targetRef,
+            BindStrength = strength,
+            CreatedAt = createdAt ?? DateTimeOffset.UtcNow,
+            CreatedBySubjectId = "test",
+        };
+        db.Bindings.Add(binding);
+        await db.SaveChangesAsync();
+        return binding;
+    }
+
+    [Fact]
+    public async Task Resolve_OnEmptyDb_ReturnsZeroCount()
+    {
+        var (resolver, _) = NewResolver();
+
+        var response = await resolver.ResolveExactAsync(BindingTargetType.Repo, "repo:none/missing");
+
+        response.Count.Should().Be(0);
+        response.Bindings.Should().BeEmpty();
+        response.TargetType.Should().Be(BindingTargetType.Repo);
+        response.TargetRef.Should().Be("repo:none/missing");
+    }
+
+    [Fact]
+    public async Task Resolve_FiltersOutRetiredVersion()
+    {
+        var (resolver, db) = NewResolver();
+        var live = await SeedVersionAsync(db, "live-pol", 1, LifecycleState.Active);
+        var retired = await SeedVersionAsync(db, "live-pol", 2, LifecycleState.Retired);
+        const string target = "template:abc";
+        await SeedBindingAsync(db, live.Id, BindingTargetType.Template, target, BindStrength.Mandatory);
+        await SeedBindingAsync(db, retired.Id, BindingTargetType.Template, target, BindStrength.Mandatory);
+
+        var response = await resolver.ResolveExactAsync(BindingTargetType.Template, target);
+
+        response.Bindings.Should().ContainSingle()
+            .Which.PolicyVersionId.Should().Be(live.Id);
+    }
+
+    [Fact]
+    public async Task Resolve_DedupsSameVersion_PrefersMandatory()
+    {
+        var (resolver, db) = NewResolver();
+        var version = await SeedVersionAsync(db, "dup-pol", 1, LifecycleState.Active);
+        const string target = "tenant:abc";
+        await SeedBindingAsync(db, version.Id, BindingTargetType.Tenant, target,
+            BindStrength.Recommended, createdAt: DateTimeOffset.UtcNow.AddMinutes(-10));
+        await SeedBindingAsync(db, version.Id, BindingTargetType.Tenant, target,
+            BindStrength.Mandatory, createdAt: DateTimeOffset.UtcNow);
+
+        var response = await resolver.ResolveExactAsync(BindingTargetType.Tenant, target);
+
+        response.Bindings.Should().ContainSingle()
+            .Which.BindStrength.Should().Be(BindStrength.Mandatory);
+    }
+
+    [Fact]
+    public async Task Resolve_DedupsSameVersion_TwoRecommended_KeepsEarliest()
+    {
+        var (resolver, db) = NewResolver();
+        var version = await SeedVersionAsync(db, "tie-pol", 1, LifecycleState.Active);
+        var earlier = await SeedBindingAsync(db, version.Id, BindingTargetType.Org,
+            "org:acme", BindStrength.Recommended, DateTimeOffset.UtcNow.AddMinutes(-5));
+        await SeedBindingAsync(db, version.Id, BindingTargetType.Org,
+            "org:acme", BindStrength.Recommended, DateTimeOffset.UtcNow);
+
+        var response = await resolver.ResolveExactAsync(BindingTargetType.Org, "org:acme");
+
+        response.Bindings.Should().ContainSingle()
+            .Which.BindingId.Should().Be(earlier.Id);
+    }
+
+    [Fact]
+    public async Task Resolve_MatchIsByteExact_NoCaseFolding()
+    {
+        var (resolver, db) = NewResolver();
+        var v1 = await SeedVersionAsync(db, "case-a", 1, LifecycleState.Active);
+        var v2 = await SeedVersionAsync(db, "case-b", 1, LifecycleState.Active);
+        await SeedBindingAsync(db, v1.Id, BindingTargetType.Template, "template:abc", BindStrength.Mandatory);
+        await SeedBindingAsync(db, v2.Id, BindingTargetType.Template, "template:Abc", BindStrength.Mandatory);
+
+        var lower = await resolver.ResolveExactAsync(BindingTargetType.Template, "template:abc");
+        var mixed = await resolver.ResolveExactAsync(BindingTargetType.Template, "template:Abc");
+
+        lower.Bindings.Should().ContainSingle().Which.PolicyVersionId.Should().Be(v1.Id);
+        mixed.Bindings.Should().ContainSingle().Which.PolicyVersionId.Should().Be(v2.Id);
+    }
+
+    [Fact]
+    public async Task Resolve_FiltersOutSoftDeletedBindings()
+    {
+        var (resolver, db) = NewResolver();
+        var v = await SeedVersionAsync(db, "del-pol", 1, LifecycleState.Active);
+        var alive = await SeedBindingAsync(db, v.Id, BindingTargetType.Repo, "repo:a/live", BindStrength.Mandatory);
+        var dead = await SeedBindingAsync(db, v.Id, BindingTargetType.Repo, "repo:a/live", BindStrength.Recommended);
+        dead.DeletedAt = DateTimeOffset.UtcNow;
+        dead.DeletedBySubjectId = "test";
+        await db.SaveChangesAsync();
+
+        var response = await resolver.ResolveExactAsync(BindingTargetType.Repo, "repo:a/live");
+
+        response.Bindings.Should().ContainSingle().Which.BindingId.Should().Be(alive.Id);
+    }
+
+    [Fact]
+    public async Task Resolve_OrdersByPolicyNameAsc_ThenVersionNumberDesc()
+    {
+        var (resolver, db) = NewResolver();
+        var alphaV1 = await SeedVersionAsync(db, "alpha", 1, LifecycleState.Active);
+        var alphaV2 = await SeedVersionAsync(db, "alpha", 2, LifecycleState.WindingDown);
+        var betaV1 = await SeedVersionAsync(db, "beta", 1, LifecycleState.Active);
+        const string target = "scope:abc";
+        await SeedBindingAsync(db, alphaV1.Id, BindingTargetType.ScopeNode, target, BindStrength.Mandatory);
+        await SeedBindingAsync(db, alphaV2.Id, BindingTargetType.ScopeNode, target, BindStrength.Mandatory);
+        await SeedBindingAsync(db, betaV1.Id, BindingTargetType.ScopeNode, target, BindStrength.Mandatory);
+
+        var response = await resolver.ResolveExactAsync(BindingTargetType.ScopeNode, target);
+
+        response.Bindings.Select(b => (b.PolicyName, b.VersionNumber)).Should().ContainInOrder(
+            ("alpha", 2),
+            ("alpha", 1),
+            ("beta", 1));
+    }
+
+    [Fact]
+    public async Task Resolve_EmitsWireFormatCasing_ForEnforcementSeverityState()
+    {
+        var (resolver, db) = NewResolver();
+        var policy = PolicyBuilders.APolicy(name: "wire-pol");
+        var version = PolicyBuilders.AVersion(policy.Id, number: 1, state: LifecycleState.Active);
+        version.Enforcement = EnforcementLevel.Must;
+        version.Severity = Severity.Critical;
+        db.Policies.Add(policy);
+        db.PolicyVersions.Add(version);
+        await db.SaveChangesAsync();
+        await SeedBindingAsync(db, version.Id, BindingTargetType.Template, "template:wire", BindStrength.Mandatory);
+
+        var response = await resolver.ResolveExactAsync(BindingTargetType.Template, "template:wire");
+
+        var dto = response.Bindings.Single();
+        dto.Enforcement.Should().Be("MUST");
+        dto.Severity.Should().Be("critical");
+        dto.VersionState.Should().Be("Active");
+    }
+}


### PR DESCRIPTION
## Summary

A consumer-ready read that joins each `Binding` row to its `Policy` and `PolicyVersion` so callers (Conductor's ActionBus, andy-tasks per-task gates) get the full picture in one round-trip.

**Application:**
- `ResolvedBindingDto`: `BindingId`, `PolicyId`, `PolicyName`, `PolicyVersionId`, `VersionNumber`, `VersionState` (PascalCase), `Enforcement` (uppercase RFC 2119), `Severity` (lowercase), `Scopes`, `BindStrength`.
- `ResolveBindingsResponse` envelope: `TargetType`, `TargetRef`, `Bindings`, `Count`.
- `IBindingResolver` with one method, `ResolveExactAsync`.

**Infrastructure:**
- `BindingResolver` joins `Bindings + PolicyVersions + Policies`, filters Retired versions, dedups same-target/same-version pairs preferring `Mandatory > Recommended` (tiebreak earliest `CreatedAt`), and orders by policy name ASC then version DESC. Client-side ordering keeps SQLite happy.

**API:**
- `GET /api/bindings/resolve` on `BindingsController`. Returns 200 + empty list for unknown targets (never 404). Whitespace-only `targetRef` returns 400. No new exception mapping needed — the resolver doesn't throw, it just queries.

**Exact-match only — no hierarchy walk.** That lands in P4.

Closes #22.

## Test plan
- [x] `dotnet test` — 191 unit + 171 integration pass; 6 E2E skipped (`E2E_ENABLED=0`).
- [x] 8 unit tests in `BindingResolverTests`: empty DB, Retired filter, dedup-prefers-Mandatory, dedup-tiebreak-by-earliest, byte-exact match (no case-folding), soft-delete exclusion, ordering (policy name ASC + version DESC), wire-format casing (`MUST` / `critical` / `Active`).
- [x] 6 integration tests in `BindingsResolveTests`: empty target → 200 + empty list, whitespace targetRef → 400, happy path with all fields populated, Retired version filtered out, dedup prefers Mandatory, resolve-after-delete drops the binding.
- [x] OpenAPI snapshot regenerated (+90 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)