### PR TITLE
Implement P3.6 — gRPC BindingService (6 RPCs, REST parity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,21 @@ identically across surfaces. Errors come back as prefixed codes the
 gateway can route on (`policy.binding.not_found`,
 `policy.binding.retired_target`, `policy.binding.invalid_target`).
 
+The gRPC `BindingService` (P3.6,
+[#24](https://github.com/rivoli-ai/andy-policies/issues/24)) lives in
+`bindings.proto` alongside the existing `policies.proto`,
+`lifecycle.proto` (same `andy_policies` package +
+`Andy.Policies.Api.Protos` namespace) and exposes six RPCs:
+`CreateBinding`, `DeleteBinding`, `GetBinding`,
+`ListBindingsByPolicyVersion`, `ListBindingsByTarget`, `ResolveBindings`.
+`TargetType` and `BindStrength` are proto3 enums (UNSPECIFIED rejected as
+`InvalidArgument`); state/enforcement/severity stay strings on
+`ResolvedBindingMessage` so proto evolution doesn't couple to internal
+enum renames. Service exceptions map:
+`BindingRetiredVersionException` → `FailedPrecondition`,
+`ConflictException` → `AlreadyExists`, `ValidationException` →
+`InvalidArgument`, `NotFoundException` → `NotFound`.
+
 ## Ports
 
 Per the ecosystem registry at [`../andy-service-template/docs/ports.md`](../andy-service-template/docs/ports.md). Three deployment modes; the same host can run any combination because each mode uses a distinct port range.

--- a/src/Andy.Policies.Api/Andy.Policies.Api.csproj
+++ b/src/Andy.Policies.Api/Andy.Policies.Api.csproj
@@ -43,6 +43,9 @@
          AdditionalImportDirs entry tells protoc where to resolve sibling
          proto files (default search path is just the file's own directory). -->
     <Protobuf Include="Protos\lifecycle.proto" GrpcServices="Both" AdditionalImportDirs="Protos" />
+    <!-- bindings.proto: P3.6 (#24). Both: integration tests reference the
+         API project to drive the gRPC surface end-to-end. -->
+    <Protobuf Include="Protos\bindings.proto" GrpcServices="Both" />
   </ItemGroup>
 
 </Project>

--- a/src/Andy.Policies.Api/GrpcServices/BindingsGrpcService.cs
+++ b/src/Andy.Policies.Api/GrpcServices/BindingsGrpcService.cs
@@ -1,0 +1,243 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Claims;
+using Andy.Policies.Api.Protos;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Exceptions;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Enums;
+using Grpc.Core;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Andy.Policies.Api.GrpcServices;
+
+/// <summary>
+/// gRPC surface for the binding catalog (P3.6, story
+/// rivoli-ai/andy-policies#24). Six RPCs delegate to the same
+/// <see cref="IBindingService"/> + <see cref="IBindingResolver"/> as REST
+/// (P3.3, P3.4), MCP (P3.5), and CLI (P3.7). Service exceptions translate
+/// to gRPC status codes per the table below; the equivalent HTTP
+/// mappings live in <c>PolicyExceptionHandler</c>:
+///
+/// <list type="table">
+///   <listheader><term>Exception</term><description>gRPC status / HTTP equivalent</description></listheader>
+///   <item><term><see cref="BindingRetiredVersionException"/></term><description>FailedPrecondition / 409</description></item>
+///   <item><term><see cref="ConflictException"/></term><description>AlreadyExists / 409</description></item>
+///   <item><term><see cref="ValidationException"/></term><description>InvalidArgument / 400</description></item>
+///   <item><term><see cref="NotFoundException"/></term><description>NotFound / 404</description></item>
+/// </list>
+/// </summary>
+[Authorize]
+public class BindingsGrpcService : Andy.Policies.Api.Protos.BindingService.BindingServiceBase
+{
+    private readonly IBindingService _bindings;
+    private readonly IBindingResolver _resolver;
+
+    public BindingsGrpcService(IBindingService bindings, IBindingResolver resolver)
+    {
+        _bindings = bindings;
+        _resolver = resolver;
+    }
+
+    public override async Task<BindingResponse> CreateBinding(
+        Andy.Policies.Api.Protos.CreateBindingRequest request, ServerCallContext context)
+    {
+        var versionId = ParseGuidOrThrow(request.PolicyVersionId, "policy_version_id");
+        var targetType = ToDomainTargetType(request.TargetType);
+        var bindStrength = ToDomainBindStrength(request.BindStrength);
+
+        try
+        {
+            var dto = await _bindings.CreateAsync(
+                new Andy.Policies.Application.Dtos.CreateBindingRequest(
+                    versionId, targetType, request.TargetRef, bindStrength),
+                ResolveSubjectId(context),
+                context.CancellationToken);
+            return new BindingResponse { Binding = ToMessage(dto) };
+        }
+        catch (Exception ex) { throw MapToRpcException(ex); }
+    }
+
+    public override async Task<DeleteBindingResponse> DeleteBinding(
+        DeleteBindingRequest request, ServerCallContext context)
+    {
+        var id = ParseGuidOrThrow(request.Id, "id");
+        try
+        {
+            await _bindings.DeleteAsync(
+                id,
+                ResolveSubjectId(context),
+                string.IsNullOrEmpty(request.Rationale) ? null : request.Rationale,
+                context.CancellationToken);
+            return new DeleteBindingResponse();
+        }
+        catch (Exception ex) { throw MapToRpcException(ex); }
+    }
+
+    public override async Task<BindingResponse> GetBinding(
+        GetBindingRequest request, ServerCallContext context)
+    {
+        var id = ParseGuidOrThrow(request.Id, "id");
+        var dto = await _bindings.GetAsync(id, context.CancellationToken);
+        if (dto is null)
+        {
+            throw new RpcException(new Status(StatusCode.NotFound, $"Binding {id} not found."));
+        }
+        return new BindingResponse { Binding = ToMessage(dto) };
+    }
+
+    public override async Task<ListBindingsResponse> ListBindingsByPolicyVersion(
+        ListBindingsByPolicyVersionRequest request, ServerCallContext context)
+    {
+        var versionId = ParseGuidOrThrow(request.PolicyVersionId, "policy_version_id");
+        var rows = await _bindings.ListByPolicyVersionAsync(
+            versionId, request.IncludeDeleted, context.CancellationToken);
+        var response = new ListBindingsResponse();
+        response.Bindings.AddRange(rows.Select(ToMessage));
+        return response;
+    }
+
+    public override async Task<ListBindingsResponse> ListBindingsByTarget(
+        ListBindingsByTargetRequest request, ServerCallContext context)
+    {
+        if (string.IsNullOrEmpty(request.TargetRef))
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument, "target_ref is required."));
+        }
+        var targetType = ToDomainTargetType(request.TargetType);
+        var rows = await _bindings.ListByTargetAsync(targetType, request.TargetRef, context.CancellationToken);
+        var response = new ListBindingsResponse();
+        response.Bindings.AddRange(rows.Select(ToMessage));
+        return response;
+    }
+
+    public override async Task<Andy.Policies.Api.Protos.ResolveBindingsResponse> ResolveBindings(
+        ResolveBindingsRequest request, ServerCallContext context)
+    {
+        if (string.IsNullOrEmpty(request.TargetRef))
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument, "target_ref is required."));
+        }
+        var targetType = ToDomainTargetType(request.TargetType);
+        var dto = await _resolver.ResolveExactAsync(
+            targetType, request.TargetRef, context.CancellationToken);
+
+        var response = new Andy.Policies.Api.Protos.ResolveBindingsResponse
+        {
+            TargetType = ToProtoTargetType(dto.TargetType),
+            TargetRef = dto.TargetRef,
+            Count = dto.Count,
+        };
+        response.Bindings.AddRange(dto.Bindings.Select(ToMessage));
+        return response;
+    }
+
+    // -- helpers --------------------------------------------------------------
+
+    private static Guid ParseGuidOrThrow(string raw, string field)
+    {
+        if (!Guid.TryParse(raw, out var guid))
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument,
+                $"{field} '{raw}' is not a valid GUID."));
+        }
+        return guid;
+    }
+
+    private static string ResolveSubjectId(ServerCallContext context)
+    {
+        // Mirrors the REST controller's actor-fallback firewall (#13): refuse
+        // to act when no subject id is on the principal rather than write a
+        // fallback string into the catalog.
+        var http = context.GetHttpContext();
+        var sub = http?.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? http?.User.Identity?.Name;
+        if (string.IsNullOrEmpty(sub))
+        {
+            throw new RpcException(new Status(StatusCode.Unauthenticated,
+                "Authentication required: no subject id present on the caller's claims principal."));
+        }
+        return sub;
+    }
+
+    private static BindingTargetType ToDomainTargetType(TargetType wire) => wire switch
+    {
+        TargetType.Template => BindingTargetType.Template,
+        TargetType.Repo => BindingTargetType.Repo,
+        TargetType.ScopeNode => BindingTargetType.ScopeNode,
+        TargetType.Tenant => BindingTargetType.Tenant,
+        TargetType.Org => BindingTargetType.Org,
+        _ => throw new RpcException(new Status(StatusCode.InvalidArgument,
+            "target_type is required (TARGET_TYPE_UNSPECIFIED is not a valid value).")),
+    };
+
+    private static TargetType ToProtoTargetType(BindingTargetType domain) => domain switch
+    {
+        BindingTargetType.Template => TargetType.Template,
+        BindingTargetType.Repo => TargetType.Repo,
+        BindingTargetType.ScopeNode => TargetType.ScopeNode,
+        BindingTargetType.Tenant => TargetType.Tenant,
+        BindingTargetType.Org => TargetType.Org,
+        _ => throw new InvalidOperationException($"Unknown BindingTargetType: {domain}"),
+    };
+
+    private static Domain.Enums.BindStrength ToDomainBindStrength(Andy.Policies.Api.Protos.BindStrength wire) => wire switch
+    {
+        Andy.Policies.Api.Protos.BindStrength.Mandatory => Domain.Enums.BindStrength.Mandatory,
+        Andy.Policies.Api.Protos.BindStrength.Recommended => Domain.Enums.BindStrength.Recommended,
+        _ => throw new RpcException(new Status(StatusCode.InvalidArgument,
+            "bind_strength is required (BIND_STRENGTH_UNSPECIFIED is not a valid value).")),
+    };
+
+    private static Andy.Policies.Api.Protos.BindStrength ToProtoBindStrength(Domain.Enums.BindStrength domain) => domain switch
+    {
+        Domain.Enums.BindStrength.Mandatory => Andy.Policies.Api.Protos.BindStrength.Mandatory,
+        Domain.Enums.BindStrength.Recommended => Andy.Policies.Api.Protos.BindStrength.Recommended,
+        _ => throw new InvalidOperationException($"Unknown BindStrength: {domain}"),
+    };
+
+    private static RpcException MapToRpcException(Exception ex) => ex switch
+    {
+        // BindingRetiredVersionException is a ConflictException — match the more
+        // specific type first so FailedPrecondition wins over AlreadyExists.
+        BindingRetiredVersionException r => new RpcException(new Status(StatusCode.FailedPrecondition, r.Message)),
+        ValidationException v => new RpcException(new Status(StatusCode.InvalidArgument, v.Message)),
+        NotFoundException n => new RpcException(new Status(StatusCode.NotFound, n.Message)),
+        ConflictException c => new RpcException(new Status(StatusCode.AlreadyExists, c.Message)),
+        RpcException existing => existing,
+        _ => throw new InvalidOperationException(
+            $"Unmapped exception in BindingsGrpcService: {ex.GetType().Name}", ex),
+    };
+
+    private static BindingMessage ToMessage(BindingDto dto) => new()
+    {
+        Id = dto.Id.ToString(),
+        PolicyVersionId = dto.PolicyVersionId.ToString(),
+        TargetType = ToProtoTargetType(dto.TargetType),
+        TargetRef = dto.TargetRef,
+        BindStrength = ToProtoBindStrength(dto.BindStrength),
+        CreatedAt = dto.CreatedAt.ToString("o"),
+        CreatedBySubjectId = dto.CreatedBySubjectId,
+        DeletedAt = dto.DeletedAt?.ToString("o") ?? string.Empty,
+        DeletedBySubjectId = dto.DeletedBySubjectId ?? string.Empty,
+    };
+
+    private static ResolvedBindingMessage ToMessage(ResolvedBindingDto dto)
+    {
+        var msg = new ResolvedBindingMessage
+        {
+            BindingId = dto.BindingId.ToString(),
+            PolicyId = dto.PolicyId.ToString(),
+            PolicyName = dto.PolicyName,
+            PolicyVersionId = dto.PolicyVersionId.ToString(),
+            VersionNumber = dto.VersionNumber,
+            VersionState = dto.VersionState,
+            Enforcement = dto.Enforcement,
+            Severity = dto.Severity,
+            BindStrength = ToProtoBindStrength(dto.BindStrength),
+        };
+        msg.Scopes.AddRange(dto.Scopes);
+        return msg;
+    }
+}

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -284,6 +284,7 @@ app.MapControllers();
 app.MapGrpcService<Andy.Policies.Api.GrpcServices.ItemsGrpcService>();
 app.MapGrpcService<Andy.Policies.Api.GrpcServices.PolicyGrpcService>();
 app.MapGrpcService<Andy.Policies.Api.GrpcServices.LifecycleGrpcService>();
