### PR TITLE
Implement P4.3 — BindingResolutionService with stricter-tightens-only resolution

### DIFF
--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -98,6 +98,13 @@ builder.Services.AddScoped<IItemService, ItemService>();
 builder.Services.AddScoped<IPolicyService, PolicyService>();
 builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBindingService, Andy.Policies.Infrastructure.Services.BindingService>();
 builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBindingResolver, Andy.Policies.Infrastructure.Services.BindingResolver>();
+// P4.2 (#29): hierarchy CRUD + walk-up. Consumed by P4.3 binding
+// resolution and P4.4 tighten-only validation.
+builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IScopeService, Andy.Policies.Infrastructure.Services.ScopeService>();
+// P4.3 (#30): stricter-tightens-only resolver — walks the scope chain
+// from root to leaf and merges ScopeNode-targeted bindings with the
+// bridge bindings that target each chain node's external Ref.
+builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBindingResolutionService, Andy.Policies.Infrastructure.Services.BindingResolutionService>();
 // P3.2 (#20): Binding mutations call IAuditWriter — Epic P6
 // (rivoli-ai/andy-policies#6) replaces the no-op with the real
 // hash-chained writer. Singleton because the P6 implementation will own a

--- a/src/Andy.Policies.Application/Dtos/EffectivePolicyDto.cs
+++ b/src/Andy.Policies.Application/Dtos/EffectivePolicyDto.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Domain.Enums;
+
+namespace Andy.Policies.Application.Dtos;
+
+/// <summary>
+/// One entry in an effective-policy set (P4.3, story
+/// rivoli-ai/andy-policies#30). The result of stricter-tightens-only
+/// resolution: each <see cref="PolicyId"/> appears at most once,
+/// carrying the strictest <see cref="BindStrength"/> seen anywhere in
+/// the scope chain plus a pointer back to the binding (and the scope
+/// node that bound it) that won the resolution.
+/// </summary>
+public sealed record EffectivePolicyDto(
+    Guid PolicyId,
+    Guid PolicyVersionId,
+    string PolicyKey,
+    int Version,
+    BindStrength BindStrength,
+    Guid SourceBindingId,
+    Guid? SourceScopeNodeId,
+    ScopeType? SourceScopeType,
+    int SourceDepth);

--- a/src/Andy.Policies.Application/Dtos/EffectivePolicySetDto.cs
+++ b/src/Andy.Policies.Application/Dtos/EffectivePolicySetDto.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.Dtos;
+
+/// <summary>
+/// Envelope for <c>IBindingResolutionService</c> results (P4.3, story
+/// rivoli-ai/andy-policies#30). <see cref="ScopeNodeId"/> is null when
+/// the resolver was called with a target that does not map to a known
+/// <c>ScopeNode</c> — the service then degrades to P3 exact-match
+/// semantics rather than returning 404.
+/// </summary>
+public sealed record EffectivePolicySetDto(
+    Guid? ScopeNodeId,
+    IReadOnlyList<EffectivePolicyDto> Policies);

