### PR TITLE
Implement P3.5 — MCP binding tools (list, create, delete, resolve)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,16 @@ duplicates dedup with `Mandatory > Recommended` (tiebreak earliest
 `CreatedAt`); the result is ordered by policy name ASC, then version
 number DESC. **Exact-match only — no hierarchy walk.** That lands in P4.
 
+The same operations are exposed to LLM agents through the MCP endpoint at
+`/mcp` (P3.5, [#23](https://github.com/rivoli-ai/andy-policies/issues/23)):
+`policy.binding.list`, `policy.binding.create`, `policy.binding.delete`,
+and `policy.binding.resolve`. All four delegate to the same
+`IBindingService` / `IBindingResolver` as REST, so retired-version
+refusal, soft-delete semantics, and the dedup/order rules behave
+identically across surfaces. Errors come back as prefixed codes the
+gateway can route on (`policy.binding.not_found`,
+`policy.binding.retired_target`, `policy.binding.invalid_target`).
+
 ## Ports
 
 Per the ecosystem registry at [`../andy-service-template/docs/ports.md`](../andy-service-template/docs/ports.md). Three deployment modes; the same host can run any combination because each mode uses a distinct port range.

--- a/src/Andy.Policies.Api/Mcp/BindingTools.cs
+++ b/src/Andy.Policies.Api/Mcp/BindingTools.cs
@@ -1,0 +1,224 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.ComponentModel;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Exceptions;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Enums;
+using ModelContextProtocol.Server;
+
+namespace Andy.Policies.Api.Mcp;
+
+/// <summary>
+/// MCP tools over the binding catalog (P3.5, story
+/// rivoli-ai/andy-policies#23). Four tools — <c>policy.binding.list</c>,
+/// <c>policy.binding.create</c>, <c>policy.binding.delete</c>,
+/// <c>policy.binding.resolve</c> — delegate to the same
+/// <see cref="IBindingService"/> + <see cref="IBindingResolver"/>
+/// powering REST (P3.3, P3.4), gRPC (P3.6), and CLI (P3.7). Following the
+/// established <see cref="PolicyTools"/> + <see cref="PolicyLifecycleTools"/>
+/// contract: string GUIDs (parsed internally), formatted-string returns
+/// for human-readable tools, and JSON-serialized envelope for resolve so
+/// agents can pipe it through deterministic parsers. Mutating tools
+/// require an authenticated caller — when the MCP request reaches the
+/// tool with no <c>sub</c> / <c>name</c> claim the tool returns an error
+/// string rather than writing a fallback subject id into the catalog
+/// (mirrors the REST actor-fallback firewall — see #13).
+/// </summary>
+[McpServerToolType]
+public static class BindingTools
+{
+    /// <summary>
+    /// JSON envelope used by <see cref="Resolve"/>. Mirrors the REST
+    /// surface's serializer config (web casing, string enums) so the
+    /// MCP-tool body and the REST body are byte-for-byte identical for
+    /// agents that fall back to one or the other.
+    /// </summary>
+    private static readonly JsonSerializerOptions ResolveJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() },
+        WriteIndented = true,
+    };
+
+    [McpServerTool(Name = "policy.binding.list"), Description(
+        "List bindings attached to a specific policy version. Each line shows " +
+        "id, target type/ref, bind strength, created-by, and (when included) " +
+        "the deletion tombstone.")]
+    public static async Task<string> List(
+        IBindingService service,
+        [Description("Policy version id (GUID)")] string policyVersionId,
+        [Description("Include soft-deleted (tombstoned) bindings")] bool includeDeleted = false,
+        CancellationToken ct = default)
+    {
+        if (!Guid.TryParse(policyVersionId, out var vid))
+        {
+            return $"Invalid policy version id: '{policyVersionId}' is not a valid GUID.";
+        }
+
+        var rows = await service.ListByPolicyVersionAsync(vid, includeDeleted, ct);
+        return FormatBindingList(rows, header: $"{rows.Count} binding{(rows.Count == 1 ? "" : "s")} on version {vid}:");
+    }
+
+    [McpServerTool(Name = "policy.binding.create"), Description(
+        "Create a binding linking a policy version to a target. targetType is " +
+        "one of: Template, Repo, ScopeNode, Tenant, Org (case-insensitive). " +
+        "bindStrength is Mandatory or Recommended. Refuses bindings to Retired " +
+        "versions with policy.binding.retired_target.")]
+    public static async Task<string> Create(
+        IBindingService service,
+        IHttpContextAccessor httpContext,
+        [Description("Target policy version id (GUID)")] string policyVersionId,
+        [Description("One of: Template, Repo, ScopeNode, Tenant, Org")] string targetType,
+        [Description("Target reference (e.g. 'template:abc', 'repo:org/name')")] string targetRef,
+        [Description("Mandatory or Recommended (default Recommended)")] string bindStrength = "Recommended",
+        CancellationToken ct = default)
+    {
+        if (!Guid.TryParse(policyVersionId, out var vid))
+        {
+            return $"Invalid policy version id: '{policyVersionId}' is not a valid GUID.";
+        }
+        if (!Enum.TryParse<BindingTargetType>(targetType, ignoreCase: true, out var tt))
+        {
+            return $"policy.binding.invalid_target: targetType '{targetType}' is not valid. Use Template, Repo, ScopeNode, Tenant, or Org.";
+        }
+        if (!Enum.TryParse<BindStrength>(bindStrength, ignoreCase: true, out var bs))
+        {
+            return $"policy.binding.invalid_target: bindStrength '{bindStrength}' is not valid. Use Mandatory or Recommended.";
+        }
+
+        var actor = ResolveSubjectId(httpContext);
+        if (actor is null)
+        {
+            return "Authentication required: no subject id present on the caller's claims principal.";
+        }
+
+        try
+        {
+            var dto = await service.CreateAsync(
+                new CreateBindingRequest(vid, tt, targetRef, bs), actor, ct);
+            return FormatBindingDetail(dto);
+        }
+        catch (BindingRetiredVersionException ex)
+        {
+            return $"policy.binding.retired_target: {ex.Message}";
+        }
+        catch (NotFoundException ex)
+        {
+            return $"policy.binding.not_found: {ex.Message}";
+        }
+        catch (ValidationException ex)
+        {
+            return $"policy.binding.invalid_target: {ex.Message}";
+        }
+    }
+
+    [McpServerTool(Name = "policy.binding.delete"), Description(
+        "Soft-delete a binding. Stamps DeletedAt + DeletedBySubjectId on the " +
+        "row; the binding remains for the audit chain. Optional rationale is " +
+        "recorded against the audit event. Returns policy.binding.not_found " +
+        "if the binding does not exist or is already tombstoned.")]
+    public static async Task<string> Delete(
+        IBindingService service,
+        IHttpContextAccessor httpContext,
+        [Description("Binding id (GUID)")] string bindingId,
+        [Description("Optional rationale recorded against the audit event")] string? rationale = null,
+        CancellationToken ct = default)
+    {
+        if (!Guid.TryParse(bindingId, out var id))
+        {
+            return $"Invalid binding id: '{bindingId}' is not a valid GUID.";
+        }
+
+        var actor = ResolveSubjectId(httpContext);
+        if (actor is null)
+        {
+            return "Authentication required: no subject id present on the caller's claims principal.";
+        }
+
+        try
+        {
+            await service.DeleteAsync(id, actor, rationale, ct);
+            return $"Binding {id} soft-deleted.";
+        }
+        catch (NotFoundException ex)
+        {
+            return $"policy.binding.not_found: {ex.Message}";
+        }
+    }
+
+    [McpServerTool(Name = "policy.binding.resolve"), Description(
+        "Resolve all live bindings for an exact (targetType, targetRef) pair. " +
+        "Returns JSON containing target metadata and a list of resolved " +
+        "bindings (policy name, version state/dimension fields, scopes, " +
+        "bind strength). Retired versions are filtered; same-target/same-" +
+        "version duplicates dedup with Mandatory > Recommended. Exact-match " +
+        "only — no hierarchy walk; that's P4.")]
+    public static async Task<string> Resolve(
+        IBindingResolver resolver,
+        [Description("One of: Template, Repo, ScopeNode, Tenant, Org")] string targetType,
+        [Description("Target reference (e.g. 'template:abc')")] string targetRef,
+        CancellationToken ct = default)
+    {
+        if (!Enum.TryParse<BindingTargetType>(targetType, ignoreCase: true, out var tt))
+        {
+            return $"policy.binding.invalid_target: targetType '{targetType}' is not valid. Use Template, Repo, ScopeNode, Tenant, or Org.";
+        }
+        if (string.IsNullOrWhiteSpace(targetRef))
+        {
+            return "policy.binding.invalid_target: targetRef is required.";
+        }
+
+        var response = await resolver.ResolveExactAsync(tt, targetRef, ct);
+        return JsonSerializer.Serialize(response, ResolveJsonOptions);
+    }
+
+    // -- helpers --------------------------------------------------------------
+
+    private static string? ResolveSubjectId(IHttpContextAccessor accessor)
+    {
+        var user = accessor.HttpContext?.User;
+        if (user is null) return null;
+        var sub = user.FindFirstValue(ClaimTypes.NameIdentifier) ?? user.Identity?.Name;
+        return string.IsNullOrEmpty(sub) ? null : sub;
+    }
+
+    private static string FormatBindingList(IReadOnlyList<BindingDto> rows, string header)
+    {
+        if (rows.Count == 0)
+        {
+            return "No bindings.";
+        }
+        var sb = new StringBuilder();
+        sb.AppendLine(header);
+        foreach (var b in rows)
+        {
+            var deletedSuffix = b.DeletedAt is null
+                ? string.Empty
+                : $" [DELETED at {b.DeletedAt:u} by {b.DeletedBySubjectId ?? "?"}]";
+            sb.AppendLine(
+                $"- {b.Id} {b.TargetType}={b.TargetRef} ({b.BindStrength}) " +
+                $"by {b.CreatedBySubjectId} at {b.CreatedAt:u}{deletedSuffix}");
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string FormatBindingDetail(BindingDto b)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Binding {b.Id}");
+        sb.AppendLine($"PolicyVersionId: {b.PolicyVersionId}");
+        sb.AppendLine($"Target: {b.TargetType}={b.TargetRef}");
+        sb.AppendLine($"BindStrength: {b.BindStrength}");
+        sb.AppendLine($"Created: {b.CreatedAt:u} by {b.CreatedBySubjectId}");
+        if (b.DeletedAt is not null)
+        {
+            sb.AppendLine($"Deleted: {b.DeletedAt:u} by {b.DeletedBySubjectId ?? "?"}");
+        }
+        return sb.ToString().TrimEnd();
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Mcp/BindingToolsTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/BindingToolsTests.cs
@@ -1,0 +1,257 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Claims;
+using System.Text.Json;
+using Andy.Policies.Api.Mcp;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Infrastructure.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Mcp;
+
+/// <summary>
+/// Tests for <see cref="BindingTools"/> (P3.5, story
+/// rivoli-ai/andy-policies#23). Drives the static tool methods directly
+/// against a real <see cref="BindingService"/> + <see cref="BindingResolver"/>
+/// backed by EF Core InMemory plus a real <see cref="PolicyService"/> for
+/// seeding. Verifies the wire contract returned to MCP agents:
+/// formatted strings on success, prefixed error codes
+/// (<c>policy.binding.{not_found,retired_target,invalid_target}</c>) on
+/// failure, JSON envelope on resolve, and the actor-fallback firewall.
+/// </summary>
+public class BindingToolsTests
+{
+    private static AppDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static (BindingService binding, BindingResolver resolver, PolicyService policies, AppDbContext db)
+        NewServices()
+    {
+        var db = NewDb();
+        return (
+            new BindingService(db, new NoopAuditWriter(NullLogger<NoopAuditWriter>.Instance), TimeProvider.System),
+            new BindingResolver(db),
+            new PolicyService(db),
+            db);
+    }
+
+    private static IHttpContextAccessor AccessorFor(string? subjectId)
+    {
+        var ctx = new DefaultHttpContext();
+        if (subjectId is not null)
+        {
+            ctx.User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, subjectId),
+            }, authenticationType: "Test"));
+        }
+        return new HttpContextAccessor { HttpContext = ctx };
+    }
+
+    private static CreatePolicyRequest MinimalCreate(string name) => new(
+        Name: name,
+        Description: null,
+        Summary: "summary",
+        Enforcement: "Must",
+        Severity: "Critical",
+        Scopes: Array.Empty<string>(),
+        RulesJson: "{}");
+
+    [Fact]
+    public async Task Create_OnDraftVersion_ReturnsFormattedDetail_AndPersists()
+    {
+        var (svc, _, policies, db) = NewServices();
+        var draft = await policies.CreateDraftAsync(MinimalCreate("bind-create"), "sam");
+
+        var output = await BindingTools.Create(
+            svc, AccessorFor("agent-1"),
+            draft.Id.ToString(), "Repo", "repo:rivoli-ai/policy-x", "Mandatory");
+
+        output.Should().Contain("Binding ");
+        output.Should().Contain("Repo=repo:rivoli-ai/policy-x");
+        output.Should().Contain("Mandatory");
+        var rows = await db.Bindings.AsNoTracking().Where(b => b.PolicyVersionId == draft.Id).ToListAsync();
+        rows.Should().ContainSingle().Which.CreatedBySubjectId.Should().Be("agent-1");
+    }
+
+    [Fact]
+    public async Task Create_OnRetiredVersion_ReturnsRetiredTargetCode()
+    {
+        var (svc, _, policies, db) = NewServices();
+        var draft = await policies.CreateDraftAsync(MinimalCreate("bind-retired"), "sam");
+        // Force the version to Retired to exercise the service guard.
+        var entity = await db.PolicyVersions.FirstAsync(v => v.Id == draft.Id);
+        entity.State = LifecycleState.Retired;
+        await db.SaveChangesAsync();
+
+        var output = await BindingTools.Create(
+            svc, AccessorFor("agent-1"),
+            draft.Id.ToString(), "Repo", "repo:any/repo", "Recommended");
+
+        output.Should().StartWith("policy.binding.retired_target:");
+    }
+
+    [Fact]
+    public async Task Create_OnUnknownVersion_ReturnsNotFoundCode()
+    {
+        var (svc, _, _, _) = NewServices();
+
+        var output = await BindingTools.Create(
+            svc, AccessorFor("agent-1"),
+            Guid.NewGuid().ToString(), "Repo", "repo:rivoli-ai/policy-x", "Mandatory");
+
+        output.Should().StartWith("policy.binding.not_found:");
+    }
+
+    [Fact]
+    public async Task Create_WithInvalidTargetType_ReturnsInvalidTargetCode()
+    {
+        var (svc, _, policies, _) = NewServices();
+        var draft = await policies.CreateDraftAsync(MinimalCreate("bind-invalid"), "sam");
+
+        var output = await BindingTools.Create(
+            svc, AccessorFor("agent-1"),
+            draft.Id.ToString(), "Unicorn", "ref", "Recommended");
+
+        output.Should().StartWith("policy.binding.invalid_target:");
+    }
+
+    [Fact]
+    public async Task Create_WithEmptyTargetRef_ReturnsInvalidTargetCode()
+    {
+        var (svc, _, policies, _) = NewServices();
+        var draft = await policies.CreateDraftAsync(MinimalCreate("bind-empty"), "sam");
+
+        var output = await BindingTools.Create(
+            svc, AccessorFor("agent-1"),
+            draft.Id.ToString(), "Repo", "  ", "Recommended");
+
+        output.Should().StartWith("policy.binding.invalid_target:");
+    }
+
+    [Fact]
+    public async Task Create_WithNoSubjectId_ReturnsAuthRequired_DoesNotMutate()
+    {
+        var (svc, _, policies, db) = NewServices();
+        var draft = await policies.CreateDraftAsync(MinimalCreate("bind-noauth"), "sam");
+
+        var output = await BindingTools.Create(
+            svc, AccessorFor(subjectId: null),
+            draft.Id.ToString(), "Repo", "repo:any/repo", "Mandatory");
+
+        output.Should().Contain("Authentication required");
+        var rows = await db.Bindings.AsNoTracking().Where(b => b.PolicyVersionId == draft.Id).ToListAsync();
+        rows.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task List_FormatsHeaderAndOneLinePerBinding()
+    {
+        var (svc, _, policies, _) = NewServices();
+        var draft = await policies.CreateDraftAsync(MinimalCreate("bind-list"), "sam");
+        await BindingTools.Create(svc, AccessorFor("agent-1"),
+            draft.Id.ToString(), "Repo", "repo:a/x", "Mandatory");
+
+        var output = await BindingTools.List(svc, draft.Id.ToString());
+
+        output.Should().Contain("1 binding on version");
+        output.Should().Contain("Repo=repo:a/x");
+        output.Should().Contain("(Mandatory)");
+    }
+
+    [Fact]
+    public async Task List_OnInvalidGuid_ReturnsErrorString()
+    {
+        var (svc, _, _, _) = NewServices();
+
+        var output = await BindingTools.List(svc, "not-a-guid");
+
+        output.Should().StartWith("Invalid policy version id:");
+    }
+
+    [Fact]
+    public async Task Delete_RoundTrips_AndSecondDeleteReturnsNotFound()
+    {
+        var (svc, _, policies, _) = NewServices();
+        var draft = await policies.CreateDraftAsync(MinimalCreate("bind-del"), "sam");
+        var createOutput = await BindingTools.Create(svc, AccessorFor("agent-1"),
+            draft.Id.ToString(), "Repo", "repo:a/del", "Mandatory");
+        var bindingId = createOutput.Split('\n')[0].Replace("Binding ", "").Trim();
+
+        var first = await BindingTools.Delete(svc, AccessorFor("agent-1"), bindingId, "no longer needed");
+        first.Should().Contain("soft-deleted");
+
+        var second = await BindingTools.Delete(svc, AccessorFor("agent-1"), bindingId);
+        second.Should().StartWith("policy.binding.not_found:");
+    }
+
+    [Fact]
+    public async Task Delete_WithNoSubjectId_ReturnsAuthRequired()
+    {
+        var (svc, _, _, _) = NewServices();
+
+        var output = await BindingTools.Delete(svc, AccessorFor(subjectId: null), Guid.NewGuid().ToString());
+
+        output.Should().Contain("Authentication required");
+    }
+
+    [Fact]
+    public async Task Resolve_ReturnsValidJsonEnvelope_MatchingDtoShape()
+    {
+        var (svc, resolver, policies, db) = NewServices();
+        var draft = await policies.CreateDraftAsync(MinimalCreate("bind-res"), "sam");
+        var entity = await db.PolicyVersions.FirstAsync(v => v.Id == draft.Id);
+        entity.State = LifecycleState.Active;
+        await db.SaveChangesAsync();
+        await BindingTools.Create(svc, AccessorFor("agent-1"),
+            draft.Id.ToString(), "Template", "template:abc", "Mandatory");
+
+        var output = await BindingTools.Resolve(resolver, "Template", "template:abc");
+
+        // Output is JSON; parse it back to confirm the envelope shape.
+        using var doc = JsonDocument.Parse(output);
+        doc.RootElement.GetProperty("count").GetInt32().Should().Be(1);
+        doc.RootElement.GetProperty("targetRef").GetString().Should().Be("template:abc");
+        var first = doc.RootElement.GetProperty("bindings").EnumerateArray().First();
+        first.GetProperty("policyVersionId").GetString().Should().Be(draft.Id.ToString());
+        first.GetProperty("versionState").GetString().Should().Be("Active");
+        first.GetProperty("enforcement").GetString().Should().Be("MUST");
+        first.GetProperty("severity").GetString().Should().Be("critical");
+        first.GetProperty("bindStrength").GetString().Should().Be("Mandatory");
+    }
+
+    [Fact]
+    public async Task Resolve_OnInvalidTargetType_ReturnsInvalidTargetCode()
+    {
+        var (_, resolver, _, _) = NewServices();
+
+        var output = await BindingTools.Resolve(resolver, "Unicorn", "anything");
+
+        output.Should().StartWith("policy.binding.invalid_target:");
+    }
+
+    [Fact]
+    public async Task Resolve_OnEmptyTargetRef_ReturnsInvalidTargetCode()
+    {
+        var (_, resolver, _, _) = NewServices();
+
+        var output = await BindingTools.Resolve(resolver, "Template", "  ");
+
+        output.Should().StartWith("policy.binding.invalid_target:");
+    }
+}


