### PR TITLE
Implement P3.9 — Epic P3 docs (ADR 0003 + consumer integration guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,12 @@ The `BindingCrossSurfaceParityTests` integration suite (P3.8,
 [#26](https://github.com/rivoli-ai/andy-policies/issues/26)) asserts
 that REST, MCP, and gRPC `resolve` return identical results for a shared
 fixture; `BindingConcurrencyStressTests` exercises 50-way parallel
-create/delete workloads against Postgres without deadlocks.
+create/delete workloads against Postgres without deadlocks. For the
+*why* behind the design (metadata-only firewall, soft-delete to
+preserve audit, two-valued bind-strength, exact-match before P4
+hierarchy walk), see [ADR 0003 — Bindings are content-only metadata](docs/adr/0003-bindings.md).
+A step-by-step guide for services that consume the binding surface
+lives at [`docs/guides/consumer-integration-bindings.md`](docs/guides/consumer-integration-bindings.md).
 
 ## Ports
 

--- a/docs/adr/0003-bindings.md
+++ b/docs/adr/0003-bindings.md
@@ -1,0 +1,296 @@
+# ADR 0003 — Bindings are content-only metadata
+
+## Status
+
+**Accepted** — 2026-04-28. Closes Epic P3 (rivoli-ai/andy-policies#3).
+The implementation stories (P3.1 #19, P3.2 #20, P3.3 #21, P3.4 #22, P3.5
+#23, P3.6 #24, P3.7 #25, P3.8 #26) shipped ahead of this ADR's
+acceptance because the aggregate shape and `targetRef` contract were
+already pinned in the per-story specs. This ADR captures the decisions
+authoritatively for downstream readers.
+
+Supersedes: nothing. Companion to:
+
+- ADR 0001 — Policy versioning (defines the `PolicyVersion` aggregate
+  the binding's FK points at).
+- ADR 0002 — Lifecycle states (the retired-version refusal cited in
+  Decision 5 lives there).
+- ADR 0006 — Audit hash chain (records every binding mutation;
+  `IAuditWriter` call sites in `BindingService` from P3.2 are
+  pre-wired for the real implementation).
+- ADR 0007 — Edit RBAC (per-mutation permission gates that wrap binding
+  writes; lands with P7).
+
+## Context
+
+Epic P3 (rivoli-ai/andy-policies#3) introduces the third
+governance-catalog entity: a metadata link between an immutable
+`PolicyVersion` and a foreign target (template, repo, scope node,
+tenant, org). Consumers — Conductor's ActionBus, andy-tasks per-task
+gates, andy-mcp-gateway tool policy — need to ask "which policies apply
+to this target?" and get back a stable, reproducible answer.
+
+The binding model has to balance four concerns:
+
+1. **Cross-service consistency** must be the consumer's contract, not
+   andy-policies'. We don't validate that a `template:{guid}` actually
+   exists in andy-tasks; that's not our service boundary.
+2. **Audit completeness.** Every mutation is captured by Epic P6's
+   hash-chained audit; that requires the binding row to survive delete
+   so the audit chain can refer back to it.
+3. **Lifecycle correctness.** A binding to a Retired version is
+   semantically invalid (the policy is no longer in force) and must
+   never appear in resolve responses.
+4. **Surface parity.** REST, MCP, gRPC, and CLI must all return the
+   same answer for the same logical question — no surface gets to add
+   business logic.
+
+Three drift risks this ADR addresses, flagged during P3 implementation:
+
+- **`targetRef` validation creep.** Early P3.2 drafts considered
+  validating `targetRef` against a strict regex; rejected because the
+  shapes are consumer-defined and would couple this service to the
+  shape of every consumer.
+- **Hard delete vs soft delete.** Hard delete simplifies queries by
+  removing the row entirely but breaks the audit chain (P6 can't refer
+  to a row that no longer exists). Soft delete with a `DeletedAt`
+  tombstone is the only option that preserves audit semantics.
+- **Three-valued bind strength** (Forbidden / Mandatory /
+  Recommended). Rejected because "forbid" is an override concern (Epic
+  P5), not a baseline binding semantic. A Recommended binding combined
+  with a P5 Override of strength `Mandatory:Forbid` is the documented
+  way to express "this policy must NOT apply here."
+
+## Decisions
+
+### 1. A `Binding` is a typed metadata row linking a `PolicyVersion` to a target reference.
+
+```
+Binding(
+  Id, PolicyVersionId, TargetType, TargetRef,
+  BindStrength, CreatedAt, CreatedBySubjectId,
+  DeletedAt?, DeletedBySubjectId?
+)
+```
+
+`TargetType` is a closed enum of five values
+(`Template / Repo / ScopeNode / Tenant / Org`); `BindStrength` is a
+closed enum of two values (`Mandatory / Recommended`). Both ordinals
+are persisted via `HasConversion<int>` and are load-bearing on disk —
+renaming an enum member is safe, reordering is not.
+
+The aggregate intentionally has no compound uniqueness across
+`(PolicyVersionId, TargetType, TargetRef)` — the same target can
+intentionally bind to multiple versions of the same policy during
+rollout. Duplicate-active detection is a consumer concern.
+
+Rejected:
+- **Embed `targetRef` as a typed object per `TargetType`** (e.g., a
+  `RepoRef { org, name }` discriminated union). Adds proto/JSON
+  serialization complexity for no benefit; the canonical string shapes
+  documented in the design doc are easier for cross-language consumers
+  to produce and parse.
+- **Inline the target on `PolicyVersion`** (bindings as a JSON column).
+  Loses the index path on `(TargetType, TargetRef)` and prevents P4
+  hierarchy walks from joining on the binding row.
+
+### 2. andy-policies does not validate `targetRef` against foreign systems.
+
+`BindingService.CreateAsync` validates only that `targetRef` is
+non-empty (after trim) and ≤512 chars. Cross-service consistency of
+the target is the consumer's contract.
+
+The canonical shapes per `TargetType` are documented in the design
+doc but **not enforced** by this service:
+
+- `template:{guid}` (andy-tasks template id)
+- `repo:{org}/{name}` (GitHub-style slug)
+- `scope:{guid}` (`ScopeNode.Id`, P4)
+- `tenant:{guid}`, `org:{guid}`
+
+Consumers can validate as strictly as they want before calling create;
+this service treats `targetRef` as opaque.
+
+Rejected:
+- **Synchronous resolution against andy-tasks / andy-issues on every
+  create.** Service-boundary firewall break — andy-policies would
+  develop a hard dependency on services it has no operational control
+  over, and a transient andy-tasks outage would cascade into binding
+  failures here. The operational fan-in is a non-goal.
+- **Validation regex per `TargetType`.** Pushes the consumer's shape
+  decisions into our service contract. If andy-tasks changes its
+  template id format, our regex would either reject valid bindings or
+  drift behind. Consumer-side validation is the right boundary.
+
+### 3. Resolution is exact-match in P3.
+
+`GET /api/bindings/resolve?targetType=&targetRef=` returns the
+deduplicated set of `(PolicyVersion, BindStrength)` pairs whose
+binding row has byte-exact `(TargetType, TargetRef)` match. No prefix,
+no case-folding, no hierarchy walk.
+
+The endpoint is shipped this epic so consumers have a stable URL.
+Hierarchical walk lands in P4 behind a `?mode=hierarchy` flag on the
+same endpoint, so consumers written against exact-match resolve do
+not have to move when P4 ships.
+
+Rejected:
+- **Combine exact + hierarchy in one mode at launch.** Hierarchy
+  semantics are non-trivial (stricter-tightens-only resolution, cycle
+  prevention, walk-up traversal) and gate further design decisions
+  that aren't ready in P3. Shipping exact-match first lets consumers
+  integrate now.
+
+### 4. Bind-strength has two values: `Mandatory` and `Recommended`.
+
+- **Mandatory** — the binding's policy *must* apply; consumers reject
+  runs that violate it.
+- **Recommended** — the binding's policy applies as guidance;
+  consumers warn but do not block.
+
+When two bindings on the same target reference the same `PolicyVersion`,
+`Mandatory` wins the dedup over `Recommended` (tiebreak earliest
+`CreatedAt`). The administrative duplicate this guards against ("oops,
+two bindings for the same target and version") would otherwise show up
+to consumers as redundant rows.
+
+Rejected:
+- **Forbidden as a third value.** Forbid semantics are an override
+  concern (Epic P5). A Recommended binding paired with a P5 override
+  of strength `Mandatory:Forbid` expresses "must NOT apply here"
+  cleanly, with the override carrying its own approval workflow and
+  expiry. Three-valued bind-strength would conflate "applicability"
+  with "exclusion."
+- **Numeric priority** (e.g., 0–10). Encourages bikeshedding over
+  fairly arbitrary numbers and introduces a comparator dimension that
+  consumers don't actually need. The two-value enum is sufficient.
+
+### 5. Retired versions cannot be bound; existing bindings to Retired versions are filtered out of resolve.
+
+`BindingService.CreateAsync` refuses bindings whose target version is
+in `LifecycleState.Retired` and throws
+`BindingRetiredVersionException` (HTTP 409, gRPC `FailedPrecondition`,
+MCP `policy.binding.retired_target`). `Active` and `WindingDown` both
+accept new bindings — `WindingDown` lets consumers author bindings
+during a sunset window.
+
+`BindingResolver.ResolveExactAsync` filters out bindings whose target
+version is currently `Retired`, even if the binding row was created
+when the version was still `Active`. Consumers never see retired
+versions in resolve responses.
+
+The retired-version guard runs inside the create's serializable
+transaction. A concurrent retire can race a concurrent create — one of
+two outcomes: (a) the retire commits first, the create observes
+`State == Retired` and throws; (b) the create commits first, the row
+is alive against the newly-Retired version but is filtered from
+subsequent resolves. Consumers see the same end state either way.
+
+Rejected:
+- **Delete bindings on retire.** Breaks the audit chain (P6); a
+  forensic "what bindings existed for this version when it was
+  Retired?" query becomes impossible.
+- **CHECK constraint via DB trigger.** Couples two domain concerns
+  (lifecycle and binding) at the DB layer; the service-layer guard is
+  testable in isolation and colocates with the invariant's owner.
+
+### 6. Bindings use soft-delete to preserve the audit chain.
+
+`DeleteAsync` stamps `DeletedAt = now` and `DeletedBySubjectId = actor`
+rather than removing the row. Already-tombstoned bindings are treated
+as not-found for both read and delete (a second delete returns 404).
+
+Read endpoints filter `DeletedAt IS NULL` by default. The
+version-rooted enumeration (`/api/policies/{id}/versions/{vid}/bindings`)
+opts in via `?includeDeleted=true` for forensic queries.
+
+Rejected:
+- **Hard delete + audit-only preservation.** P6's audit chain would
+  hold the deleted row's content but the binding's stable id would no
+  longer resolve from any read endpoint. Investigators would have to
+  cross-reference via the audit log, which is a worse UX than
+  preserving the row and stamping a tombstone.
+
+### 7. The same service layer powers REST, MCP, gRPC, CLI surfaces.
+
+`IBindingService` and `IBindingResolver` are the single source of
+truth. Every controller, MCP tool, gRPC service, and CLI command
+delegates here — there is no business logic anywhere outside
+`BindingService` and `BindingResolver`. Surface drift is caught by
+`BindingCrossSurfaceParityTests` (P3.8), which drives the same logical
+request through REST, MCP, and gRPC and asserts the response set is
+identical.
+
+The CLI (P3.7) is a thin REST client; its parity is implied by the
+REST assertion, mirroring the rationale established in
+`CrossSurfaceParityTests` from P1.
+
+Rejected:
+- **Duplicate validation across surfaces.** Any "let me re-check this
+  invariant on the gRPC layer just in case" pattern violates the rule
+  and creates drift opportunities. The cross-surface parity test
+  catches the obvious cases; the rule itself is the prevention.
+
+## Consequences
+
+### Positive
+
+- **Consumers own target semantics.** A consumer can choose to validate
+  `targetRef` strictly or loosely; this service does not constrain
+  them. New target types can be added without breaking existing
+  consumers (additive enum extension).
+- **Audit completeness.** Soft-delete + retired-version filter together
+  mean every mutation is recoverable from the audit chain (P6) and no
+  retired version "haunts" downstream evaluations.
+- **Surface parity is a testing invariant, not a coding intent.** The
+  cross-surface parity test fails when surfaces drift, so the rule is
+  enforced rather than aspirational.
+- **Forward compatibility with P4.** The exact-match resolve URL stays
+  stable; hierarchy walk is additive behind a query flag.
+
+### Negative / accepted trade-offs
+
+- **No referential integrity across services.** A binding can point at
+  a `template:{guid}` that no longer exists in andy-tasks. Consumers
+  must handle stale refs themselves (treat as "no policy applies" or
+  surface a UI warning).
+- **Soft-delete grows the table monotonically.** Storage scales with
+  binding-mutation volume, not active binding count. Bounded by author
+  workflow pace; ADR 0006's non-goal of audit truncation applies.
+- **Two-valued bind-strength is coarse.** Consumers that want finer
+  gradients have to encode the nuance in the policy rule body
+  (`PolicyVersion.RulesJson`), not the binding. Acceptable because the
+  binding model stays simple and the rule body is the right home for
+  policy-specific gradients.
+
+### Follow-ups
+
+- ADR 0004 — Scope hierarchy + tighten-only resolution (Epic P4) extends
+  the resolver with `?mode=hierarchy` semantics; this ADR's exact-match
+  contract stays the default.
+- ADR 0005 — Overrides (Epic P5) introduces the `Mandatory:Forbid`
+  shape that pairs with `Recommended` binding to express exclusion.
+- ADR 0006 — Audit hash chain replaces the no-op `IAuditWriter` with
+  the real implementation; the call sites added in P3.2 are
+  pre-wired.
+
+## Considered alternatives
+
+| Alternative                                                           | Rejected because |
+|-----------------------------------------------------------------------|------------------|
+| Embed `targetRef` as a typed discriminated union per `TargetType`     | Cross-language serialization complexity; canonical string shapes are easier |
+| Inline bindings as a JSON column on `PolicyVersion`                   | Loses the `(TargetType, TargetRef)` index; prevents P4 join semantics |
+| Synchronous resolution against foreign systems on create              | Service-boundary firewall break; transient outage cascades |
+| Validation regex per `TargetType`                                     | Pushes consumer shape decisions into our service contract |
+| Hierarchy walk in P3                                                  | Non-trivial design (stricter-tightens-only, cycle prevention) blocks per-story progress |
+| Three-valued bind-strength (Forbidden / Mandatory / Recommended)      | Forbid is an override concern (P5); conflates applicability with exclusion |
+| Numeric priority for bind-strength                                    | Encourages bikeshedding; consumers don't need a comparator |
+| Hard-delete bindings                                                  | Breaks audit chain |
+| Delete bindings on retire                                             | Breaks the "bindings to Retired version" forensic query |
+| CHECK constraint trigger for retired-version refusal                  | Couples lifecycle and binding at the DB layer |
+| Hard delete + audit-only preservation                                 | Stable id no longer resolves from read endpoints |
+| Duplicate validation across surfaces "just in case"                   | Surface drift opportunity; the parity test is the prevention |
+
+---
+
+**Authors**: drafted by Claude during P3.9 implementation. Post-acceptance edits require a follow-up ADR — this ADR is load-bearing for ADR 0004's hierarchy walk semantics and ADR 0006's audit-row mapping.

--- a/docs/design/bindings.md
+++ b/docs/design/bindings.md
@@ -10,8 +10,7 @@ This document targets two readers: a contributor about to touch
 `BindingService`, and a consumer engineer (Conductor's ActionBus,
 andy-tasks per-task gates) who's wiring up policy resolution. For the
 *why* — the metadata-only firewall, soft-delete preservation, dedup
-rules — see ADR 0003 — Bindings (lands with
-[P3.9](https://github.com/rivoli-ai/andy-policies/issues/27)). For the
+rules — see [ADR 0003 — Bindings](../adr/0003-bindings.md). For the
 underlying aggregate, see [Policy Document Core](policy-document-core.md);
 for lifecycle states, [Lifecycle States](lifecycle.md).
 
@@ -188,4 +187,5 @@ of two outcomes:
   retired-version refusal cited above.
 - [Lifecycle States design](lifecycle.md) — surface parity table for
   the lifecycle state machine these bindings observe.
-- ADR 0003 — Bindings (deferred to [P3.9](https://github.com/rivoli-ai/andy-policies/issues/27); will capture the metadata-only firewall and dedup rules).
+- [ADR 0003 — Bindings are content-only metadata](../adr/0003-bindings.md) — the decisions captured authoritatively (metadata-only firewall, soft-delete preservation, dedup rules, surface parity).
+- [Consumer integration: bindings](../guides/consumer-integration-bindings.md) — step-by-step guide for services that consume the binding surface.

--- a/docs/guides/consumer-integration-bindings.md
+++ b/docs/guides/consumer-integration-bindings.md
@@ -1,0 +1,247 @@
+# Consumer Integration: Bindings
+
+A practical guide for services that need to ask **"which policies apply
+to this target?"** and act on the answer. Targeted at: Conductor's
+ActionBus, andy-tasks per-task gates, andy-mcp-gateway tool policy, and
+any future consumer of andy-policies bindings.
+
+For the *what* and *why* — entity shape, design rules, surface parity —
+start with [Bindings (design)](../design/bindings.md) and
+[ADR 0003 — Bindings are content-only metadata](../adr/0003-bindings.md).
+This guide assumes you've read those.
+
+> **Scope reminder.** andy-policies stores *what* policies bind to *what*
+> targets. Whether a run violates a policy is a consumer concern —
+> Conductor's ActionBus evaluates the rule body, andy-tasks gates the
+> task, etc. This service is the catalog, not the enforcer.
+
+## 1. Build a canonical `targetRef`
+
+Each `TargetType` has a canonical shape. andy-policies does not enforce
+the shape (per ADR 0003 §2), but stick to the table below so P4
+hierarchy walks and P8 bundle resolves can join on the same key.
+
+| `TargetType` | Canonical `targetRef`        | Example                                         |
+|--------------|------------------------------|-------------------------------------------------|
+| `Template`   | `template:{guid}`            | `template:3f2e5c1a-1010-4d6c-9d83-001e842b9013` |
+| `Repo`       | `repo:{org}/{name}`          | `repo:rivoli-ai/andy-policies`                  |
+| `ScopeNode`  | `scope:{guid}`               | `scope:b87...` (the `ScopeNode.Id` from P4)     |
+| `Tenant`     | `tenant:{guid}`              | `tenant:00000000-0000-0000-0000-000000000001`   |
+| `Org`        | `org:{guid}`                 | `org:00000000-0000-0000-0000-000000000001`      |
+
+For `ScopeNode`, P4.2 will expose path → id resolution. Until then,
+consumers that want to bind to a path resolve the path to its
+`ScopeNode.Id` first via `IScopeService` (when P4 lands), then build
+`scope:{id}`.
+
+Service-side validation: non-empty (after trim), ≤ 512 chars. Anything
+else passes — the consumer is responsible for shape correctness.
+
+## 2. Resolve before deciding
+
+Always call `resolve` to get the consumer-ready set of `(PolicyVersion,
+BindStrength)` tuples for a target. The endpoint joins `Binding +
+PolicyVersion + Policy` and returns a deduplicated, ordered response.
+
+### REST
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "$API/api/bindings/resolve?targetType=Template&targetRef=template:abc"
+```
+
+```json
+{
+  "targetType": "Template",
+  "targetRef": "template:abc",
+  "count": 1,
+  "bindings": [
+    {
+      "bindingId": "9d28...",
+      "policyId": "55ab...",
+      "policyName": "write-branch-only",
+      "policyVersionId": "0a17...",
+      "versionNumber": 3,
+      "versionState": "Active",
+      "enforcement": "MUST",
+      "severity": "critical",
+      "scopes": ["prod"],
+      "bindStrength": "Mandatory"
+    }
+  ]
+}
+```
+
+### MCP
+
+```text
+policy.binding.resolve targetType=Template targetRef=template:abc
+```
+
+The tool returns the same JSON envelope (web casing, string enums) so
+agents can pipe through deterministic parsers.
+
+### gRPC
+
+```bash
+grpcurl -plaintext -d '{
+  "target_type": "TARGET_TYPE_TEMPLATE",
+  "target_ref":  "template:abc"
+}' $API andy_policies.BindingService/ResolveBindings
+```
+
+### CLI
+
+```bash
+andy-policies-cli bindings resolve \
+  --target-type Template \
+  --target-ref template:abc \
+  --output json
+```
+
+All four surfaces return identical results for the same target; the
+parity is verified by `BindingCrossSurfaceParityTests` (P3.8).
+
+## 3. Interpret `bindStrength`
+
+| Value          | Consumer behaviour                                                           |
+|----------------|------------------------------------------------------------------------------|
+| `Mandatory`    | The policy *must* apply. Reject runs that violate it; surface as an error.  |
+| `Recommended`  | The policy applies as guidance. Warn / annotate UI; do not block.           |
+
+Same-target/same-version duplicates dedup with `Mandatory > Recommended`
+(tiebreak earliest `CreatedAt`), so consumers see at most one row per
+`(target, policyVersion)`. If you need finer gradients, encode them in
+the policy rule body — that's not the binding's job (ADR 0003 §4).
+
+## 4. Handle zero results
+
+A target with no live bindings returns `200 OK` with `count: 0` and an
+empty `bindings` array — never `404`. Treat this as **"no policy
+constraints"**.
+
+andy-policies is fail-open for this resolution: zero bindings means the
+catalog has nothing to say about the target. Consumers can choose to
+fail-closed at their own layer (e.g., "no binding = reject the run")
+but that's an enforcement decision, not something the catalog encodes.
+
+## 5. Cache locally
+
+The resolve response is safe to cache by `(targetType, targetRef)` for
+short-to-medium TTLs. Two invalidation hints:
+
+- **Active version flips.** When a publisher promotes a new
+  `PolicyVersion` to `Active`, the prior version transitions to
+  `WindingDown` in the same DB transaction (Epic P2 lifecycle). The
+  resolve response will contain the new `policyVersionId` next time
+  you ask. If your TTL is longer than your tolerance for stale rule
+  bodies, listen for the `PolicyVersionPublished` /
+  `PolicyVersionSuperseded` events (today in-process; v2 over NATS via
+  Epic AL).
+- **Bundle pinning.** Epic P8 introduces immutable bundle snapshots —
+  consumers that need reproducible decisions across cache windows can
+  pin a bundle id and resolve through `?bundleId=…` instead. Until P8,
+  use a TTL ≤ your acceptable staleness window.
+
+Recommended TTL: **30–120s** for steady-state; **invalidate on event**
+when available.
+
+## 6. Edge cases
+
+### A binding's target version transitions to Retired
+
+The row stays in the DB, but `resolve` filters it out (Epic P2 §retire
++ ADR 0003 §5). Consumers see the binding disappear from resolve
+responses; no client-side action needed.
+
+If you cached the resolve response, the cache will refresh on TTL
+expiry. If you need to react immediately, listen for the
+`PolicyVersionRetired` domain event.
+
+### A binding is soft-deleted
+
+`DeleteAsync` stamps `DeletedAt` rather than removing the row.
+Tombstoned bindings:
+
+- Are visible via `GET /api/bindings/{id}` (forensic / audit) — you
+  can inspect `deletedAt` and `deletedBySubjectId`.
+- Are invisible in the default `GET /api/bindings?...` and in
+  `resolve`.
+- Are visible in the version-rooted enumeration with
+  `?includeDeleted=true`.
+
+A tombstoned binding's id never resurrects. Creating a "new" binding
+to the same `(targetType, targetRef, policyVersionId)` mints a fresh
+`Binding.Id`.
+
+### A target has bindings to multiple versions of the same policy
+
+This is the rollout scenario: a target was bound to `write-branch v1`,
+then someone added a binding to `write-branch v2` for canary. Both
+versions appear in the resolve response (different `policyVersionId`s),
+ordered by version number DESC.
+
+Consumers typically use the highest-numbered `Active` version per
+policy; check `versionState == "Active"` and ignore `WindingDown`
+unless your read path explicitly tolerates legacy versions (e.g.,
+Conductor pinning to `policyVersionId` for reproducibility).
+
+### A target ref points at a foreign id that no longer exists
+
+andy-policies has no referential integrity with andy-tasks /
+andy-issues / etc. (ADR 0003 §2). A binding to `template:gone-guid`
+will continue to appear in resolve. The consumer is responsible for
+detecting the stale ref:
+
+- Treat it as "no policy applies" (silent), or
+- Surface a UI warning ("stale binding to deleted template"), or
+- Run a periodic reconciler that soft-deletes orphaned bindings.
+
+andy-policies will not perform this reconciliation.
+
+## 7. Forward compatibility: P4 hierarchy mode
+
+Today, `resolve` is exact-match: only bindings whose `(targetType,
+targetRef)` match byte-for-byte are returned. P4 (Scope hierarchy +
+tighten-only resolution) extends the same endpoint with a
+`?mode=hierarchy` flag that walks up the scope tree and applies
+stricter-tightens-only resolution semantics.
+
+**Consumer code written against the exact-match resolve will continue
+to work without changes.** The default mode stays exact-match;
+hierarchy mode is opt-in.
+
+When P4 ships, you can choose to:
+
+1. Keep exact-match. Your consumer continues to see exactly the
+   bindings whose target matches the ref it sends.
+2. Opt into hierarchy. Your consumer asks "what policies apply to
+   this target *and its ancestors*?" and gets back the
+   stricter-tightens-only resolved set.
+
+The decision is per-call. ActionBus might use hierarchy for "which
+policies govern this run?", while a forensic UI might use exact-match
+to show only the directly-attached bindings.
+
+## 8. Cross-references
+
+- [Bindings (design)](../design/bindings.md) — entity shape,
+  invariants, surface parity table.
+- [ADR 0003 — Bindings are content-only metadata](../adr/0003-bindings.md)
+  — the decisions captured authoritatively.
+- [Policy Document Core (design)](../design/policy-document-core.md) —
+  the `Policy` + `PolicyVersion` aggregate the binding's FK points at.
+- [Lifecycle States (design)](../design/lifecycle.md) — the
+  retired-version refusal cited in §6 and ADR 0003 §5.
+
+For consumer-side integrations:
+
+- **Conductor ActionBus** —
+  [rivoli-ai/conductor#647 (Epic AF)](https://github.com/rivoli-ai/conductor/issues/647)
+  for the Cockpit binding UX deep-link.
+- **andy-tasks** —
+  [rivoli-ai/andy-tasks#10 (Epic U)](https://github.com/rivoli-ai/andy-tasks/issues/10)
+  for `DelegationContract.PolicyVersionId` usage.
+- **andy-mcp-gateway** —
+  [rivoli-ai/andy-mcp-gateway#2 (Epic AM)](https://github.com/rivoli-ai/andy-mcp-gateway/issues/2)
+  for tool-policy binding patterns.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,8 +20,11 @@ nav:
     - Policy document core: design/policy-document-core.md
     - Lifecycle states: design/lifecycle.md
     - Bindings: design/bindings.md
+  - Guides:
+    - Consumer integration — bindings: guides/consumer-integration-bindings.md
   - ADRs:
     - 0001 Policy versioning: adr/0001-policy-versioning.md
     - 0002 Lifecycle states: adr/0002-lifecycle-states.md
+    - 0003 Bindings: adr/0003-bindings.md
     - 0006 Audit hash chain: adr/0006-audit-hash-chain.md
     - 0007 Edit RBAC: adr/0007-edit-rbac.md


### PR DESCRIPTION
## Summary

Closes Epic P3 with the documentation artefacts the per-story specs deferred:

- **`docs/adr/0003-bindings.md`** — Bindings are content-only metadata. Captures the seven decisions authoritatively (typed metadata row; no foreign-system validation; exact-match resolution in P3 with hierarchy deferred to P4; two-valued bind-strength; retired-version refusal + filter; soft-delete to preserve audit; single service layer powers all four surfaces). Documents the trade-offs and exhaustive considered-alternatives table.
- **`docs/guides/consumer-integration-bindings.md`** — step-by-step guide for services that consume the binding surface (Conductor's ActionBus, andy-tasks per-task gates, andy-mcp-gateway tool policy). Covers canonical `TargetRef` shapes, resolve-before-decision pattern across REST/MCP/gRPC/CLI, `BindStrength` interpretation, zero-result handling, caching guidance, edge cases (retired versions, soft-delete, stale refs, multi-version targets), and the forward-compatibility path to P4 hierarchy mode.
- **`mkdocs.yml`** — adds a `Guides` nav section + ADR 0003 + design-doc cross-link. `mkdocs build --strict` clean.
- **`README.md`** — links to the ADR and the consumer guide alongside the existing design-doc reference.
- **`docs/design/bindings.md`** — replaces the "lands with P3.9" caveat with live links to ADR 0003 and the consumer guide.

Closes #27, closes Epic P3 (#3).

## Test plan
- [x] `dotnet test` — 199 unit + 219 integration pass; 6 E2E skipped (`E2E_ENABLED=0`). No new tests in this story; the docs reference the test suites that already exist.
- [x] `mkdocs build --strict` — clean build, no warnings or broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)