### PR TITLE
Implement P4.4 — tighten-only write validation on binding mutations

### DIFF
--- a/src/Andy.Policies.Api/ExceptionHandlers/PolicyExceptionHandler.cs
+++ b/src/Andy.Policies.Api/ExceptionHandlers/PolicyExceptionHandler.cs
@@ -51,6 +51,33 @@ public sealed class PolicyExceptionHandler : IExceptionHandler
             return true;
         }
 
+        // P4.4: tighten-only violation carries the offending ancestor
+        // binding id + scope node id so admins can triage from the
+        // error response without a follow-up query. We inject the
+        // structured payload as ProblemDetails extension members.
+        if (exception is TightenOnlyViolationException tvex)
+        {
+            var problem409 = new ProblemDetails
+            {
+                Status = StatusCodes.Status409Conflict,
+                Title = "Tighten-only violation",
+                Detail = tvex.Message,
+                Type = "/problems/binding-tighten-only-violation",
+                Instance = httpContext.Request.Path,
+                Extensions =
+                {
+                    ["errorCode"] = "binding.tighten-only-violation",
+                    ["offendingAncestorBindingId"] = tvex.Violation.OffendingAncestorBindingId,
+                    ["offendingScopeNodeId"] = tvex.Violation.OffendingScopeNodeId,
+                    ["offendingScopeDisplayName"] = tvex.Violation.OffendingScopeDisplayName,
+                    ["policyKey"] = tvex.Violation.PolicyKey,
+                },
+            };
+            httpContext.Response.StatusCode = StatusCodes.Status409Conflict;
+            await httpContext.Response.WriteAsJsonAsync(problem409, cancellationToken);
+            return true;
+        }
+
         var (status, title) = exception switch
         {
             ValidationException => (StatusCodes.Status400BadRequest, "Validation failed"),

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -105,6 +105,10 @@ builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IScopeService, A
 // from root to leaf and merges ScopeNode-targeted bindings with the
 // bridge bindings that target each chain node's external Ref.
 builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBindingResolutionService, Andy.Policies.Infrastructure.Services.BindingResolutionService>();
+// P4.4 (#32): write-time enforcement of stricter-tightens-only.
+// Injected into BindingService so CreateAsync refuses Recommended
+// proposals that would shadow a Mandatory ancestor binding.
+builder.Services.AddScoped<Andy.Policies.Application.Interfaces.ITightenOnlyValidator, Andy.Policies.Infrastructure.Services.TightenOnlyValidator>();
 // P3.2 (#20): Binding mutations call IAuditWriter — Epic P6
 // (rivoli-ai/andy-policies#6) replaces the no-op with the real
 // hash-chained writer. Singleton because the P6 implementation will own a

--- a/src/Andy.Policies.Application/Exceptions/TightenOnlyViolationException.cs
+++ b/src/Andy.Policies.Application/Exceptions/TightenOnlyViolationException.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Interfaces;
+
+namespace Andy.Policies.Application.Exceptions;
+
+/// <summary>
+/// Thrown by <c>BindingService.CreateAsync</c> when
+/// <c>ITightenOnlyValidator.ValidateCreateAsync</c> rejects the
+/// proposed binding because it would loosen a Mandatory binding
+/// declared upstream (P4.4, story rivoli-ai/andy-policies#32). API
+/// layer maps to HTTP 409 with
+/// <c>errorCode = "binding.tighten-only-violation"</c> and surfaces
+/// the offending ancestor binding id + scope node id so admins can
+/// triage without a follow-up query.
+/// </summary>
+public sealed class TightenOnlyViolationException : ConflictException
+{
+    public TightenViolation Violation { get; }
+
+    public TightenOnlyViolationException(TightenViolation violation)
+        : base(violation.Reason)
+    {
+        Violation = violation;
+    }
+}

--- a/src/Andy.Policies.Application/Interfaces/ITightenOnlyValidator.cs
+++ b/src/Andy.Policies.Application/Interfaces/ITightenOnlyValidator.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Domain.Enums;
+
+namespace Andy.Policies.Application.Interfaces;
+
+/// <summary>
+/// Write-path enforcement of stricter-tightens-only (P4.4, story
+/// rivoli-ai/andy-policies#32). Companion to the read-time fold in
+/// <see cref="IBindingResolutionService"/> from P4.3 — the read path
+/// silently drops would-be downgrades; this interface refuses to
+/// commit them in the first place so the catalog never accumulates
+/// unreachable rows.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Returns <c>null</c> for the allowed shape. Returns a populated
+/// <see cref="TightenViolation"/> when the proposed change would
+/// loosen a Mandatory binding declared upstream — callers translate
+/// that into <see cref="Exceptions.TightenOnlyViolationException"/>
+/// and the API layer maps to HTTP 409.
+/// </para>
+/// <para>
+/// <see cref="ValidateDeleteAsync"/> is a null-returning hook. Per
+/// the issue's reviewer-flagged reconciliation, tighten-only is a
+/// CREATE-time invariant only — a delete cannot produce a weaker
+/// downstream binding (it can only remove one). The hook stays for
+/// P5 overrides and P6 audit to attach side-effect checks later.
+/// </para>
+/// </remarks>
+public interface ITightenOnlyValidator
+{
+    Task<TightenViolation?> ValidateCreateAsync(
+        Guid policyVersionId,
+        BindingTargetType targetType,
+        string targetRef,
+        BindStrength bindStrength,
+        CancellationToken ct = default);
+
+    Task<TightenViolation?> ValidateDeleteAsync(
+        Guid bindingId,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Describes which ancestor binding blocked the proposed write
+/// (P4.4). Carries enough information for the REST/MCP/gRPC error
+/// envelope to point an admin at the conflict without a follow-up
+/// query.
+/// </summary>
+public sealed record TightenViolation(
+    Guid OffendingAncestorBindingId,
+    Guid OffendingScopeNodeId,
+    string OffendingScopeDisplayName,
+    string PolicyKey,
+    string Reason);

--- a/src/Andy.Policies.Infrastructure/Services/BindingService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BindingService.cs
@@ -25,12 +25,31 @@ public sealed class BindingService : IBindingService
     private readonly AppDbContext _db;
     private readonly IAuditWriter _audit;
     private readonly TimeProvider _clock;
+    private readonly ITightenOnlyValidator? _tightenValidator;
 
     public BindingService(AppDbContext db, IAuditWriter audit, TimeProvider clock)
+        : this(db, audit, clock, tightenValidator: null) { }
+
+    /// <summary>
+    /// Optional <see cref="ITightenOnlyValidator"/> overload (P4.4,
+    /// rivoli-ai/andy-policies#32). Production DI passes the live
+    /// validator so <see cref="CreateAsync"/> rejects mutations that
+    /// would loosen a Mandatory binding declared upstream. Existing
+    /// unit tests that construct <c>BindingService</c> directly fall
+    /// through the parameterless overload above and see the legacy
+    /// behaviour (no tighten check), preserving the P3 test
+    /// inventory unchanged.
+    /// </summary>
+    public BindingService(
+        AppDbContext db,
+        IAuditWriter audit,
+        TimeProvider clock,
+        ITightenOnlyValidator? tightenValidator)
     {
         _db = db;
         _audit = audit;
         _clock = clock;
+        _tightenValidator = tightenValidator;
     }
 
     public async Task<BindingDto> CreateAsync(
@@ -63,6 +82,22 @@ public sealed class BindingService : IBindingService
         if (version.State == LifecycleState.Retired)
         {
             throw new BindingRetiredVersionException(version.Id);
+        }
+
+        // P4.4: stricter-tightens-only — reject Recommended creates that
+        // would shadow a Mandatory binding declared upstream. The
+        // validator returns null when no scope chain is involved (soft
+        // refs) or when the proposal is itself Mandatory; we throw on
+        // every non-null violation.
+        if (_tightenValidator is not null)
+        {
+            var violation = await _tightenValidator.ValidateCreateAsync(
+                version.Id, request.TargetType, targetRef, request.BindStrength, ct)
+                .ConfigureAwait(false);
+            if (violation is not null)
+            {
+                throw new TightenOnlyViolationException(violation);
+            }
         }
 
         var binding = new Binding

--- a/src/Andy.Policies.Infrastructure/Services/TightenOnlyValidator.cs
+++ b/src/Andy.Policies.Infrastructure/Services/TightenOnlyValidator.cs
@@ -1,0 +1,237 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Andy.Policies.Infrastructure.Services;
+
+/// <summary>
+/// EF-backed write-path enforcement of stricter-tightens-only (P4.4,
+/// story rivoli-ai/andy-policies#32). For a proposed binding, the
+/// validator resolves <c>(targetType, targetRef)</c> to the matching
+/// scope node (when one exists), walks the ancestor chain, and flags
+/// any ancestor that already binds the same policy as Mandatory when
+/// the caller is proposing Recommended. Soft refs (a target that
+/// doesn't resolve to a scope) are allowed unchecked — the catalog
+/// never resolves foreign refs, per the P3 non-goal.
+/// </summary>
+public sealed class TightenOnlyValidator : ITightenOnlyValidator
+{
+    private readonly AppDbContext _db;
+    private readonly IScopeService _scopes;
+
+    public TightenOnlyValidator(AppDbContext db, IScopeService scopes)
+    {
+        _db = db;
+        _scopes = scopes;
+    }
+
+    public async Task<TightenViolation?> ValidateCreateAsync(
+        Guid policyVersionId,
+        BindingTargetType targetType,
+        string targetRef,
+        BindStrength bindStrength,
+        CancellationToken ct = default)
+    {
+        // The rule only fires when the proposal is Recommended — a
+        // Mandatory proposal can never be a downgrade.
+        if (bindStrength != BindStrength.Recommended)
+        {
+            return null;
+        }
+
+        // Resolve the target to a scope node. Soft refs (targets we
+        // can't map) skip the walk — see header comment.
+        var targetScope = await ResolveTargetScopeAsync(targetType, targetRef, ct).ConfigureAwait(false);
+        if (targetScope is null)
+        {
+            return null;
+        }
+
+        // Find the policy id behind the proposed PolicyVersion.
+        var version = await _db.PolicyVersions.AsNoTracking()
+            .FirstOrDefaultAsync(v => v.Id == policyVersionId, ct)
+            .ConfigureAwait(false);
+        if (version is null)
+        {
+            // Don't pre-empt the service-layer NotFound check; let
+            // BindingService raise the canonical NotFoundException
+            // when it loads the version itself.
+            return null;
+        }
+
+        // Walk ancestors (root-first). For each ancestor scope, check
+        // both the scope-targeted and bridge bindings on the same
+        // PolicyId; pick the deepest Mandatory and report it. The
+        // deepest reported ancestor is the most specific cause — most
+        // useful for admin triage.
+        var ancestors = await _scopes.GetAncestorsAsync(targetScope.Id, ct).ConfigureAwait(false);
+        if (ancestors.Count == 0)
+        {
+            return null;
+        }
+
+        var ancestorScopeRefs = ancestors.Select(a => $"scope:{a.Id}").ToList();
+        var ancestorBridgeKeys = ancestors
+            .Select(a => (Type: TryMapToBindingTargetType(a.Type), Ref: a.Ref))
+            .Where(p => p.Type is not null)
+            .ToList();
+
+        // Two predicate halves: scope-targeted bindings + bridge
+        // bindings on the ancestors' external Refs. Same shape as
+        // BindingResolutionService from P4.3, narrowed to the same
+        // PolicyId we're proposing.
+        var scopeTargeted = await _db.Bindings.AsNoTracking()
+            .Where(b => b.TargetType == BindingTargetType.ScopeNode
+                        && b.DeletedAt == null
+                        && ancestorScopeRefs.Contains(b.TargetRef)
+                        && b.BindStrength == BindStrength.Mandatory
+                        && _db.PolicyVersions.Any(v =>
+                            v.Id == b.PolicyVersionId && v.PolicyId == version.PolicyId))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var bridgeTargeted = new List<Binding>();
+        if (ancestorBridgeKeys.Count > 0)
+        {
+            var bridgeTypes = ancestorBridgeKeys.Select(k => k.Type!.Value).Distinct().ToList();
+            var bridgeRefs = ancestorBridgeKeys.Select(k => k.Ref).Distinct().ToList();
+            var candidates = await _db.Bindings.AsNoTracking()
+                .Where(b => bridgeTypes.Contains(b.TargetType)
+                            && bridgeRefs.Contains(b.TargetRef)
+                            && b.DeletedAt == null
+                            && b.BindStrength == BindStrength.Mandatory
+                            && _db.PolicyVersions.Any(v =>
+                                v.Id == b.PolicyVersionId && v.PolicyId == version.PolicyId))
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+            var keySet = ancestorBridgeKeys
+                .Select(k => (k.Type!.Value, k.Ref))
+                .ToHashSet();
+            bridgeTargeted = candidates
+                .Where(b => keySet.Contains((b.TargetType, b.TargetRef)))
+                .ToList();
+        }
+
+        if (scopeTargeted.Count == 0 && bridgeTargeted.Count == 0)
+        {
+            return null;
+        }
+
+        // Map each offending binding back to the depth of the ancestor
+        // that bound it; report the deepest one.
+        var ancestorById = ancestors.ToDictionary(a => a.Id);
+        var ancestorByBridgeKey = ancestorBridgeKeys.Count == 0
+            ? new Dictionary<(BindingTargetType, string), Guid>()
+            : ancestors
+                .Where(a => TryMapToBindingTargetType(a.Type) is not null)
+                .GroupBy(a => (TryMapToBindingTargetType(a.Type)!.Value, a.Ref))
+                .ToDictionary(g => g.Key, g => g.OrderByDescending(a => a.Depth).First().Id);
+
+        var deepest = scopeTargeted
+            .Select(b =>
+            {
+                var idText = b.TargetRef.AsSpan("scope:".Length);
+                Guid id = Guid.Parse(idText);
+                return (Binding: b, ScopeNodeId: id, Depth: ancestorById[id].Depth);
+            })
+            .Concat(bridgeTargeted.Select(b =>
+            {
+                var sid = ancestorByBridgeKey[(b.TargetType, b.TargetRef)];
+                return (Binding: b, ScopeNodeId: sid, Depth: ancestorById[sid].Depth);
+            }))
+            .OrderByDescending(t => t.Depth)
+            .ThenBy(t => t.Binding.CreatedAt)
+            .First();
+
+        var policy = await _db.Policies.AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == version.PolicyId, ct)
+            .ConfigureAwait(false);
+        var policyKey = policy?.Name ?? version.PolicyId.ToString();
+        var ancestorScope = ancestorById[deepest.ScopeNodeId];
+
+        return new TightenViolation(
+            OffendingAncestorBindingId: deepest.Binding.Id,
+            OffendingScopeNodeId: ancestorScope.Id,
+            OffendingScopeDisplayName: ancestorScope.DisplayName,
+            PolicyKey: policyKey,
+            Reason: $"Cannot create a Recommended binding for policy '{policyKey}' " +
+                    $"at this scope — ancestor {ancestorScope.Type} '{ancestorScope.DisplayName}' " +
+                    $"binds it as Mandatory (binding {deepest.Binding.Id}).");
+    }
+
+    public Task<TightenViolation?> ValidateDeleteAsync(Guid bindingId, CancellationToken ct = default)
+    {
+        // Tighten-only is a CREATE-time invariant; deletes cannot
+        // produce a weaker downstream binding (P4.4 §reviewer-flagged
+        // reconciliation). The hook stays for P5 / P6 to layer side-
+        // effect checks without changing the BindingService API.
+        return Task.FromResult<TightenViolation?>(null);
+    }
+
+    /// <summary>
+    /// Resolve a <c>(targetType, targetRef)</c> pair to a scope node.
+    /// Returns null when the target is a soft ref — i.e., a binding
+    /// whose target doesn't correspond to any node in the scope tree
+    /// (P3 non-scope binding pattern). Calling code allows soft-ref
+    /// creates without walking; the rule only applies to hierarchical
+    /// targets.
+    /// </summary>
+    private async Task<Domain.Entities.ScopeNode?> ResolveTargetScopeAsync(
+        BindingTargetType targetType,
+        string targetRef,
+        CancellationToken ct)
+    {
+        if (targetType == BindingTargetType.ScopeNode)
+        {
+            // Accept "scope:{guid}" or bare guid forms.
+            if (targetRef.StartsWith("scope:", StringComparison.Ordinal)
+                && Guid.TryParse(targetRef.AsSpan("scope:".Length), out var fromPrefix))
+            {
+                return await _db.ScopeNodes.AsNoTracking()
+                    .FirstOrDefaultAsync(s => s.Id == fromPrefix, ct)
+                    .ConfigureAwait(false);
+            }
+            if (Guid.TryParse(targetRef, out var raw))
+            {
+                return await _db.ScopeNodes.AsNoTracking()
+                    .FirstOrDefaultAsync(s => s.Id == raw, ct)
+                    .ConfigureAwait(false);
+            }
+            return null;
+        }
+
+        var scopeType = TryMapToScopeType(targetType);
+        if (scopeType is null)
+        {
+            return null;
+        }
+        return await _db.ScopeNodes.AsNoTracking()
+            .FirstOrDefaultAsync(s => s.Type == scopeType.Value && s.Ref == targetRef, ct)
+            .ConfigureAwait(false);
+    }
+
+    private static ScopeType? TryMapToScopeType(BindingTargetType targetType) => targetType switch
+    {
+        BindingTargetType.Org => ScopeType.Org,
+        BindingTargetType.Tenant => ScopeType.Tenant,
+        BindingTargetType.Repo => ScopeType.Repo,
+        BindingTargetType.Template => ScopeType.Template,
+        // Team and Run scopes have no BindingTargetType equivalent; the
+        // ScopeNode case is handled above.
+        _ => null,
+    };
+
+    private static BindingTargetType? TryMapToBindingTargetType(ScopeType type) => type switch
+    {
+        ScopeType.Org => BindingTargetType.Org,
+        ScopeType.Tenant => BindingTargetType.Tenant,
+        ScopeType.Repo => BindingTargetType.Repo,
+        ScopeType.Template => BindingTargetType.Template,
+        _ => null,
+    };
+}

--- a/tests/Andy.Policies.Tests.Integration/Controllers/BindingsTightenOnlyTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/BindingsTightenOnlyTests.cs
@@ -1,0 +1,199 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Controllers;
+
+/// <summary>
+/// Integration tests for tighten-only enforcement at the REST surface
+/// (P4.4, story rivoli-ai/andy-policies#32). Drives the full pipeline:
+/// scope hierarchy seeded via the live <see cref="IScopeService"/>, an
+/// ancestor Mandatory binding inserted via the DbContext, then a
+/// <c>POST /api/bindings</c> for a Recommended downstream binding —
+/// asserts 409 with the structured ProblemDetails payload (errorCode,
+/// offendingAncestorBindingId, offendingScopeNodeId).
+/// </summary>
+public class BindingsTightenOnlyTests : IClassFixture<PoliciesApiFactory>
+{
+    private readonly PoliciesApiFactory _factory;
+    private readonly HttpClient _client;
+
+    public BindingsTightenOnlyTests(PoliciesApiFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    private static CreatePolicyRequest MinimalCreatePolicy(string name) => new(
+        Name: name,
+        Description: null,
+        Summary: "summary",
+        Enforcement: "Must",
+        Severity: "Critical",
+        Scopes: Array.Empty<string>(),
+        RulesJson: "{}");
+
+    private async Task<PolicyVersionDto> CreateAndPublishAsync(string slug)
+    {
+        var draft = await _client.PostAsJsonAsync("/api/policies", MinimalCreatePolicy(slug));
+        draft.EnsureSuccessStatusCode();
+        var version = (await draft.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
+        var publish = await _client.PostAsJsonAsync(
+            $"/api/policies/{version.PolicyId}/versions/{version.Id}/publish",
+            new LifecycleTransitionRequest("ship"));
+        publish.EnsureSuccessStatusCode();
+        return (await publish.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
+    }
+
+    private async Task<(Guid org, Guid repo)> SeedChainAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var scopes = scope.ServiceProvider.GetRequiredService<IScopeService>();
+        var unique = Guid.NewGuid().ToString("N").Substring(0, 8);
+        var org = await scopes.CreateAsync(new CreateScopeNodeRequest(
+            null, ScopeType.Org, $"org:tov-{unique}", $"Org {unique}"));
+        var tenant = await scopes.CreateAsync(new CreateScopeNodeRequest(
+            org.Id, ScopeType.Tenant, $"tenant:tov-{unique}", $"Tenant {unique}"));
+        var team = await scopes.CreateAsync(new CreateScopeNodeRequest(
+            tenant.Id, ScopeType.Team, $"team:tov-{unique}", $"Team {unique}"));
+        var repo = await scopes.CreateAsync(new CreateScopeNodeRequest(
+            team.Id, ScopeType.Repo, $"repo:tov/{unique}", $"Repo {unique}"));
+        return (org.Id, repo.Id);
+    }
+
+    private async Task<Guid> SeedAncestorMandatoryAsync(Guid scopeNodeId, Guid policyVersionId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var bindingId = Guid.NewGuid();
+        db.Bindings.Add(new Binding
+        {
+            Id = bindingId,
+            PolicyVersionId = policyVersionId,
+            TargetType = BindingTargetType.ScopeNode,
+            TargetRef = $"scope:{scopeNodeId}",
+            BindStrength = BindStrength.Mandatory,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBySubjectId = "test",
+        });
+        await db.SaveChangesAsync();
+        return bindingId;
+    }
+
+    [Fact]
+    public async Task PostBinding_WithRecommendedShadowingAncestorMandatory_Returns409_WithStructuredPayload()
+    {
+        var version = await CreateAndPublishAsync($"tov-{Guid.NewGuid():N}".Substring(0, 16));
+        var (org, repo) = await SeedChainAsync();
+        var ancestorBindingId = await SeedAncestorMandatoryAsync(org, version.Id);
+
+        var resp = await _client.PostAsJsonAsync("/api/bindings", new
+        {
+            policyVersionId = version.Id,
+            targetType = "ScopeNode",
+            targetRef = $"scope:{repo}",
+            bindStrength = "Recommended",
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var raw = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(raw);
+        var root = doc.RootElement;
+        root.GetProperty("type").GetString().Should().Be("/problems/binding-tighten-only-violation");
+        root.GetProperty("errorCode").GetString().Should().Be("binding.tighten-only-violation");
+        root.GetProperty("offendingAncestorBindingId").GetGuid().Should().Be(ancestorBindingId);
+        root.GetProperty("offendingScopeNodeId").GetGuid().Should().Be(org);
+    }
+
+    [Fact]
+    public async Task PostBinding_UpgradingRecommendedAncestorToMandatory_Returns201()
+    {
+        var version = await CreateAndPublishAsync($"upg-{Guid.NewGuid():N}".Substring(0, 16));
+        var (org, repo) = await SeedChainAsync();
+        // Seed an ancestor Recommended; proposed Mandatory at Repo is an upgrade.
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            db.Bindings.Add(new Binding
+            {
+                Id = Guid.NewGuid(),
+                PolicyVersionId = version.Id,
+                TargetType = BindingTargetType.ScopeNode,
+                TargetRef = $"scope:{org}",
+                BindStrength = BindStrength.Recommended,
+                CreatedAt = DateTimeOffset.UtcNow,
+                CreatedBySubjectId = "test",
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var resp = await _client.PostAsJsonAsync("/api/bindings", new
+        {
+            policyVersionId = version.Id,
+            targetType = "ScopeNode",
+            targetRef = $"scope:{repo}",
+            bindStrength = "Mandatory",
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task PostBinding_OnSoftRef_NotResolvableToScopeNode_Allowed()
+    {
+        // Soft refs (targets that don't resolve to any ScopeNode) skip
+        // the tighten-only walk entirely — P3 non-goal preservation.
+        var version = await CreateAndPublishAsync($"soft-{Guid.NewGuid():N}".Substring(0, 16));
+
+        var resp = await _client.PostAsJsonAsync("/api/bindings", new
+        {
+            policyVersionId = version.Id,
+            targetType = "Repo",
+            targetRef = $"repo:never/heard-of-this-{Guid.NewGuid():N}".Substring(0, 40),
+            bindStrength = "Recommended",
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task DeleteBinding_NeverViolatesTightenOnly()
+    {
+        var version = await CreateAndPublishAsync($"del-{Guid.NewGuid():N}".Substring(0, 16));
+        var (org, repo) = await SeedChainAsync();
+
+        // Create a Mandatory at Org via the REST surface (allowed —
+        // proposing Mandatory under no ancestor binding for this policy).
+        var orgBinding = await _client.PostAsJsonAsync("/api/bindings", new
+        {
+            policyVersionId = version.Id,
+            targetType = "ScopeNode",
+            targetRef = $"scope:{org}",
+            bindStrength = "Mandatory",
+        });
+        orgBinding.EnsureSuccessStatusCode();
+        // The validator's null-returning ValidateDeleteAsync hook means
+        // the soft-delete succeeds without a tighten-only check.
+        var bindingDto = (await orgBinding.Content.ReadFromJsonAsync<BindingDto>(
+            new JsonSerializerOptions(JsonSerializerDefaults.Web)
+            {
+                Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
+            }))!;
+
+        var del = await _client.DeleteAsync($"/api/bindings/{bindingDto.Id}");
+
+        del.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Services/BindingServiceTightenOnlyTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/BindingServiceTightenOnlyTests.cs
@@ -1,0 +1,166 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Exceptions;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Infrastructure.Services;
+using Andy.Policies.Tests.Unit.Fixtures;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Services;
+
+/// <summary>
+/// Verifies that <see cref="BindingService"/> consults the injected
+/// <see cref="ITightenOnlyValidator"/> on create and rolls back the
+/// proposed insert when the validator returns a violation (P4.4,
+/// story rivoli-ai/andy-policies#32). DeleteAsync never raises a
+/// tighten-only error per the issue's reviewer-flagged
+/// reconciliation.
+/// </summary>
+public class BindingServiceTightenOnlyTests
+{
+    private static (BindingService binding, ScopeService scopes, TightenOnlyValidator validator, AppDbContext db)
+        NewServices()
+    {
+        var db = InMemoryDbFixture.Create();
+        var scopes = new ScopeService(db, TimeProvider.System);
+        var validator = new TightenOnlyValidator(db, scopes);
+        var audit = new NoopAuditWriter(NullLogger<NoopAuditWriter>.Instance);
+        var binding = new BindingService(db, audit, TimeProvider.System, validator);
+        return (binding, scopes, validator, db);
+    }
+
+    private sealed record ChainIds(Guid Org, Guid Repo);
+
+    private static async Task<ChainIds> SeedChainAsync(ScopeService scopes)
+    {
+        var org = await scopes.CreateAsync(new CreateScopeNodeRequest(
+            null, ScopeType.Org, "org:bs-tov", "Org"));
+        var tenant = await scopes.CreateAsync(new CreateScopeNodeRequest(
+            org.Id, ScopeType.Tenant, "tenant:bs-tov", "Tenant"));
+        var team = await scopes.CreateAsync(new CreateScopeNodeRequest(
+            tenant.Id, ScopeType.Team, "team:bs-tov", "Team"));
+        var repo = await scopes.CreateAsync(new CreateScopeNodeRequest(
+            team.Id, ScopeType.Repo, "repo:bs-tov/svc", "Repo"));
+        return new ChainIds(org.Id, repo.Id);
+    }
+
+    private static async Task<(Policy policy, PolicyVersion version)> SeedPolicyAsync(
+        AppDbContext db, string name)
+    {
+        var policy = PolicyBuilders.APolicy(name: name);
+        var version = PolicyBuilders.AVersion(policy.Id, number: 1, state: LifecycleState.Active);
+        db.Policies.Add(policy);
+        db.PolicyVersions.Add(version);
+        await db.SaveChangesAsync();
+        return (policy, version);
+    }
+
+    private static async Task AddBindingAsync(
+        AppDbContext db, Guid scopeNodeId, Guid policyVersionId, BindStrength strength)
+    {
+        db.Bindings.Add(new Binding
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = policyVersionId,
+            TargetType = BindingTargetType.ScopeNode,
+            TargetRef = $"scope:{scopeNodeId}",
+            BindStrength = strength,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBySubjectId = "test",
+        });
+        await db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task CreateAsync_OnLoosening_Throws_AndDoesNotPersistRow()
+    {
+        var (svc, scopes, _, db) = NewServices();
+        var chain = await SeedChainAsync(scopes);
+        var (_, version) = await SeedPolicyAsync(db, "tov-pol");
+        await AddBindingAsync(db, chain.Org, version.Id, BindStrength.Mandatory);
+        var bindingCountBefore = await db.Bindings.CountAsync();
+
+        var act = async () => await svc.CreateAsync(
+            new CreateBindingRequest(
+                version.Id,
+                BindingTargetType.ScopeNode,
+                $"scope:{chain.Repo}",
+                BindStrength.Recommended),
+            "test-actor");
+
+        var thrown = await act.Should().ThrowAsync<TightenOnlyViolationException>();
+        thrown.Which.Violation.OffendingScopeNodeId.Should().Be(chain.Org);
+        thrown.Which.Violation.PolicyKey.Should().Be("tov-pol");
+
+        var bindingCountAfter = await db.Bindings.CountAsync();
+        bindingCountAfter.Should().Be(bindingCountBefore,
+            "the violation must roll back the proposed insert");
+    }
+
+    [Fact]
+    public async Task CreateAsync_TighteningProposal_Succeeds()
+    {
+        // Recommended ancestor + Mandatory descendant proposal: an
+        // upgrade is tightening, not loosening — allowed.
+        var (svc, scopes, _, db) = NewServices();
+        var chain = await SeedChainAsync(scopes);
+        var (_, version) = await SeedPolicyAsync(db, "upgrade-pol");
+        await AddBindingAsync(db, chain.Org, version.Id, BindStrength.Recommended);
+
+        var dto = await svc.CreateAsync(
+            new CreateBindingRequest(
+                version.Id,
+                BindingTargetType.ScopeNode,
+                $"scope:{chain.Repo}",
+                BindStrength.Mandatory),
+            "test-actor");
+
+        dto.BindStrength.Should().Be(BindStrength.Mandatory);
+    }
+
+    [Fact]
+    public async Task CreateAsync_NoAncestorPolicy_Allowed()
+    {
+        var (svc, scopes, _, db) = NewServices();
+        var chain = await SeedChainAsync(scopes);
+        var (_, version) = await SeedPolicyAsync(db, "fresh-pol");
+
+        var dto = await svc.CreateAsync(
+            new CreateBindingRequest(
+                version.Id,
+                BindingTargetType.ScopeNode,
+                $"scope:{chain.Repo}",
+                BindStrength.Recommended),
+            "test-actor");
+
+        dto.BindStrength.Should().Be(BindStrength.Recommended);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_NeverThrowsTightenOnlyViolation()
+    {
+        var (svc, scopes, _, db) = NewServices();
+        var chain = await SeedChainAsync(scopes);
+        var (_, version) = await SeedPolicyAsync(db, "del-pol");
+
+        var dto = await svc.CreateAsync(
+            new CreateBindingRequest(
+                version.Id,
+                BindingTargetType.ScopeNode,
+                $"scope:{chain.Repo}",
+                BindStrength.Mandatory),
+            "test-actor");
+
+        var act = async () => await svc.DeleteAsync(dto.Id, "test-actor", rationale: null);
+
+        await act.Should().NotThrowAsync<TightenOnlyViolationException>();
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Services/TightenOnlyValidatorTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/TightenOnlyValidatorTests.cs
@@ -1,0 +1,223 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Infrastructure.Services;
+using Andy.Policies.Tests.Unit.Fixtures;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Services;
+
+/// <summary>
+/// Unit tests for <see cref="TightenOnlyValidator"/> (P4.4, story
+/// rivoli-ai/andy-policies#32). Drives the validator over EF Core
+/// InMemory across the full ancestor × proposed strength matrix and
+/// the multi-ancestor / soft-ref edge cases.
+/// </summary>
+public class TightenOnlyValidatorTests
+{
+    private static (TightenOnlyValidator validator, ScopeService scopes, AppDbContext db)
+        NewServices()
+    {
+        var db = InMemoryDbFixture.Create();
+        var scopes = new ScopeService(db, TimeProvider.System);
+        var validator = new TightenOnlyValidator(db, scopes);
+        return (validator, scopes, db);
+    }
+
+    private sealed record ChainIds(Guid Org, Guid Tenant, Guid Team, Guid Repo);
+
+    private static async Task<ChainIds> SeedFourLevelChainAsync(ScopeService scopes)
+    {
+        var org = await scopes.CreateAsync(new CreateScopeNodeRequest(
+            null, ScopeType.Org, "org:tov", "Org"));
+        var tenant = await scopes.CreateAsync(new CreateScopeNodeRequest(
+            org.Id, ScopeType.Tenant, "tenant:tov", "Tenant"));
+        var team = await scopes.CreateAsync(new CreateScopeNodeRequest(
+            tenant.Id, ScopeType.Team, "team:tov", "Team"));
+        var repo = await scopes.CreateAsync(new CreateScopeNodeRequest(
+            team.Id, ScopeType.Repo, "repo:tov/svc", "Repo"));
+        return new ChainIds(org.Id, tenant.Id, team.Id, repo.Id);
+    }
+
+    private static async Task<(Policy policy, PolicyVersion version)> SeedPolicyAsync(
+        AppDbContext db, string name)
+    {
+        var policy = PolicyBuilders.APolicy(name: name);
+        var version = PolicyBuilders.AVersion(policy.Id, number: 1, state: LifecycleState.Active);
+        db.Policies.Add(policy);
+        db.PolicyVersions.Add(version);
+        await db.SaveChangesAsync();
+        return (policy, version);
+    }
+
+    private static async Task AddAncestorBindingAsync(
+        AppDbContext db, Guid scopeNodeId, Guid policyVersionId, BindStrength strength)
+    {
+        db.Bindings.Add(new Binding
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = policyVersionId,
+            TargetType = BindingTargetType.ScopeNode,
+            TargetRef = $"scope:{scopeNodeId}",
+            BindStrength = strength,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBySubjectId = "test",
+        });
+        await db.SaveChangesAsync();
+    }
+
+    [Theory]
+    // ancestor × proposed matrix. Only Mandatory × Recommended is a violation.
+    [InlineData(null, BindStrength.Recommended, false)]
+    [InlineData(null, BindStrength.Mandatory, false)]
+    [InlineData(BindStrength.Recommended, BindStrength.Recommended, false)]
+    [InlineData(BindStrength.Recommended, BindStrength.Mandatory, false)]
+    [InlineData(BindStrength.Mandatory, BindStrength.Mandatory, false)]
+    [InlineData(BindStrength.Mandatory, BindStrength.Recommended, true)]
+    public async Task ValidateCreate_AncestorXProposedMatrix(
+        BindStrength? ancestorStrength,
+        BindStrength proposedStrength,
+        bool expectViolation)
+    {
+        var (validator, scopes, db) = NewServices();
+        var chain = await SeedFourLevelChainAsync(scopes);
+        var (_, version) = await SeedPolicyAsync(db, "matrix-pol");
+        if (ancestorStrength is { } strength)
+        {
+            await AddAncestorBindingAsync(db, chain.Org, version.Id, strength);
+        }
+
+        var result = await validator.ValidateCreateAsync(
+            version.Id, BindingTargetType.ScopeNode, $"scope:{chain.Repo}", proposedStrength);
+
+        if (expectViolation)
+        {
+            result.Should().NotBeNull();
+            result!.OffendingScopeNodeId.Should().Be(chain.Org);
+            result.PolicyKey.Should().Be("matrix-pol");
+        }
+        else
+        {
+            result.Should().BeNull();
+        }
+    }
+
+    [Fact]
+    public async Task ValidateCreate_MultipleAncestors_ReportsDeepestMandatory()
+    {
+        // Root Recommended + parent Mandatory; proposed leaf Recommended →
+        // violation reports the parent (deeper-is-more-specific).
+        var (validator, scopes, db) = NewServices();
+        var chain = await SeedFourLevelChainAsync(scopes);
+        var (_, version) = await SeedPolicyAsync(db, "multi-pol");
+        await AddAncestorBindingAsync(db, chain.Org, version.Id, BindStrength.Recommended);
+        await AddAncestorBindingAsync(db, chain.Team, version.Id, BindStrength.Mandatory);
+
+        var result = await validator.ValidateCreateAsync(
+            version.Id, BindingTargetType.ScopeNode, $"scope:{chain.Repo}", BindStrength.Recommended);
+
+        result.Should().NotBeNull();
+        result!.OffendingScopeNodeId.Should().Be(chain.Team,
+            "the deeper Mandatory ancestor is more specific");
+    }
+
+    [Fact]
+    public async Task ValidateCreate_UnrelatedPolicyAtAncestor_NeverFlags()
+    {
+        var (validator, scopes, db) = NewServices();
+        var chain = await SeedFourLevelChainAsync(scopes);
+        var (_, ancestorVersion) = await SeedPolicyAsync(db, "ancestor-pol");
+        var (_, proposedVersion) = await SeedPolicyAsync(db, "different-pol");
+        await AddAncestorBindingAsync(db, chain.Org, ancestorVersion.Id, BindStrength.Mandatory);
+
+        var result = await validator.ValidateCreateAsync(
+            proposedVersion.Id, BindingTargetType.ScopeNode,
+            $"scope:{chain.Repo}", BindStrength.Recommended);
+
+        result.Should().BeNull("ancestor binds a different PolicyId");
+    }
+
+    [Fact]
+    public async Task ValidateCreate_SoftRef_NotResolvableToScopeNode_AllowsCreate()
+    {
+        var (validator, _, db) = NewServices();
+        var (_, version) = await SeedPolicyAsync(db, "soft-pol");
+
+        // No scope nodes seeded with this Ref — soft-ref path skips the walk.
+        var result = await validator.ValidateCreateAsync(
+            version.Id, BindingTargetType.Repo, "repo:nowhere/never", BindStrength.Recommended);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ValidateCreate_BridgeBinding_ViaAncestorRepoRef_FiresViolation()
+    {
+        // A binding authored against the ancestor's external Ref
+        // (TargetType=Repo, TargetRef=repo:foo) should trip the
+        // tighten check the same as a ScopeNode-targeted Mandatory.
+        var (validator, scopes, db) = NewServices();
+        var chain = await SeedFourLevelChainAsync(scopes);
+        var (_, version) = await SeedPolicyAsync(db, "bridge-pol");
+
+        // Anchor the Repo ancestor's Ref so the chain walk picks it up.
+        var repoNode = await db.ScopeNodes.FirstAsync(s => s.Id == chain.Repo);
+        db.Bindings.Add(new Binding
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = version.Id,
+            TargetType = BindingTargetType.Repo,
+            TargetRef = repoNode.Ref,
+            BindStrength = BindStrength.Mandatory,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBySubjectId = "test",
+        });
+        await db.SaveChangesAsync();
+
+        // Add a Template scope under the Repo and propose a Recommended
+        // binding there — should be rejected by the Repo-bridge Mandatory.
+        var templateScope = await scopes.CreateAsync(new CreateScopeNodeRequest(
+            chain.Repo, ScopeType.Template, "template:tov", "Template"));
+
+        var result = await validator.ValidateCreateAsync(
+            version.Id, BindingTargetType.ScopeNode,
+            $"scope:{templateScope.Id}", BindStrength.Recommended);
+
+        result.Should().NotBeNull();
+        result!.OffendingScopeNodeId.Should().Be(chain.Repo);
+    }
+
+    [Fact]
+    public async Task ValidateDelete_AlwaysReturnsNull_PerSpec()
+    {
+        var (validator, _, _) = NewServices();
+
+        var result = await validator.ValidateDeleteAsync(Guid.NewGuid());
+
+        result.Should().BeNull(
+            "tighten-only is a CREATE-time invariant; deletes never violate the rule");
+    }
+
+    [Fact]
+    public async Task ValidateCreate_MandatoryProposal_NeverFlags_EvenWithMandatoryAncestor()
+    {
+        // Adding a Mandatory under a Mandatory is a duplicate but not a
+        // loosening — allowed. Reads will then dedup deepest-wins (P4.3).
+        var (validator, scopes, db) = NewServices();
+        var chain = await SeedFourLevelChainAsync(scopes);
+        var (_, version) = await SeedPolicyAsync(db, "duplicate-pol");
+        await AddAncestorBindingAsync(db, chain.Org, version.Id, BindStrength.Mandatory);
+
+        var result = await validator.ValidateCreateAsync(
+            version.Id, BindingTargetType.ScopeNode, $"scope:{chain.Repo}", BindStrength.Mandatory);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Companion to P4.3's read-time fold: refuses to commit a binding that would loosen a Mandatory binding declared upstream, so the catalog never accumulates unreachable rows that confuse audit logs and the Cockpit tree view (P9).

**Application:**
- `ITightenOnlyValidator` interface with `ValidateCreateAsync` (returns null on allowed; populated `TightenViolation` on rejected) and `ValidateDeleteAsync` (always-null hook per the issue's reviewer-flagged reconciliation: tighten-only is a CREATE-time invariant only, retained for P5/P6 to attach later side-effect checks).
- `TightenViolation` record carries `OffendingAncestorBindingId`, `OffendingScopeNodeId`, `OffendingScopeDisplayName`, `PolicyKey`, `Reason` — enough for admin triage from the error response.
- `TightenOnlyViolationException` (subclass of `ConflictException`) so the existing 409 mapping catches it.

**Infrastructure:**
- `TightenOnlyValidator` resolves `(targetType, targetRef) → ScopeNode` (soft refs allowed unchecked per the P3 non-goal); walks ancestors via `IScopeService`; checks both `ScopeNode`-targeted and bridge bindings on the ancestors' external `Ref`s (mirrors the P4.3 fold shape). Reports the deepest Mandatory ancestor — most specific is most useful for triage.
- `BindingService` gained an optional `ITightenOnlyValidator` overload; `CreateAsync` calls it before `SaveChanges`. Existing P3 unit tests that construct `BindingService` directly fall through the parameterless overload and see the legacy behaviour, preserving the test inventory unchanged.
- `PolicyExceptionHandler` maps `TightenOnlyViolationException` to a structured 409 `ProblemDetails`: `type=/problems/binding-tighten-only-violation`, `errorCode=binding.tighten-only-violation`, and `ProblemDetails.Extensions` carries `offendingAncestorBindingId`, `offendingScopeNodeId`, `offendingScopeDisplayName`, `policyKey`.

Closes #32.

## Test plan
- [x] `dotnet test` — 259 unit + 233 integration pass; 6 E2E skipped.
- [x] 8 unit (`TightenOnlyValidatorTests`): full ancestor × proposed strength matrix (only Mandatory × Recommended fires), multi-ancestor case reports deepest Mandatory, unrelated `PolicyId` never flags, soft refs allowed unchecked, bridge binding on `Repo` external `Ref` fires correctly, `ValidateDeleteAsync` always returns null, Mandatory proposal allowed even with Mandatory ancestor.
- [x] 4 unit (`BindingServiceTightenOnlyTests`): `CreateAsync` rolls back the proposed insert when the validator rejects, tightening proposal succeeds, no-ancestor case allowed, `DeleteAsync` never raises tighten-only.
- [x] 4 integration (`BindingsTightenOnlyTests`): REST POST returns 409 with the structured `ProblemDetails` payload, upgrading Recommended to Mandatory returns 201, soft refs return 201, DELETE returns 204 even on bindings that would have been the offending ancestor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)