### PR DESCRIPTION
## Summary

Four new MCP tools in `BindingTools.cs` delegate to the same `IBindingService` + `IBindingResolver` powering REST (P3.3, P3.4) — and gRPC/CLI when those land — so retired-version refusal, soft-delete semantics, and the dedup/order rules behave identically across surfaces:

- `policy.binding.list` — formatted-string roll-up of all bindings on a given `PolicyVersion`; optional `includeDeleted` flag.
- `policy.binding.create` — refuses Retired targets with `policy.binding.retired_target` prefix.
- `policy.binding.delete` — soft-delete with optional rationale; second delete returns `policy.binding.not_found`.
- `policy.binding.resolve` — JSON-serialised `ResolveBindingsResponse` so agents can pipe through deterministic parsers (web casing + string enums matching the REST surface).

Follows the established `PolicyTools` / `PolicyLifecycleTools` pattern: string GUIDs (parsed internally), formatted-string returns for human-readable tools, prefixed error codes for failure paths (`policy.binding.{not_found,retired_target,invalid_target}`). Mutating tools read the caller subject id from `HttpContext` claims (`NameIdentifier` → `Name` fallback) via `IHttpContextAccessor` and refuse to act when neither is present — same actor-fallback firewall as the REST controller and the P2.5 lifecycle tools.

Closes #23.

## Test plan
- [x] `dotnet test` — 191 unit + 184 integration pass; 6 E2E skipped (`E2E_ENABLED=0`).
- [x] 13 new tests in `BindingToolsTests`: create round-trip + DB persistence, retired target → `policy.binding.retired_target`, unknown version → `not_found`, invalid `targetType` → `invalid_target`, empty `targetRef` → `invalid_target`, no-subject-id firewall (no DB mutation), list formatting, list invalid-GUID error, delete round-trip + double-delete returns `not_found`, delete-no-auth firewall, resolve emits valid JSON with the full DTO shape (count, targetRef, policyVersionId, versionState `Active`, enforcement `MUST`, severity `critical`, bindStrength `Mandatory`), resolve invalid `targetType` + empty `targetRef` → `invalid_target`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)