+app.MapGrpcService<Andy.Policies.Api.GrpcServices.BindingsGrpcService>();
 
 // --- MCP endpoint ---
 app.MapMcp("/mcp")

--- a/src/Andy.Policies.Api/Protos/bindings.proto
+++ b/src/Andy.Policies.Api/Protos/bindings.proto
@@ -1,0 +1,154 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+//
+// gRPC contract for the binding catalog (P3.6, rivoli-ai/andy-policies#24).
+// Sits alongside policies.proto and lifecycle.proto in the same
+// `andy_policies` package + `Andy.Policies.Api.Protos` C# namespace so
+// existing consumers that already imported the package get binding calls
+// without a second stub generation.
+//
+// Wire format conventions match the sibling protos:
+//   - state, enforcement, severity are strings on ResolvedBinding so
+//     proto evolution doesn't couple to internal enum renames (ADR 0001
+//     §6 PascalCase for state, uppercase RFC 2119 for enforcement,
+//     lowercase for severity).
+//   - target_type and bind_strength are proto enums because they're
+//     small, stable, and consumers benefit from the type safety. The
+//     `*_UNSPECIFIED = 0` proto3 default is rejected as INVALID_ARGUMENT
+//     by the server.
+//   - Ids are UUID strings; timestamps land in the message as ISO 8601
+//     strings rather than google.protobuf.Timestamp, matching the
+//     PolicyVersionMessage convention from policies.proto.
+
+syntax = "proto3";
+
+option csharp_namespace = "Andy.Policies.Api.Protos";
+
+package andy_policies;
+
+service BindingService {
+  // Create a new binding. Refuses bindings to Retired PolicyVersions
+  // (FailedPrecondition); validates non-empty / ≤512-char target_ref
+  // (InvalidArgument); rejects unknown policy_version_id (NotFound).
+  rpc CreateBinding (CreateBindingRequest) returns (BindingResponse);
+
+  // Soft-delete a binding (rationale recorded against the audit chain).
+  // Returns NotFound if the binding does not exist or is already
+  // tombstoned.
+  rpc DeleteBinding (DeleteBindingRequest) returns (DeleteBindingResponse);
+
+  // Get a single binding by id. Tombstoned rows are visible here so
+  // audit investigators can inspect their DeletedAt stamp.
+  rpc GetBinding (GetBindingRequest) returns (BindingResponse);
+
+  // List bindings against a given PolicyVersion ordered most-recently-
+  // created first. include_deleted controls tombstone visibility.
+  rpc ListBindingsByPolicyVersion (ListBindingsByPolicyVersionRequest) returns (ListBindingsResponse);
+
+  // List active bindings for a target — exact-equality match on
+  // (target_type, target_ref); no prefix or case-folding.
+  rpc ListBindingsByTarget (ListBindingsByTargetRequest) returns (ListBindingsResponse);
+
+  // Resolve all live bindings for an exact target. Joins each binding
+  // to its Policy and PolicyVersion; filters Retired versions; dedups
+  // same-target/same-version pairs preferring Mandatory over
+  // Recommended; orders policy name ASC then version DESC. Exact-match
+  // only — no hierarchy walk; that's P4.
+  rpc ResolveBindings (ResolveBindingsRequest) returns (ResolveBindingsResponse);
+}
+
+// -- enums ----------------------------------------------------------------
+
+enum TargetType {
+  TARGET_TYPE_UNSPECIFIED = 0;
+  TARGET_TYPE_TEMPLATE = 1;
+  TARGET_TYPE_REPO = 2;
+  TARGET_TYPE_SCOPE_NODE = 3;
+  TARGET_TYPE_TENANT = 4;
+  TARGET_TYPE_ORG = 5;
+}
+
+enum BindStrength {
+  BIND_STRENGTH_UNSPECIFIED = 0;
+  BIND_STRENGTH_MANDATORY = 1;
+  BIND_STRENGTH_RECOMMENDED = 2;
+}
+
+// -- shared messages ------------------------------------------------------
+
+message BindingMessage {
+  string id = 1;
+  string policy_version_id = 2;
+  TargetType target_type = 3;
+  string target_ref = 4;
+  BindStrength bind_strength = 5;
+  string created_at = 6;          // ISO 8601 (DateTimeOffset.ToString("o"))
+  string created_by_subject_id = 7;
+  string deleted_at = 8;          // empty when not tombstoned
+  string deleted_by_subject_id = 9;
+}
+
+message ResolvedBindingMessage {
+  string binding_id = 1;
+  string policy_id = 2;
+  string policy_name = 3;
+  string policy_version_id = 4;
+  int32 version_number = 5;
+  string version_state = 6;       // PascalCase per ADR 0001 §6
+  string enforcement = 7;         // uppercase RFC 2119 (MAY/SHOULD/MUST)
+  string severity = 8;            // lowercase
+  repeated string scopes = 9;
+  BindStrength bind_strength = 10;
+}
+
+// -- mutation rpcs --------------------------------------------------------
+
+message CreateBindingRequest {
+  string policy_version_id = 1;
+  TargetType target_type = 2;
+  string target_ref = 3;
+  BindStrength bind_strength = 4;
+}
+
+message DeleteBindingRequest {
+  string id = 1;
+  string rationale = 2;
+}
+
+message DeleteBindingResponse {}
+
+// -- read rpcs -----------------------------------------------------------
+
+message GetBindingRequest {
+  string id = 1;
+}
+
+message BindingResponse {
+  BindingMessage binding = 1;
+}
+
+message ListBindingsByPolicyVersionRequest {
+  string policy_version_id = 1;
+  bool include_deleted = 2;
+}
+
+message ListBindingsByTargetRequest {
+  TargetType target_type = 1;
+  string target_ref = 2;
+}
+
+message ListBindingsResponse {
+  repeated BindingMessage bindings = 1;
+}
+
+message ResolveBindingsRequest {
+  TargetType target_type = 1;
+  string target_ref = 2;
+}
+
+message ResolveBindingsResponse {
+  TargetType target_type = 1;
+  string target_ref = 2;
+  repeated ResolvedBindingMessage bindings = 3;
+  int32 count = 4;
+}