--- a/src/Andy.Policies.Application/Interfaces/IBindingResolutionService.cs
+++ b/src/Andy.Policies.Application/Interfaces/IBindingResolutionService.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Domain.Enums;
+
+namespace Andy.Policies.Application.Interfaces;
+
+/// <summary>
+/// Hierarchy-aware resolution: walks the scope chain from root to
+/// leaf, gathers every binding that targets a node in the chain (or
+/// the chain's own external <c>Ref</c> via the bridge to P3 non-scope
+/// bindings), and folds them with stricter-tightens-only semantics
+/// (P4.3, story rivoli-ai/andy-policies#30).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Distinct from <see cref="IBindingResolver"/> from P3.4: that
+/// service does an exact-match lookup at a single target;
+/// <see cref="IBindingResolutionService"/> walks the chain and merges.
+/// </para>
+/// <para>
+/// <b>Tighten-only fold rules</b>:
+/// <list type="bullet">
+///   <item>For each <c>PolicyId</c> seen in the chain, a Mandatory
+///     binding anywhere wins over any Recommended binding for the
+///     same policy (descendant Recommended cannot downgrade an
+///     ancestor Mandatory).</item>
+///   <item>Among bindings of the strictest strength present, the
+///     deepest binding wins (most-specific-wins). Tied depth +
+///     strength: earliest <c>CreatedAt</c> wins.</item>
+///   <item>Result is sorted Mandatory-first, then by
+///     <c>PolicyKey</c> alphabetically.</item>
+/// </list>
+/// </para>
+/// <para>
+/// Retired versions are <b>not</b> filtered here — what's bound is
+/// what's returned. Consumers (Conductor's ActionBus, andy-tasks
+/// per-task gates) decide how to handle deprecation. This differs
+/// deliberately from <see cref="IBindingResolver.ResolveExactAsync"/>,
+/// which filters Retired because it's a single-target view; chain
+/// resolution surfaces the entire policy story.
+/// </para>
+/// </remarks>
+public interface IBindingResolutionService
+{
+    /// <summary>
+    /// Resolve the effective policy set for a known scope node.
+    /// Throws <c>NotFoundException</c> when the scope node does not
+    /// exist.
+    /// </summary>
+    Task<EffectivePolicySetDto> ResolveForScopeAsync(
+        Guid scopeNodeId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Resolve the effective policy set for a foreign target. If
+    /// <paramref name="targetType"/>/<paramref name="targetRef"/>
+    /// maps to a known <see cref="Domain.Entities.ScopeNode"/>, the
+    /// resolver walks from that node. Otherwise it degrades to P3
+    /// exact-match semantics — returns whatever bindings target the
+    /// pair directly, with <c>SourceScopeNodeId</c> = null on the
+    /// envelope.
+    /// </summary>
+    Task<EffectivePolicySetDto> ResolveForTargetAsync(
+        BindingTargetType targetType,
+        string targetRef,
+        CancellationToken ct = default);
+}

--- a/src/Andy.Policies.Infrastructure/Services/BindingResolutionService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BindingResolutionService.cs
@@ -1,0 +1,339 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Exceptions;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Andy.Policies.Infrastructure.Services;
+
+/// <summary>
+/// Hierarchy-aware binding resolver (P4.3, story
+/// rivoli-ai/andy-policies#30). Walks the scope chain from root Org
+/// down to the leaf (or to the resolved target) and folds the binding
+/// set with stricter-tightens-only semantics. The fold rule is the
+/// header decision of Epic P4: a Mandatory binding anywhere in the
+/// chain cannot be downgraded by a descendant; the deepest binding of
+/// the strictest strength wins.
+/// </summary>
+public sealed class BindingResolutionService : IBindingResolutionService
+{
+    private readonly AppDbContext _db;
+    private readonly IScopeService _scopes;
+
+    public BindingResolutionService(AppDbContext db, IScopeService scopes)
+    {
+        _db = db;
+        _scopes = scopes;
+    }
+
+    public async Task<EffectivePolicySetDto> ResolveForScopeAsync(
+        Guid scopeNodeId,
+        CancellationToken ct = default)
+    {
+        var leaf = await _db.ScopeNodes.AsNoTracking()
+            .FirstOrDefaultAsync(s => s.Id == scopeNodeId, ct)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException($"ScopeNode {scopeNodeId} not found.");
+
+        var ancestors = await _scopes.GetAncestorsAsync(scopeNodeId, ct).ConfigureAwait(false);
+        var chain = ancestors.Select(a => new ChainNode(a.Id, a.Type, a.Ref, a.Depth)).ToList();
+        chain.Add(new ChainNode(leaf.Id, leaf.Type, leaf.Ref, leaf.Depth));
+
+        var policies = await ResolveAlongChainAsync(chain, ct).ConfigureAwait(false);
+        return new EffectivePolicySetDto(scopeNodeId, policies);
+    }
+
+    public async Task<EffectivePolicySetDto> ResolveForTargetAsync(
+        BindingTargetType targetType,
+        string targetRef,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(targetRef);
+
+        // Try the bridge: BindingTargetType maps to ScopeType for the
+        // overlapping levels (Org/Tenant/Repo/Template). Team and Run
+        // have no BindingTargetType; ScopeNode is the explicit
+        // chain-walk path. If we find a ScopeNode by (Type, Ref),
+        // hand off to the chain walker.
+        if (TryMapToScopeType(targetType, out var scopeType))
+        {
+            var match = await _db.ScopeNodes.AsNoTracking()
+                .FirstOrDefaultAsync(s => s.Type == scopeType && s.Ref == targetRef, ct)
+                .ConfigureAwait(false);
+            if (match is not null)
+            {
+                return await ResolveForScopeAsync(match.Id, ct).ConfigureAwait(false);
+            }
+        }
+        else if (targetType == BindingTargetType.ScopeNode)
+        {
+            // Caller passed scopeRef as a ScopeNode target — let them
+            // address the node directly. The conventional shape is
+            // "scope:{guid}" but we accept either form.
+            if (Guid.TryParse(targetRef, out var directId)
+                || (targetRef.StartsWith("scope:", StringComparison.Ordinal)
+                    && Guid.TryParse(targetRef.AsSpan("scope:".Length), out directId)))
+            {
+                var directMatch = await _db.ScopeNodes.AsNoTracking()
+                    .FirstOrDefaultAsync(s => s.Id == directId, ct)
+                    .ConfigureAwait(false);
+                if (directMatch is not null)
+                {
+                    return await ResolveForScopeAsync(directMatch.Id, ct).ConfigureAwait(false);
+                }
+            }
+        }
+
+        // Fallback to P3 exact-match: no scope node, just whatever
+        // bindings target this exact pair. SourceScopeNodeId stays
+        // null on the envelope so callers can tell the difference.
+        var (fallbackRows, fallbackVersions, fallbackPolicies) = await LoadBindingsWithHydrationAsync(
+                _db.Bindings.AsNoTracking()
+                    .Where(b => b.TargetType == targetType && b.TargetRef == targetRef && b.DeletedAt == null),
+                ct)
+            .ConfigureAwait(false);
+        var policies = FoldRows(fallbackRows, scopeDepthLookup: null,
+            versionById: fallbackVersions, policyById: fallbackPolicies);
+        return new EffectivePolicySetDto(ScopeNodeId: null, policies);
+    }
+
+    private async Task<IReadOnlyList<EffectivePolicyDto>> ResolveAlongChainAsync(
+        IReadOnlyList<ChainNode> chain,
+        CancellationToken ct)
+    {
+        // Build the predicate set for one round-trip. For each node we
+        // pick up:
+        //   1. ScopeNode-targeted bindings via "scope:{nodeId}".
+        //   2. Bridge bindings — the same row a P3 caller would create
+        //      against the leaf's external ref (e.g. "repo:org/name"
+        //      with TargetType=Repo). This lets the catalog stay
+        //      backward-compatible with bindings authored before
+        //      scope nodes existed.
+        var scopeNodeRefs = chain.Select(c => $"scope:{c.Id}").ToList();
+        var bridgeKeys = chain
+            .Select(c => (Type: TryMapToBindingTargetType(c.Type), Ref: c.Ref))
+            .Where(p => p.Type is not null)
+            .Select(p => new BridgeKey(p.Type!.Value, p.Ref))
+            .Distinct()
+            .ToList();
+
+        // EF Core 8 can't combine the two filters into one query
+        // directly, but we can pull each subset and merge in memory —
+        // both subsets are bounded by the chain depth (≤ 6) × bindings
+        // per node, so the cost is small and avoids a recursive CTE.
+        var scopeBound = await _db.Bindings.AsNoTracking()
+            .Where(b => b.TargetType == BindingTargetType.ScopeNode
+                        && b.DeletedAt == null
+                        && scopeNodeRefs.Contains(b.TargetRef))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var bridgeBound = new List<Binding>();
+        if (bridgeKeys.Count > 0)
+        {
+            var bridgeTypes = bridgeKeys.Select(k => k.Type).Distinct().ToList();
+            var bridgeRefs = bridgeKeys.Select(k => k.Ref).Distinct().ToList();
+            var candidates = await _db.Bindings.AsNoTracking()
+                .Where(b => bridgeTypes.Contains(b.TargetType)
+                            && bridgeRefs.Contains(b.TargetRef)
+                            && b.DeletedAt == null)
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+            // Filter to the exact (Type, Ref) pairs we care about; the
+            // pre-filter above is wider to keep the SQL simple.
+            var keySet = new HashSet<BridgeKey>(bridgeKeys);
+            bridgeBound = candidates
+                .Where(b => keySet.Contains(new BridgeKey(b.TargetType, b.TargetRef)))
+                .ToList();
+        }
+
+        // Hydrate PolicyVersion + Policy in one shot.
+        var versionIds = scopeBound.Concat(bridgeBound).Select(b => b.PolicyVersionId).Distinct().ToList();
+        var versions = await _db.PolicyVersions.AsNoTracking()
+            .Where(v => versionIds.Contains(v.Id))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+        var policyIds = versions.Select(v => v.PolicyId).Distinct().ToList();
+        var policies = await _db.Policies.AsNoTracking()
+            .Where(p => policyIds.Contains(p.Id))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+        var versionById = versions.ToDictionary(v => v.Id);
+        var policyById = policies.ToDictionary(p => p.Id);
+
+        // Build a lookup from each binding to the depth of the scope
+        // node it semantically attached to. For ScopeNode-targeted
+        // bindings, parse the targetRef tail. For bridge-bound, look
+        // up by (Type, Ref). When a row touches multiple chain nodes
+        // (shouldn't happen with our keys, but be safe), pick the
+        // deepest occurrence.
+        var depthByBinding = new Dictionary<Guid, (int Depth, Guid? ScopeNodeId, ScopeType? ScopeType)>();
+        var chainScopeRefById = chain.ToDictionary(c => c.Id);
+        foreach (var b in scopeBound)
+        {
+            // "scope:{guid}" → guid → chain node depth
+            if (b.TargetRef.StartsWith("scope:", StringComparison.Ordinal)
+                && Guid.TryParse(b.TargetRef.AsSpan("scope:".Length), out var nodeId)
+                && chainScopeRefById.TryGetValue(nodeId, out var node))
+            {
+                depthByBinding[b.Id] = (node.Depth, node.Id, node.Type);
+            }
+        }
+        foreach (var b in bridgeBound)
+        {
+            // Find the chain node whose (Type, Ref) bridges to this
+            // binding. Pick the deepest if multiple match (defensive).
+            var matchingChain = chain
+                .Where(c => TryMapToBindingTargetType(c.Type) == b.TargetType && c.Ref == b.TargetRef)
+                .OrderByDescending(c => c.Depth)
+                .FirstOrDefault();
+            if (matchingChain is not null)
+            {
+                depthByBinding[b.Id] = (matchingChain.Depth, matchingChain.Id, matchingChain.Type);
+            }
+        }
+
+        var allBindings = scopeBound.Concat(bridgeBound).Distinct(new BindingIdComparer()).ToList();
+        return FoldRows(
+            allBindings,
+            scopeDepthLookup: bindingId => depthByBinding.TryGetValue(bindingId, out var info) ? info : default,
+            versionById: versionById,
+            policyById: policyById);
+    }
+
+    private static IReadOnlyList<EffectivePolicyDto> FoldRows(
+        IReadOnlyList<Binding> bindings,
+        Func<Guid, (int Depth, Guid? ScopeNodeId, ScopeType? ScopeType)>? scopeDepthLookup = null,
+        Dictionary<Guid, PolicyVersion>? versionById = null,
+        Dictionary<Guid, Policy>? policyById = null)
+    {
+        if (bindings.Count == 0)
+        {
+            return Array.Empty<EffectivePolicyDto>();
+        }
+
+        // Need the version + policy hydration; if the caller didn't
+        // provide them, assume the bindings list is already small
+        // enough to hydrate per-row (used by the fallback path).
+        return bindings
+            .Select(b =>
+            {
+                var depthInfo = scopeDepthLookup?.Invoke(b.Id) ?? default;
+                versionById ??= new Dictionary<Guid, PolicyVersion>();
+                policyById ??= new Dictionary<Guid, Policy>();
+                if (!versionById.TryGetValue(b.PolicyVersionId, out var version)
+                    || !policyById.TryGetValue(version.PolicyId, out var policy))
+                {
+                    return (EffectiveCandidate?)null;
+                }
+                return new EffectiveCandidate(
+                    Binding: b,
+                    Version: version,
+                    Policy: policy,
+                    Depth: depthInfo.Depth,
+                    ScopeNodeId: depthInfo.ScopeNodeId,
+                    ScopeType: depthInfo.ScopeType);
+            })
+            .Where(c => c is not null)
+            .Select(c => c!)
+            .GroupBy(c => c.Policy.Id)
+            .Select(group =>
+            {
+                // Tighten-only: pick the deepest Mandatory if any;
+                // otherwise the deepest Recommended. Tiebreak earliest
+                // CreatedAt — older wins so ordering is deterministic.
+                var mandatory = group.Where(c => c.Binding.BindStrength == BindStrength.Mandatory).ToList();
+                var winner = (mandatory.Count > 0 ? mandatory : group.ToList())
+                    .OrderByDescending(c => c.Depth)
+                    .ThenByDescending(c => c.Binding.BindStrength)  // Mandatory(1) wins ties since we already filtered
+                    .ThenBy(c => c.Binding.CreatedAt)
+                    .First();
+                return new EffectivePolicyDto(
+                    PolicyId: winner.Policy.Id,
+                    PolicyVersionId: winner.Version.Id,
+                    PolicyKey: winner.Policy.Name,
+                    Version: winner.Version.Version,
+                    BindStrength: winner.Binding.BindStrength,
+                    SourceBindingId: winner.Binding.Id,
+                    SourceScopeNodeId: winner.ScopeNodeId,
+                    SourceScopeType: winner.ScopeType,
+                    SourceDepth: winner.Depth);
+            })
+            .OrderBy(p => p.BindStrength)  // Mandatory(1) before Recommended(2)
+            .ThenBy(p => p.PolicyKey, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private async Task<(IReadOnlyList<Binding> Rows, Dictionary<Guid, PolicyVersion> Versions, Dictionary<Guid, Policy> Policies)>
+        LoadBindingsWithHydrationAsync(IQueryable<Binding> bindings, CancellationToken ct)
+    {
+        var rows = await bindings.ToListAsync(ct).ConfigureAwait(false);
+        var versionIds = rows.Select(b => b.PolicyVersionId).Distinct().ToList();
+        if (versionIds.Count == 0)
+        {
+            return (rows, new Dictionary<Guid, PolicyVersion>(), new Dictionary<Guid, Policy>());
+        }
+        var versions = await _db.PolicyVersions.AsNoTracking()
+            .Where(v => versionIds.Contains(v.Id))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+        var policyIds = versions.Select(v => v.PolicyId).Distinct().ToList();
+        var policies = await _db.Policies.AsNoTracking()
+            .Where(p => policyIds.Contains(p.Id))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+        return (rows, versions.ToDictionary(v => v.Id), policies.ToDictionary(p => p.Id));
+    }
+
+    private static bool TryMapToScopeType(BindingTargetType targetType, out ScopeType scopeType)
+    {
+        switch (targetType)
+        {
+            case BindingTargetType.Org: scopeType = ScopeType.Org; return true;
+            case BindingTargetType.Tenant: scopeType = ScopeType.Tenant; return true;
+            case BindingTargetType.Repo: scopeType = ScopeType.Repo; return true;
+            case BindingTargetType.Template: scopeType = ScopeType.Template; return true;
+            // BindingTargetType.ScopeNode is handled separately;
+            // ScopeType.Team and ScopeType.Run have no binding-target
+            // equivalent (binding directly to a Team/Run goes via
+            // ScopeNode references).
+            default:
+                scopeType = default;
+                return false;
+        }
+    }
+
+    private static BindingTargetType? TryMapToBindingTargetType(ScopeType type) => type switch
+    {
+        ScopeType.Org => BindingTargetType.Org,
+        ScopeType.Tenant => BindingTargetType.Tenant,
+        ScopeType.Repo => BindingTargetType.Repo,
+        ScopeType.Template => BindingTargetType.Template,
+        _ => null,  // Team and Run have no bridge.
+    };
+
+    // --- helpers --------------------------------------------------------
+
+    private sealed record ChainNode(Guid Id, ScopeType Type, string Ref, int Depth);
+
+    private sealed record BridgeKey(BindingTargetType Type, string Ref);
+
+    private sealed record EffectiveCandidate(
+        Binding Binding,
+        PolicyVersion Version,
+        Policy Policy,
+        int Depth,
+        Guid? ScopeNodeId,
+        ScopeType? ScopeType);
+
+    private sealed class BindingIdComparer : IEqualityComparer<Binding>
+    {
+        public bool Equals(Binding? x, Binding? y) => x?.Id == y?.Id;
+        public int GetHashCode(Binding obj) => obj.Id.GetHashCode();
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Services/BindingResolutionServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/BindingResolutionServiceTests.cs
@@ -1,0 +1,303 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Exceptions;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Infrastructure.Services;
+using Andy.Policies.Tests.Unit.Fixtures;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Services;
+
+/// <summary>
+/// Unit tests for <see cref="BindingResolutionService"/> (P4.3, story
+/// rivoli-ai/andy-policies#30). Walks a hand-seeded scope chain over
+/// EF Core InMemory and asserts the tighten-only fold rules from the
+/// issue body verbatim:
+/// <list type="bullet">
+///   <item>Worked example: 3 entries with correct strengths + sources.</item>
+///   <item>Ancestor Mandatory + descendant Recommended → Mandatory wins,
+///     ancestor as source (descendant silently dropped).</item>
+///   <item>Ancestor Recommended + descendant Mandatory → upgrade,
+///     descendant as source.</item>
+///   <item>Same-depth tie of two Mandatories on same PolicyId → older
+///     CreatedAt wins.</item>
+///   <item>Leaf-only binding returns exactly one entry.</item>
+///   <item>Retired versions are NOT filtered (consumers decide).</item>
+/// </list>
+/// </summary>
+public class BindingResolutionServiceTests
+{
+    private static (BindingResolutionService resolver, ScopeService scopes, AppDbContext db)
+        NewServices()
+    {
+        var db = InMemoryDbFixture.Create();
+        var scopes = new ScopeService(db, TimeProvider.System);
+        var resolver = new BindingResolutionService(db, scopes);
+        return (resolver, scopes, db);
+    }
+
+    private sealed record ChainIds(Guid Org, Guid Tenant, Guid Team, Guid Repo, Guid Template);
+
+    private static async Task<ChainIds> SeedFiveLevelChainAsync(ScopeService scopes)
+    {
+        var org = await scopes.CreateAsync(new CreateScopeNodeRequest(
+            null, ScopeType.Org, "org:acme", "Acme"));
+        var tenant = await scopes.CreateAsync(new CreateScopeNodeRequest(
+            org.Id, ScopeType.Tenant, "tenant:t1", "T1"));
+        var team = await scopes.CreateAsync(new CreateScopeNodeRequest(
+            tenant.Id, ScopeType.Team, "team:red", "Red"));
+        var repo = await scopes.CreateAsync(new CreateScopeNodeRequest(
+            team.Id, ScopeType.Repo, "repo:acme/svc", "Service"));
+        var template = await scopes.CreateAsync(new CreateScopeNodeRequest(
+            repo.Id, ScopeType.Template, "template:deploy", "Deploy"));
+        return new ChainIds(org.Id, tenant.Id, team.Id, repo.Id, template.Id);
+    }
+
+    private static async Task<(Policy policy, PolicyVersion version)> SeedPolicyAndPublishAsync(
+        AppDbContext db, string name, int versionNumber = 1)
+    {
+        var policy = PolicyBuilders.APolicy(name: name);
+        var version = PolicyBuilders.AVersion(policy.Id, number: versionNumber, state: LifecycleState.Active);
+        db.Policies.Add(policy);
+        db.PolicyVersions.Add(version);
+        await db.SaveChangesAsync();
+        return (policy, version);
+    }
+
+    private static async Task<Binding> AddScopeBindingAsync(
+        AppDbContext db, Guid scopeNodeId, Guid policyVersionId,
+        BindStrength strength, DateTimeOffset? createdAt = null)
+    {
+        var binding = new Binding
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = policyVersionId,
+            TargetType = BindingTargetType.ScopeNode,
+            TargetRef = $"scope:{scopeNodeId}",
+            BindStrength = strength,
+            CreatedAt = createdAt ?? DateTimeOffset.UtcNow,
+            CreatedBySubjectId = "test",
+        };
+        db.Bindings.Add(binding);
+        await db.SaveChangesAsync();
+        return binding;
+    }
+
+    [Fact]
+    public async Task WorkedExample_FromIssueBody_ProducesThreeEntriesWithCorrectStrengthsAndSources()
+    {
+        var (resolver, scopes, db) = NewServices();
+        var chain = await SeedFiveLevelChainAsync(scopes);
+        var (_, noProd) = await SeedPolicyAndPublishAsync(db, "no-prod");
+        var (_, sandboxed) = await SeedPolicyAndPublishAsync(db, "sandboxed");
+        var (_, highRisk) = await SeedPolicyAndPublishAsync(db, "high-risk");
+
+        await AddScopeBindingAsync(db, chain.Org, noProd.Id, BindStrength.Mandatory);
+        await AddScopeBindingAsync(db, chain.Team, sandboxed.Id, BindStrength.Recommended);
+        await AddScopeBindingAsync(db, chain.Repo, highRisk.Id, BindStrength.Mandatory);
+
+        var result = await resolver.ResolveForScopeAsync(chain.Repo);
+
+        result.ScopeNodeId.Should().Be(chain.Repo);
+        result.Policies.Should().HaveCount(3);
+
+        // Mandatories come first, then Recommended, alpha-by-key within strength.
+        result.Policies[0].PolicyKey.Should().Be("high-risk");
+        result.Policies[0].BindStrength.Should().Be(BindStrength.Mandatory);
+        result.Policies[0].SourceScopeNodeId.Should().Be(chain.Repo);
+
+        result.Policies[1].PolicyKey.Should().Be("no-prod");
+        result.Policies[1].BindStrength.Should().Be(BindStrength.Mandatory);
+        result.Policies[1].SourceScopeNodeId.Should().Be(chain.Org);
+
+        result.Policies[2].PolicyKey.Should().Be("sandboxed");
+        result.Policies[2].BindStrength.Should().Be(BindStrength.Recommended);
+        result.Policies[2].SourceScopeNodeId.Should().Be(chain.Team);
+    }
+
+    [Fact]
+    public async Task AncestorMandatory_PlusDescendantRecommended_KeepsMandatoryWithAncestorSource()
+    {
+        var (resolver, scopes, db) = NewServices();
+        var chain = await SeedFiveLevelChainAsync(scopes);
+        var (_, noProd) = await SeedPolicyAndPublishAsync(db, "no-prod");
+        await AddScopeBindingAsync(db, chain.Org, noProd.Id, BindStrength.Mandatory);
+        await AddScopeBindingAsync(db, chain.Repo, noProd.Id, BindStrength.Recommended);
+
+        var result = await resolver.ResolveForScopeAsync(chain.Repo);
+
+        result.Policies.Should().ContainSingle();
+        result.Policies[0].BindStrength.Should().Be(BindStrength.Mandatory);
+        result.Policies[0].SourceScopeNodeId.Should().Be(chain.Org);
+    }
+
+    [Fact]
+    public async Task AncestorRecommended_PlusDescendantMandatory_UpgradesToMandatoryWithDescendantSource()
+    {
+        var (resolver, scopes, db) = NewServices();
+        var chain = await SeedFiveLevelChainAsync(scopes);
+        var (_, sandboxed) = await SeedPolicyAndPublishAsync(db, "sandboxed");
+        await AddScopeBindingAsync(db, chain.Team, sandboxed.Id, BindStrength.Recommended);
+        await AddScopeBindingAsync(db, chain.Repo, sandboxed.Id, BindStrength.Mandatory);
+
+        var result = await resolver.ResolveForScopeAsync(chain.Repo);
+
+        result.Policies.Should().ContainSingle();
+        result.Policies[0].BindStrength.Should().Be(BindStrength.Mandatory);
+        result.Policies[0].SourceScopeNodeId.Should().Be(chain.Repo);
+    }
+
+    [Fact]
+    public async Task SameDepthTie_TwoMandatoriesOnSamePolicy_OlderCreatedAtWins()
+    {
+        var (resolver, scopes, db) = NewServices();
+        var chain = await SeedFiveLevelChainAsync(scopes);
+        var (_, sandboxed) = await SeedPolicyAndPublishAsync(db, "sandboxed");
+
+        var older = await AddScopeBindingAsync(
+            db, chain.Repo, sandboxed.Id, BindStrength.Mandatory,
+            DateTimeOffset.UtcNow.AddMinutes(-10));
+        await AddScopeBindingAsync(
+            db, chain.Repo, sandboxed.Id, BindStrength.Mandatory,
+            DateTimeOffset.UtcNow);
+
+        var result = await resolver.ResolveForScopeAsync(chain.Repo);
+
+        result.Policies.Should().ContainSingle();
+        result.Policies[0].SourceBindingId.Should().Be(older.Id);
+    }
+
+    [Fact]
+    public async Task LeafOnlyBinding_ReturnsExactlyOneEntry()
+    {
+        var (resolver, scopes, db) = NewServices();
+        var chain = await SeedFiveLevelChainAsync(scopes);
+        var (_, version) = await SeedPolicyAndPublishAsync(db, "leaf-only");
+        await AddScopeBindingAsync(db, chain.Repo, version.Id, BindStrength.Mandatory);
+
+        var result = await resolver.ResolveForScopeAsync(chain.Repo);
+
+        result.Policies.Should().ContainSingle();
+        result.Policies[0].PolicyKey.Should().Be("leaf-only");
+        result.Policies[0].SourceScopeNodeId.Should().Be(chain.Repo);
+    }
+
+    [Fact]
+    public async Task RetiredVersion_StillReturnedByResolution_ConsumersHandleDeprecation()
+    {
+        var (resolver, scopes, db) = NewServices();
+        var chain = await SeedFiveLevelChainAsync(scopes);
+        var policy = PolicyBuilders.APolicy(name: "retired-policy");
+        var version = PolicyBuilders.AVersion(policy.Id, number: 1, state: LifecycleState.Retired);
+        db.Policies.Add(policy);
+        db.PolicyVersions.Add(version);
+        await db.SaveChangesAsync();
+        await AddScopeBindingAsync(db, chain.Repo, version.Id, BindStrength.Mandatory);
+
+        var result = await resolver.ResolveForScopeAsync(chain.Repo);
+
+        result.Policies.Should().ContainSingle();
+        result.Policies[0].PolicyKey.Should().Be("retired-policy");
+    }
+
+    [Fact]
+    public async Task SoftDeletedBinding_IsExcludedFromResolution()
+    {
+        var (resolver, scopes, db) = NewServices();
+        var chain = await SeedFiveLevelChainAsync(scopes);
+        var (_, version) = await SeedPolicyAndPublishAsync(db, "tombstoned");
+        var binding = await AddScopeBindingAsync(db, chain.Repo, version.Id, BindStrength.Mandatory);
+        binding.DeletedAt = DateTimeOffset.UtcNow;
+        binding.DeletedBySubjectId = "test";
+        await db.SaveChangesAsync();
+
+        var result = await resolver.ResolveForScopeAsync(chain.Repo);
+
+        result.Policies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task BridgeBinding_OnRepoExternalRef_PicksUpInChainWalk()
+    {
+        // A binding authored against TargetType=Repo, TargetRef="repo:acme/svc"
+        // (a P3 binding pre-dating scope nodes) should be picked up by the
+        // chain walker when the leaf scope's Ref matches.
+        var (resolver, scopes, db) = NewServices();
+        var chain = await SeedFiveLevelChainAsync(scopes);
+        var (_, version) = await SeedPolicyAndPublishAsync(db, "bridge-policy");
+        var binding = new Binding
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = version.Id,
+            TargetType = BindingTargetType.Repo,
+            TargetRef = "repo:acme/svc",
+            BindStrength = BindStrength.Mandatory,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBySubjectId = "test",
+        };
+        db.Bindings.Add(binding);
+        await db.SaveChangesAsync();
+
+        var result = await resolver.ResolveForScopeAsync(chain.Repo);
+
+        result.Policies.Should().ContainSingle();
+        result.Policies[0].PolicyKey.Should().Be("bridge-policy");
+        result.Policies[0].SourceBindingId.Should().Be(binding.Id);
+        result.Policies[0].SourceScopeNodeId.Should().Be(chain.Repo);
+    }
+
+    [Fact]
+    public async Task ResolveForScopeAsync_OnUnknownId_ThrowsNotFound()
+    {
+        var (resolver, _, _) = NewServices();
+
+        var act = async () => await resolver.ResolveForScopeAsync(Guid.NewGuid());
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task ResolveForTargetAsync_OnKnownScopeRef_WalksTheChain()
+    {
+        var (resolver, scopes, db) = NewServices();
+        var chain = await SeedFiveLevelChainAsync(scopes);
+        var (_, version) = await SeedPolicyAndPublishAsync(db, "via-target");
+        await AddScopeBindingAsync(db, chain.Org, version.Id, BindStrength.Mandatory);
+
+        var result = await resolver.ResolveForTargetAsync(BindingTargetType.Repo, "repo:acme/svc");
+
+        result.ScopeNodeId.Should().Be(chain.Repo);
+        result.Policies.Should().ContainSingle();
+        result.Policies[0].SourceScopeNodeId.Should().Be(chain.Org);
+    }
+
+    [Fact]
+    public async Task ResolveForTargetAsync_OnUnknownScope_DegradesToExactMatch()
+    {
+        var (resolver, _, db) = NewServices();
+        var (_, version) = await SeedPolicyAndPublishAsync(db, "exact-only");
+        var binding = new Binding
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = version.Id,
+            TargetType = BindingTargetType.Repo,
+            TargetRef = "repo:unknown/repo",
+            BindStrength = BindStrength.Mandatory,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBySubjectId = "test",
+        };
+        db.Bindings.Add(binding);
+        await db.SaveChangesAsync();
+
+        var result = await resolver.ResolveForTargetAsync(BindingTargetType.Repo, "repo:unknown/repo");
+
+        result.ScopeNodeId.Should().BeNull("no scope node matched — fallback to exact-match");
+        result.Policies.Should().ContainSingle();
+        result.Policies[0].PolicyKey.Should().Be("exact-only");
+    }
+}


### PR DESCRIPTION
## Summary

Adds the chain-walker that consumers (Conductor's ActionBus, andy-tasks per-task gates) call to ask "which policies apply to this target?" with hierarchy semantics. Walks from root `Org` down to the leaf scope, gathers every binding that targets a node in the chain (or each chain node's external `Ref` via the bridge to P3 non-scope bindings), and folds them with stricter-tightens-only semantics.

**Application:**
- `EffectivePolicyDto`: `PolicyId`, `PolicyVersionId`, `PolicyKey`, `Version`, `BindStrength`, `SourceBindingId`, `SourceScopeNodeId` (nullable for the exact-match fallback path), `SourceScopeType`, `SourceDepth`.
- `EffectivePolicySetDto` envelope: `ScopeNodeId` (null when the resolver degraded to P3 exact-match) + ordered `Policies` list.
- `IBindingResolutionService` with `ResolveForScopeAsync` (known scope id) and `ResolveForTargetAsync` (target ref → maybe-scope or fallback).

**Infrastructure (`BindingResolutionService`):**
- `ResolveForScopeAsync` walks ancestors via `IScopeService`, gathers bindings against `scope:{nodeId}` for each chain node and bridge bindings against each node's `(Type, Ref)` — the latter handles P3 bindings authored before scope nodes existed.
- Tighten-only fold: group all matching bindings by `PolicyId`, pick the deepest `Mandatory` if any (else deepest `Recommended`); tiebreak earliest `CreatedAt`. Sort: `Mandatory` first, then `PolicyKey` ASC.
- `ResolveForTargetAsync` first tries to map `(BindingTargetType, ref)` → `ScopeNode` (Org/Tenant/Repo/Template have direct mappings; `ScopeNode` target accepts `"scope:{guid}"` or bare guid). Falls back to P3 exact-match semantics with `SourceScopeNodeId=null` when no scope match — service degrades gracefully instead of returning 404.
- Soft-deleted bindings are excluded; Retired versions are kept (consumer concern per the issue spec — the chain walker surfaces the entire policy story, unlike the single-target resolver in P3.4).

**Bonus fix:** the `IScopeService` DI registration was missing from P4.2's commit; added here so the resolver can inject it.

Closes #30.

## Test plan
- [x] `dotnet test` — 243 unit + 229 integration pass; 6 E2E skipped.
- [x] 11 unit (`BindingResolutionServiceTests`, EF InMemory): worked example from the issue body, ancestor Mandatory + descendant Recommended (Mandatory wins, ancestor source), ancestor Recommended + descendant Mandatory (upgrade fires, descendant source), same-depth tie (older `CreatedAt` wins), leaf-only binding, Retired versions still returned, soft-deleted bindings excluded, bridge binding on `Repo` external `Ref` picked up, unknown scope id throws NotFound, `ResolveForTargetAsync` with known scope ref walks chain, fallback to exact-match with `ScopeNodeId=null` when no scope match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)