--- a/tests/Andy.Policies.Tests.Integration/GrpcServices/BindingsGrpcServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/GrpcServices/BindingsGrpcServiceTests.cs
@@ -1,0 +1,352 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net.Http.Json;
+using Andy.Policies.Api.Protos;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Tests.Integration.Controllers;
+using FluentAssertions;
+using Grpc.Core;
+using Grpc.Net.Client;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+using ProtoBindStrength = Andy.Policies.Api.Protos.BindStrength;
+
+namespace Andy.Policies.Tests.Integration.GrpcServices;
+
+/// <summary>
+/// End-to-end gRPC tests for the binding surface (P3.6, story
+/// rivoli-ai/andy-policies#24). Exercises every RPC over a real HTTP/2
+/// channel against the test server, verifying the proto contract, the
+/// generated stubs, exception → status-code mapping, and parity with
+/// the REST/MCP surfaces (retired-version refusal, soft-delete,
+/// dedup/order on resolve).
+/// </summary>
+public class BindingsGrpcServiceTests : IClassFixture<PoliciesApiFactory>, IDisposable
+{
+    private readonly PoliciesApiFactory _factory;
+    private readonly GrpcChannel _channel;
+    private readonly Andy.Policies.Api.Protos.BindingService.BindingServiceClient _bindings;
+    private readonly Andy.Policies.Api.Protos.PolicyService.PolicyServiceClient _policies;
+    private readonly LifecycleService.LifecycleServiceClient _lifecycle;
+
+    public BindingsGrpcServiceTests(PoliciesApiFactory factory)
+    {
+        _factory = factory;
+        var handler = factory.Server.CreateHandler();
+        _channel = GrpcChannel.ForAddress(factory.Server.BaseAddress, new GrpcChannelOptions
+        {
+            HttpHandler = handler,
+        });
+        _bindings = new Andy.Policies.Api.Protos.BindingService.BindingServiceClient(_channel);
+        _policies = new Andy.Policies.Api.Protos.PolicyService.PolicyServiceClient(_channel);
+        _lifecycle = new LifecycleService.LifecycleServiceClient(_channel);
+    }
+
+    public void Dispose() => _channel.Dispose();
+
+    private static CreateDraftRequest MinimalCreate(string name) => new()
+    {
+        Name = name,
+        Description = "",
+        Summary = "summary",
+        Enforcement = "Must",
+        Severity = "Critical",
+        RulesJson = "{}",
+    };
+
+    private async Task<PolicyVersionMessage> CreateDraftAsync(string slug)
+    {
+        var draft = await _policies.CreateDraftAsync(MinimalCreate(slug));
+        return draft.Version;
+    }
+
+    private async Task<PolicyVersionMessage> CreateAndPublishAsync(string slug)
+    {
+        var draft = await CreateDraftAsync(slug);
+        var publish = await _lifecycle.PublishVersionAsync(new PublishVersionRequest
+        {
+            PolicyId = draft.PolicyId,
+            VersionId = draft.Id,
+            Rationale = "ship",
+        });
+        return publish.Version;
+    }
+
+    private static string Slug(string prefix) =>
+        $"grpc-{prefix}-{Guid.NewGuid():N}".Substring(0, 16);
+
+    [Fact]
+    public async Task CreateBinding_OnDraftVersion_ReturnsPopulatedBinding()
+    {
+        var draft = await CreateDraftAsync(Slug("bind"));
+
+        var response = await _bindings.CreateBindingAsync(new Andy.Policies.Api.Protos.CreateBindingRequest
+        {
+            PolicyVersionId = draft.Id,
+            TargetType = TargetType.Repo,
+            TargetRef = "repo:rivoli-ai/policy-x",
+            BindStrength = ProtoBindStrength.Mandatory,
+        });
+
+        response.Binding.PolicyVersionId.Should().Be(draft.Id);
+        response.Binding.TargetType.Should().Be(TargetType.Repo);
+        response.Binding.TargetRef.Should().Be("repo:rivoli-ai/policy-x");
+        response.Binding.BindStrength.Should().Be(ProtoBindStrength.Mandatory);
+        response.Binding.DeletedAt.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateBinding_OnRetiredVersion_ThrowsFailedPrecondition()
+    {
+        var version = await CreateAndPublishAsync(Slug("retired"));
+        await _lifecycle.TransitionVersionAsync(new TransitionVersionRequest
+        {
+            PolicyId = version.PolicyId,
+            VersionId = version.Id,
+            TargetState = "Retired",
+            Rationale = "recall",
+        });
+
+        var ex = await Assert.ThrowsAsync<RpcException>(() =>
+            _bindings.CreateBindingAsync(new Andy.Policies.Api.Protos.CreateBindingRequest
+            {
+                PolicyVersionId = version.Id,
+                TargetType = TargetType.Repo,
+                TargetRef = "repo:any/repo",
+                BindStrength = ProtoBindStrength.Recommended,
+            }).ResponseAsync);
+
+        ex.StatusCode.Should().Be(StatusCode.FailedPrecondition);
+    }
+
+    [Fact]
+    public async Task CreateBinding_WithUnspecifiedTargetType_ThrowsInvalidArgument()
+    {
+        var draft = await CreateDraftAsync(Slug("unsp"));
+
+        var ex = await Assert.ThrowsAsync<RpcException>(() =>
+            _bindings.CreateBindingAsync(new Andy.Policies.Api.Protos.CreateBindingRequest
+            {
+                PolicyVersionId = draft.Id,
+                TargetType = TargetType.Unspecified,
+                TargetRef = "repo:a/b",
+                BindStrength = ProtoBindStrength.Mandatory,
+            }).ResponseAsync);
+
+        ex.StatusCode.Should().Be(StatusCode.InvalidArgument);
+    }
+
+    [Fact]
+    public async Task CreateBinding_WithEmptyTargetRef_ThrowsInvalidArgument()
+    {
+        var draft = await CreateDraftAsync(Slug("empty"));
+
+        var ex = await Assert.ThrowsAsync<RpcException>(() =>
+            _bindings.CreateBindingAsync(new Andy.Policies.Api.Protos.CreateBindingRequest
+            {
+                PolicyVersionId = draft.Id,
+                TargetType = TargetType.Repo,
+                TargetRef = "  ",
+                BindStrength = ProtoBindStrength.Mandatory,
+            }).ResponseAsync);
+
+        ex.StatusCode.Should().Be(StatusCode.InvalidArgument);
+    }
+
+    [Fact]
+    public async Task CreateBinding_WithUnknownVersion_ThrowsNotFound()
+    {
+        var ex = await Assert.ThrowsAsync<RpcException>(() =>
+            _bindings.CreateBindingAsync(new Andy.Policies.Api.Protos.CreateBindingRequest
+            {
+                PolicyVersionId = Guid.NewGuid().ToString(),
+                TargetType = TargetType.Repo,
+                TargetRef = "repo:a/b",
+                BindStrength = ProtoBindStrength.Mandatory,
+            }).ResponseAsync);
+
+        ex.StatusCode.Should().Be(StatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetBinding_RoundTripsAfterCreate()
+    {
+        var draft = await CreateDraftAsync(Slug("get"));
+        var created = await _bindings.CreateBindingAsync(new Andy.Policies.Api.Protos.CreateBindingRequest
+        {
+            PolicyVersionId = draft.Id,
+            TargetType = TargetType.Tenant,
+            TargetRef = $"tenant:{Guid.NewGuid()}",
+            BindStrength = ProtoBindStrength.Recommended,
+        });
+
+        var fetched = await _bindings.GetBindingAsync(new GetBindingRequest { Id = created.Binding.Id });
+
+        fetched.Binding.Id.Should().Be(created.Binding.Id);
+        fetched.Binding.TargetType.Should().Be(TargetType.Tenant);
+    }
+
+    [Fact]
+    public async Task GetBinding_OnUnknownId_ThrowsNotFound()
+    {
+        var ex = await Assert.ThrowsAsync<RpcException>(() =>
+            _bindings.GetBindingAsync(new GetBindingRequest { Id = Guid.NewGuid().ToString() }).ResponseAsync);
+
+        ex.StatusCode.Should().Be(StatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteBinding_RoundTrips_AndSecondDeleteThrowsNotFound()
+    {
+        var draft = await CreateDraftAsync(Slug("del"));
+        var created = await _bindings.CreateBindingAsync(new Andy.Policies.Api.Protos.CreateBindingRequest
+        {
+            PolicyVersionId = draft.Id,
+            TargetType = TargetType.Repo,
+            TargetRef = "repo:a/del",
+            BindStrength = ProtoBindStrength.Mandatory,
+        });
+
+        await _bindings.DeleteBindingAsync(new DeleteBindingRequest
+        {
+            Id = created.Binding.Id,
+            Rationale = "no longer needed",
+        });
+
+        var ex = await Assert.ThrowsAsync<RpcException>(() =>
+            _bindings.DeleteBindingAsync(new DeleteBindingRequest { Id = created.Binding.Id }).ResponseAsync);
+
+        ex.StatusCode.Should().Be(StatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ListBindingsByPolicyVersion_HonoursIncludeDeletedFlag()
+    {
+        var draft = await CreateDraftAsync(Slug("list"));
+        await _bindings.CreateBindingAsync(new Andy.Policies.Api.Protos.CreateBindingRequest
+        {
+            PolicyVersionId = draft.Id,
+            TargetType = TargetType.Repo,
+            TargetRef = "repo:a/alive",
+            BindStrength = ProtoBindStrength.Mandatory,
+        });
+        var dead = await _bindings.CreateBindingAsync(new Andy.Policies.Api.Protos.CreateBindingRequest
+        {
+            PolicyVersionId = draft.Id,
+            TargetType = TargetType.Repo,
+            TargetRef = "repo:a/dead",
+            BindStrength = ProtoBindStrength.Mandatory,
+        });
+        await _bindings.DeleteBindingAsync(new DeleteBindingRequest { Id = dead.Binding.Id });
+
+        var visible = await _bindings.ListBindingsByPolicyVersionAsync(new ListBindingsByPolicyVersionRequest
+        {
+            PolicyVersionId = draft.Id,
+            IncludeDeleted = false,
+        });
+        var all = await _bindings.ListBindingsByPolicyVersionAsync(new ListBindingsByPolicyVersionRequest
+        {
+            PolicyVersionId = draft.Id,
+            IncludeDeleted = true,
+        });
+
+        visible.Bindings.Should().ContainSingle();
+        all.Bindings.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ListBindingsByTarget_ReturnsExactMatchOnly()
+    {
+        var draft = await CreateDraftAsync(Slug("tgt"));
+        var lower = $"repo:rivoli-ai/q-{Guid.NewGuid():N}".Substring(0, 30);
+        var upper = lower.ToUpperInvariant();
+        await _bindings.CreateBindingAsync(new Andy.Policies.Api.Protos.CreateBindingRequest
+        {
+            PolicyVersionId = draft.Id,
+            TargetType = TargetType.Repo,
+            TargetRef = lower,
+            BindStrength = ProtoBindStrength.Mandatory,
+        });
+        await _bindings.CreateBindingAsync(new Andy.Policies.Api.Protos.CreateBindingRequest
+        {
+            PolicyVersionId = draft.Id,
+            TargetType = TargetType.Repo,
+            TargetRef = upper,
+            BindStrength = ProtoBindStrength.Mandatory,
+        });
+
+        var lowerResp = await _bindings.ListBindingsByTargetAsync(new ListBindingsByTargetRequest
+        {
+            TargetType = TargetType.Repo,
+            TargetRef = lower,
+        });
+        var upperResp = await _bindings.ListBindingsByTargetAsync(new ListBindingsByTargetRequest
+        {
+            TargetType = TargetType.Repo,
+            TargetRef = upper,
+        });
+
+        lowerResp.Bindings.Should().ContainSingle().Which.TargetRef.Should().Be(lower);
+        upperResp.Bindings.Should().ContainSingle().Which.TargetRef.Should().Be(upper);
+    }
+
+    [Fact]
+    public async Task ResolveBindings_MatchesRestSurface()
+    {
+        var version = await CreateAndPublishAsync(Slug("res"));
+        var target = $"template:{Guid.NewGuid()}";
+        await _bindings.CreateBindingAsync(new Andy.Policies.Api.Protos.CreateBindingRequest
+        {
+            PolicyVersionId = version.Id,
+            TargetType = TargetType.Template,
+            TargetRef = target,
+            BindStrength = ProtoBindStrength.Mandatory,
+        });
+
+        var grpc = await _bindings.ResolveBindingsAsync(new ResolveBindingsRequest
+        {
+            TargetType = TargetType.Template,
+            TargetRef = target,
+        });
+
+        // REST parity check: same target id resolves to the same binding set.
+        var http = _factory.CreateClient();
+        var rest = await http.GetFromJsonAsync<Andy.Policies.Application.Dtos.ResolveBindingsResponse>(
+            $"/api/bindings/resolve?targetType=Template&targetRef={Uri.EscapeDataString(target)}",
+            new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web)
+            {
+                Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
+            });
+
+        grpc.Count.Should().Be(rest!.Count);
+        grpc.Bindings.Select(b => b.BindingId)
+            .Should().BeEquivalentTo(rest.Bindings.Select(b => b.BindingId.ToString()));
+    }
+
+    [Fact]
+    public async Task ResolveBindings_OnEmptyTarget_ReturnsZeroCount()
+    {
+        var response = await _bindings.ResolveBindingsAsync(new ResolveBindingsRequest
+        {
+            TargetType = TargetType.Repo,
+            TargetRef = $"repo:none/missing-{Guid.NewGuid():N}",
+        });
+
+        response.Count.Should().Be(0);
+        response.Bindings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ResolveBindings_WithEmptyTargetRef_ThrowsInvalidArgument()
+    {
+        var ex = await Assert.ThrowsAsync<RpcException>(() =>
+            _bindings.ResolveBindingsAsync(new ResolveBindingsRequest
+            {
+                TargetType = TargetType.Repo,
+                TargetRef = "",
+            }).ResponseAsync);
+
+        ex.StatusCode.Should().Be(StatusCode.InvalidArgument);
+    }
+}


### PR DESCRIPTION
## Summary

`bindings.proto` extends the existing `andy_policies` package + `Andy.Policies.Api.Protos` C# namespace with six RPCs sitting on top of `IBindingService` + `IBindingResolver` — same services powering REST (P3.3, P3.4) and MCP (P3.5):

- `CreateBinding` — refuses Retired targets with `FailedPrecondition`.
- `DeleteBinding` — soft-delete; second delete returns `NotFound`.
- `GetBinding` — single-id read; tombstones still visible.
- `ListBindingsByPolicyVersion` (with `include_deleted` flag).
- `ListBindingsByTarget` — exact-equality match.
- `ResolveBindings` — JOIN-shaped read; same Retired filter + `Mandatory > Recommended` dedup as REST `/api/bindings/resolve`.

**Proto design notes:**
- `TargetType` + `BindStrength` are proto3 enums; the `*_UNSPECIFIED` zero values are rejected as `InvalidArgument` by the server, so callers must pick a real value.
- `state` / `enforcement` / `severity` stay strings on `ResolvedBindingMessage` so proto evolution doesn't couple to internal enum renames (matches `policies.proto` + `lifecycle.proto` convention).
- Timestamps are ISO 8601 strings rather than `google.protobuf.Timestamp`, matching the existing sibling protos.

**Exception mapping** mirrors the REST `PolicyExceptionHandler`:
- `BindingRetiredVersionException` → `FailedPrecondition`
- `ConflictException` → `AlreadyExists`
- `ValidationException` → `InvalidArgument`
- `NotFoundException` → `NotFound`

`ResolveSubjectId` mirrors the REST controller's actor-fallback firewall: when no `NameIdentifier` or `Name` claim is present the RPC throws `Unauthenticated` rather than write a fallback subject id into the catalog.

Closes #24.

## Test plan
- [x] `dotnet test` — 191 unit + 197 integration pass; 6 E2E skipped (`E2E_ENABLED=0`).
- [x] 13 new tests in `BindingsGrpcServiceTests`: create round-trip, retired target → `FailedPrecondition`, unspecified `targetType` → `InvalidArgument`, empty `target_ref` → `InvalidArgument`, unknown version → `NotFound`, get round-trip, get-unknown → `NotFound`, double-delete → `NotFound`, list `includeDeleted` flag, list-by-target exact match (case-sensitive verification), resolve REST parity (binding ids match byte-for-byte), resolve empty target → count 0, resolve empty `target_ref` → `InvalidArgument`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)