### PR TITLE
Implement P4.5 — REST endpoints for scopes CRUD, tree, effective-policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,38 @@ Exit codes follow the federated-CLI contract from Conductor Epic AN: `0`
 success, `2` bad arguments (missing filter on `list`), `3` auth (401/403),
 `4` not found, `5` conflict (covers `BindingRetiredVersionException`).
 
+### Scope endpoints
+
+REST surface for the hierarchical scope tree (P4.5,
+[#33](https://github.com/rivoli-ai/andy-policies/issues/33)). Six
+endpoints sit on top of the `IScopeService` (P4.2,
+[#29](https://github.com/rivoli-ai/andy-policies/issues/29)) +
+`IBindingResolutionService` (P4.3,
+[#30](https://github.com/rivoli-ai/andy-policies/issues/30)):
+
+```http
+GET    /api/scopes?type=Tenant                       # list (optional type filter)
+GET    /api/scopes/tree                              # full forest, nested
+GET    /api/scopes/{id}                              # single node
+GET    /api/scopes/{id}/effective-policies            # tighten-only resolved set
+POST   /api/scopes                                    # create (canonical ladder enforced)
+DELETE /api/scopes/{id}                               # leaf-only delete
+```
+
+Create enforces the `Org → Tenant → Team → Repo → Template → Run`
+ladder; mismatched parent type returns `400` with
+`errorCode=scope.parent-type-mismatch`. Duplicate `(Type, Ref)` returns
+`409` with `errorCode=scope.ref-conflict`. Deleting a non-leaf returns
+`409` with `errorCode=scope.has-descendants` and `childCount` in the
+ProblemDetails extensions. Effective-policies resolution filters
+Retired versions, dedups same-target/same-version pairs preferring
+`Mandatory`, and orders mandatories first. Write-time tighten-only
+validation (P4.4,
+[#32](https://github.com/rivoli-ai/andy-policies/issues/32)) refuses to
+commit a `Recommended` binding that would shadow an upstream
+`Mandatory`; the `409` response carries `offendingAncestorBindingId`
+and `offendingScopeNodeId` so admins can triage from the error.
+
 For the full design — canonical `TargetRef` shapes, retired-version
 refusal, soft-delete tombstone, dedup rules on resolve, surface parity
 table, and concurrency model — see [`docs/design/bindings.md`](docs/design/bindings.md).

--- a/docs/openapi/andy-policies-v1.yaml
+++ b/docs/openapi/andy-policies-v1.yaml
@@ -889,6 +889,173 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
+  /api/scopes:
+    get:
+      tags:
+        - Scopes
+      summary: "List scope nodes. Optional `?type=` filter narrows to a\r\nsingle ScopeType (Org/Tenant/Team/Repo/Template/Run); without\r\nthe filter the entire catalogue is returned ordered by\r\n(Depth, Ref)."
+      operationId: Scopes_List
+      parameters:
+        - name: type
+          in: query
+          schema:
+            $ref: '#/components/schemas/ScopeType'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ScopeNodeDto'
+    post:
+      tags:
+        - Scopes
+      summary: "Create a new scope node. Andy.Policies.Application.Dtos.CreateScopeNodeRequest.ParentId\r\nis null for a root Andy.Policies.Domain.Enums.ScopeType.Org node and\r\nrequired otherwise. The service enforces the canonical\r\nOrg→Tenant→Team→Repo→Template→Run ladder; mismatched type\r\nreturns 400."
+      operationId: Scopes_Create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateScopeNodeRequest'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/CreateScopeNodeRequest'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/CreateScopeNodeRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScopeNodeDto'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+  /api/scopes/tree:
+    get:
+      tags:
+        - Scopes
+      summary: "Return the full forest as nested Andy.Policies.Application.Dtos.ScopeTreeDtos.\r\nOne entry per root node; an empty catalogue returns an empty\r\nlist. Order is (Ref ASC) at every level for deterministic\r\nsnapshotting."
+      operationId: Scopes_Tree
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ScopeTreeDto'
+  '/api/scopes/{id}':
+    get:
+      tags:
+        - Scopes
+      summary: Get a single scope node by id. Returns 404 if not found.
+      operationId: Scopes_Get
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScopeNodeDto'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+    delete:
+      tags:
+        - Scopes
+      summary: "Delete a leaf scope node. Refuses with 409 if the node still\r\nhas children; consumers must walk the subtree and delete\r\nleaves first."
+      operationId: Scopes_Delete
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: No Content
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+  '/api/scopes/{id}/effective-policies':
+    get:
+      tags:
+        - Scopes
+      summary: "Resolve the effective policy set for a scope node using the\r\nstricter-tightens-only fold (P4.3). Returns 404 if the node\r\ndoesn't exist."
+      operationId: Scopes_Effective
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EffectivePolicySetDto'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
 components:
   schemas:
     BindStrength:
@@ -996,6 +1163,68 @@ components:
           nullable: true
       additionalProperties: false
       description: "Request payload for `IPolicyService.CreateDraftAsync`. Creates both the\r\nstable `Policy` row and its first `PolicyVersion` (version 1, Draft).\r\nEnum fields accept any casing on input (parsed case-insensitively by the service)."
+    CreateScopeNodeRequest:
+      type: object
+      properties:
+        parentId:
+          type: string
+          format: uuid
+          nullable: true
+        type:
+          $ref: '#/components/schemas/ScopeType'
+        ref:
+          type: string
+          nullable: true
+        displayName:
+          type: string
+          nullable: true
+      additionalProperties: false
+      description: "Request payload for `IScopeService.CreateAsync` (P4.2, story\r\nrivoli-ai/andy-policies#29). Andy.Policies.Application.Dtos.CreateScopeNodeRequest.ParentId is null for a\r\nroot Andy.Policies.Domain.Enums.ScopeType.Org node; non-null for any other type.\r\nThe service enforces the canonical Org→Tenant→Team→Repo→Template→Run\r\nladder."
+    EffectivePolicyDto:
+      type: object
+      properties:
+        policyId:
+          type: string
+          format: uuid
+        policyVersionId:
+          type: string
+          format: uuid
+        policyKey:
+          type: string
+          nullable: true
+        version:
+          type: integer
+          format: int32
+        bindStrength:
+          $ref: '#/components/schemas/BindStrength'
+        sourceBindingId:
+          type: string
+          format: uuid
+        sourceScopeNodeId:
+          type: string
+          format: uuid
+          nullable: true
+        sourceScopeType:
+          $ref: '#/components/schemas/ScopeType'
+        sourceDepth:
+          type: integer
+          format: int32
+      additionalProperties: false
+      description: "One entry in an effective-policy set (P4.3, story\r\nrivoli-ai/andy-policies#30). The result of stricter-tightens-only\r\nresolution: each Andy.Policies.Application.Dtos.EffectivePolicyDto.PolicyId appears at most once,\r\ncarrying the strictest Andy.Policies.Application.Dtos.EffectivePolicyDto.BindStrength seen anywhere in\r\nthe scope chain plus a pointer back to the binding (and the scope\r\nnode that bound it) that won the resolution."
+    EffectivePolicySetDto:
+      type: object
+      properties:
+        scopeNodeId:
+          type: string
+          format: uuid
+          nullable: true
+        policies:
+          type: array
+          items:
+            $ref: '#/components/schemas/EffectivePolicyDto'
+          nullable: true
+      additionalProperties: false
+      description: "Envelope for `IBindingResolutionService` results (P4.3, story\r\nrivoli-ai/andy-policies#30). Andy.Policies.Application.Dtos.EffectivePolicySetDto.ScopeNodeId is null when\r\nthe resolver was called with a target that does not map to a known\r\n`ScopeNode` — the service then degrades to P3 exact-match\r\nsemantics rather than returning 404."
     HelpTopic:
       type: object
       properties:
@@ -1234,6 +1463,59 @@ components:
           $ref: '#/components/schemas/BindStrength'
       additionalProperties: false
       description: "A consumer-ready binding projection (P3.4, story\r\nrivoli-ai/andy-policies#22). Joins the live `Binding` row to its\r\ntarget `PolicyVersion` and stable `Policy` identity so a\r\ncaller (Conductor's ActionBus, andy-tasks per-task gates) gets enough\r\ncontext to decide what to do without a second round-trip. Wire-format\r\ncasing follows ADR 0001 §6: `Enforcement` uppercase RFC 2119\r\ntokens, `Severity` lowercase, `VersionState` PascalCase."
+    ScopeNodeDto:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        parentId:
+          type: string
+          format: uuid
+          nullable: true
+        type:
+          $ref: '#/components/schemas/ScopeType'
+        ref:
+          type: string
+          nullable: true
+        displayName:
+          type: string
+          nullable: true
+        materializedPath:
+          type: string
+          nullable: true
+        depth:
+          type: integer
+          format: int32
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+      description: "Wire-format projection of a `ScopeNode` (P4.2, story\r\nrivoli-ai/andy-policies#29). Surface controllers (REST P4.5, MCP /\r\ngRPC / CLI in P4.6) emit this shape directly so wire behaviour stays\r\nuniform across surfaces."
+    ScopeTreeDto:
+      type: object
+      properties:
+        node:
+          $ref: '#/components/schemas/ScopeNodeDto'
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScopeTreeDto'
+          nullable: true
+      additionalProperties: false
+      description: "Recursive tree projection: a `ScopeNode` plus its full subtree\r\n(P4.2, story rivoli-ai/andy-policies#29). Returned by\r\n`IScopeService.GetTreeAsync` and surfaced unchanged by the\r\nREST/MCP/gRPC tree endpoints in P4.5 / P4.6."
+    ScopeType:
+      enum:
+        - Org
+        - Tenant
+        - Team
+        - Repo
+        - Template
+        - Run
+      type: string
     UpdatePolicyVersionRequest:
       type: object
       properties:
@@ -1283,3 +1565,5 @@ tags:
     description: "Version-rooted enumeration of `Binding`s (P3.3, story\r\nrivoli-ai/andy-policies#21). Sits next to the version resource so\r\nHATEOAS-style clients can discover bindings without a separate\r\nquery. Delegates to Andy.Policies.Application.Interfaces.IBindingService; the controller is\r\npurely a wire-format adapter."
   - name: PolicyVersionsLifecycle
     description: "REST surface for lifecycle transitions on a `PolicyVersion` (P2.3, story\r\nrivoli-ai/andy-policies#13). Three action-shaped endpoints — `publish`,\r\n`winding-down`, `retire` — sit on top of\r\nAndy.Policies.Application.Interfaces.ILifecycleTransitionService. Auto-supersede of the previous\r\nActive happens inside the service's serializable transaction; the controller\r\nis a thin wire-format adapter and never re-implements state-machine logic.\r\nService exceptions map to status codes via `PolicyExceptionHandler`:\r\nAndy.Policies.Application.Exceptions.ValidationException → 400 (rationale\r\nmissing), Andy.Policies.Application.Exceptions.NotFoundException → 404\r\n(unknown id), Andy.Policies.Application.Exceptions.InvalidLifecycleTransitionException\r\nand Andy.Policies.Application.Exceptions.ConcurrentPublishException → 409."
+  - name: Scopes
+    description: "REST surface for the scope hierarchy (P4.5, story\r\nrivoli-ai/andy-policies#33). Six endpoints sit on top of\r\nAndy.Policies.Application.Interfaces.IScopeService (P4.2) and\r\nAndy.Policies.Application.Interfaces.IBindingResolutionService (P4.3): list, get-by-id,\r\ntree, effective-policies, create, delete. Service exceptions are\r\nmapped to status codes by `PolicyExceptionHandler`:\r\n<list type=\"bullet\"><item>Andy.Policies.Application.Exceptions.NotFoundException → 404</item><item>Andy.Policies.Application.Exceptions.InvalidScopeTypeException → 400 (`scope.parent-type-mismatch`)</item><item>Andy.Policies.Application.Exceptions.ScopeRefConflictException → 409 (`scope.ref-conflict`)</item><item>Andy.Policies.Application.Exceptions.ScopeHasDescendantsException → 409 (`scope.has-descendants`)</item></list>"

--- a/src/Andy.Policies.Api/Controllers/ScopesController.cs
+++ b/src/Andy.Policies.Api/Controllers/ScopesController.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Enums;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Andy.Policies.Api.Controllers;
+
+/// <summary>
+/// REST surface for the scope hierarchy (P4.5, story
+/// rivoli-ai/andy-policies#33). Six endpoints sit on top of
+/// <see cref="IScopeService"/> (P4.2) and
+/// <see cref="IBindingResolutionService"/> (P4.3): list, get-by-id,
+/// tree, effective-policies, create, delete. Service exceptions are
+/// mapped to status codes by <c>PolicyExceptionHandler</c>:
+/// <list type="bullet">
+///   <item><see cref="Application.Exceptions.NotFoundException"/> → 404</item>
+///   <item><see cref="Application.Exceptions.InvalidScopeTypeException"/> → 400 (<c>scope.parent-type-mismatch</c>)</item>
+///   <item><see cref="Application.Exceptions.ScopeRefConflictException"/> → 409 (<c>scope.ref-conflict</c>)</item>
+///   <item><see cref="Application.Exceptions.ScopeHasDescendantsException"/> → 409 (<c>scope.has-descendants</c>)</item>
+/// </list>
+/// </summary>
+[ApiController]
+[Authorize]
+[Route("api/scopes")]
+[Produces("application/json")]
+public sealed class ScopesController : ControllerBase
+{
+    private readonly IScopeService _scopes;
+    private readonly IBindingResolutionService _resolver;
+
+    public ScopesController(IScopeService scopes, IBindingResolutionService resolver)
+    {
+        _scopes = scopes;
+        _resolver = resolver;
+    }
+
+    /// <summary>
+    /// List scope nodes. Optional <c>?type=</c> filter narrows to a
+    /// single ScopeType (Org/Tenant/Team/Repo/Template/Run); without
+    /// the filter the entire catalogue is returned ordered by
+    /// (Depth, Ref).
+    /// </summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(IReadOnlyList<ScopeNodeDto>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IReadOnlyList<ScopeNodeDto>>> List(
+        [FromQuery] ScopeType? type,
+        CancellationToken ct)
+    {
+        var rows = await _scopes.ListAsync(type, ct);
+        return Ok(rows);
+    }
+
+    /// <summary>
+    /// Return the full forest as nested <see cref="ScopeTreeDto"/>s.
+    /// One entry per root node; an empty catalogue returns an empty
+    /// list. Order is (Ref ASC) at every level for deterministic
+    /// snapshotting.
+    /// </summary>
+    [HttpGet("tree")]
+    [ProducesResponseType(typeof(IReadOnlyList<ScopeTreeDto>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IReadOnlyList<ScopeTreeDto>>> Tree(CancellationToken ct)
+    {
+        var forest = await _scopes.GetTreeAsync(ct);
+        return Ok(forest);
+    }
+
+    /// <summary>
+    /// Get a single scope node by id. Returns 404 if not found.
+    /// </summary>
+    [HttpGet("{id:guid}")]
+    [ProducesResponseType(typeof(ScopeNodeDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<ScopeNodeDto>> Get(Guid id, CancellationToken ct)
+    {
+        var dto = await _scopes.GetAsync(id, ct);
+        return dto is null ? NotFound() : Ok(dto);
+    }
+
+    /// <summary>
+    /// Resolve the effective policy set for a scope node using the
+    /// stricter-tightens-only fold (P4.3). Returns 404 if the node
+    /// doesn't exist.
+    /// </summary>
+    [HttpGet("{id:guid}/effective-policies")]
+    [ProducesResponseType(typeof(EffectivePolicySetDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<EffectivePolicySetDto>> Effective(Guid id, CancellationToken ct)
+    {
+        var result = await _resolver.ResolveForScopeAsync(id, ct);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Create a new scope node. <see cref="CreateScopeNodeRequest.ParentId"/>
+    /// is null for a root <see cref="ScopeType.Org"/> node and
+    /// required otherwise. The service enforces the canonical
+    /// Org→Tenant→Team→Repo→Template→Run ladder; mismatched type
+    /// returns 400.
+    /// </summary>
+    [HttpPost]
+    [ProducesResponseType(typeof(ScopeNodeDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<ScopeNodeDto>> Create(
+        [FromBody] CreateScopeNodeRequest request,
+        CancellationToken ct)
+    {
+        var dto = await _scopes.CreateAsync(request, ct);
+        return CreatedAtAction(nameof(Get), new { id = dto.Id }, dto);
+    }
+
+    /// <summary>
+    /// Delete a leaf scope node. Refuses with 409 if the node still
+    /// has children; consumers must walk the subtree and delete
+    /// leaves first.
+    /// </summary>
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
+    {
+        await _scopes.DeleteAsync(id, ct);
+        return NoContent();
+    }
+}

--- a/src/Andy.Policies.Api/ExceptionHandlers/PolicyExceptionHandler.cs
+++ b/src/Andy.Policies.Api/ExceptionHandlers/PolicyExceptionHandler.cs
@@ -51,6 +51,67 @@ public sealed class PolicyExceptionHandler : IExceptionHandler
             return true;
         }
 
+        // P4.5 (#33): scope-specific 4xx mappings carry typed errorCodes
+        // so the Cockpit + Angular client can branch on stable strings
+        // without parsing English messages.
+        if (exception is InvalidScopeTypeException itex)
+        {
+            var problem400 = new ProblemDetails
+            {
+                Status = StatusCodes.Status400BadRequest,
+                Title = "Scope parent type mismatch",
+                Detail = itex.Message,
+                Type = "/problems/scope-parent-type-mismatch",
+                Instance = httpContext.Request.Path,
+                Extensions = { ["errorCode"] = "scope.parent-type-mismatch" },
+            };
+            httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await httpContext.Response.WriteAsJsonAsync(problem400, cancellationToken);
+            return true;
+        }
+
+        if (exception is ScopeRefConflictException src)
+        {
+            var problem409 = new ProblemDetails
+            {
+                Status = StatusCodes.Status409Conflict,
+                Title = "Scope ref conflict",
+                Detail = src.Message,
+                Type = "/problems/scope-ref-conflict",
+                Instance = httpContext.Request.Path,
+                Extensions =
+                {
+                    ["errorCode"] = "scope.ref-conflict",
+                    ["scopeType"] = src.Type.ToString(),
+                    ["ref"] = src.Ref,
+                },
+            };
+            httpContext.Response.StatusCode = StatusCodes.Status409Conflict;
+            await httpContext.Response.WriteAsJsonAsync(problem409, cancellationToken);
+            return true;
+        }
+
+        if (exception is ScopeHasDescendantsException shdex)
+        {
+            var problem409 = new ProblemDetails
+            {
+                Status = StatusCodes.Status409Conflict,
+                Title = "Scope has descendants",
+                Detail = shdex.Message,
+                Type = "/problems/scope-has-descendants",
+                Instance = httpContext.Request.Path,
+                Extensions =
+                {
+                    ["errorCode"] = "scope.has-descendants",
+                    ["scopeNodeId"] = shdex.ScopeNodeId,
+                    ["childCount"] = shdex.ChildCount,
+                },
+            };
+            httpContext.Response.StatusCode = StatusCodes.Status409Conflict;
+            await httpContext.Response.WriteAsJsonAsync(problem409, cancellationToken);
+            return true;
+        }
+
         // P4.4: tighten-only violation carries the offending ancestor
         // binding id + scope node id so admins can triage from the
         // error response without a follow-up query. We inject the

--- a/tests/Andy.Policies.Tests.Integration/Controllers/ScopesControllerTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/ScopesControllerTests.cs
@@ -1,0 +1,211 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Domain.Enums;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Controllers;
+
+/// <summary>
+/// Integration tests for the scope REST surface (P4.5, story
+/// rivoli-ai/andy-policies#33). Drives every endpoint end-to-end
+/// against the SQLite-backed factory: full CRUD round-trip, tree
+/// shape, effective-policies bridging to P4.3, the 400 / 409
+/// problem-details payloads with their typed errorCodes, and the
+/// type-ladder enforcement.
+/// </summary>
+public class ScopesControllerTests : IClassFixture<PoliciesApiFactory>
+{
+    private readonly HttpClient _client;
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    public ScopesControllerTests(PoliciesApiFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    private async Task<ScopeNodeDto> CreateAsync(Guid? parentId, ScopeType type, string @ref, string display)
+    {
+        var resp = await _client.PostAsJsonAsync("/api/scopes",
+            new { parentId, type = type.ToString(), @ref, displayName = display });
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<ScopeNodeDto>(JsonOptions))!;
+    }
+
+    private static string Slug(string prefix) => $"{prefix}-{Guid.NewGuid():N}".Substring(0, 20);
+
+    [Fact]
+    public async Task FullCrudRoundTrip_RootOrgPlusChildTenant_TreeAndDeleteAreCorrect()
+    {
+        var orgRef = Slug("org:e2e");
+        var tenantRef = Slug("tenant:e2e");
+
+        // Create root.
+        var org = await CreateAsync(null, ScopeType.Org, orgRef, "E2E Org");
+        org.ParentId.Should().BeNull();
+        org.Depth.Should().Be(0);
+
+        // Create child.
+        var tenant = await CreateAsync(org.Id, ScopeType.Tenant, tenantRef, "E2E Tenant");
+        tenant.ParentId.Should().Be(org.Id);
+        tenant.Depth.Should().Be(1);
+
+        // GET /api/scopes/{id} returns the row we just created.
+        var fetched = await _client.GetFromJsonAsync<ScopeNodeDto>(
+            $"/api/scopes/{tenant.Id}", JsonOptions);
+        fetched!.Id.Should().Be(tenant.Id);
+
+        // GET /api/scopes/tree returns a forest. Find our org and confirm it
+        // has a child whose id matches our tenant.
+        var forest = await _client.GetFromJsonAsync<List<ScopeTreeDto>>(
+            "/api/scopes/tree", JsonOptions);
+        var orgTree = forest!.FirstOrDefault(t => t.Node.Id == org.Id);
+        orgTree.Should().NotBeNull();
+        orgTree!.Children.Select(c => c.Node.Id).Should().Contain(tenant.Id);
+
+        // DELETE root → 409 (has descendants), 204 once child is gone.
+        var rootDeleteAttempt = await _client.DeleteAsync($"/api/scopes/{org.Id}");
+        rootDeleteAttempt.StatusCode.Should().Be(HttpStatusCode.Conflict);
+
+        var childDelete = await _client.DeleteAsync($"/api/scopes/{tenant.Id}");
+        childDelete.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var rootDelete = await _client.DeleteAsync($"/api/scopes/{org.Id}");
+        rootDelete.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task Get_OnUnknownId_Returns404()
+    {
+        var resp = await _client.GetAsync($"/api/scopes/{Guid.NewGuid()}");
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Create_WithTeamAndNoParent_Returns400_WithParentTypeMismatchCode()
+    {
+        var resp = await _client.PostAsJsonAsync("/api/scopes",
+            new { parentId = (Guid?)null, type = "Team", @ref = Slug("team:bad"), displayName = "Bad" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var raw = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(raw);
+        doc.RootElement.GetProperty("errorCode").GetString().Should().Be("scope.parent-type-mismatch");
+        doc.RootElement.GetProperty("type").GetString().Should().Be("/problems/scope-parent-type-mismatch");
+    }
+
+    [Fact]
+    public async Task Create_WithTeamUnderOrg_Returns400_WithParentTypeMismatchCode()
+    {
+        var org = await CreateAsync(null, ScopeType.Org, Slug("org:lo"), "Org");
+
+        var resp = await _client.PostAsJsonAsync("/api/scopes",
+            new { parentId = org.Id, type = "Team", @ref = Slug("team:wrong"), displayName = "Team" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var raw = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(raw);
+        doc.RootElement.GetProperty("errorCode").GetString().Should().Be("scope.parent-type-mismatch");
+    }
+
+    [Fact]
+    public async Task Create_WithDuplicateTypeRef_Returns409_WithRefConflictCode()
+    {
+        var refValue = Slug("org:dup");
+        await CreateAsync(null, ScopeType.Org, refValue, "First");
+
+        var resp = await _client.PostAsJsonAsync("/api/scopes",
+            new { parentId = (Guid?)null, type = "Org", @ref = refValue, displayName = "Second" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var raw = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(raw);
+        doc.RootElement.GetProperty("errorCode").GetString().Should().Be("scope.ref-conflict");
+        doc.RootElement.GetProperty("scopeType").GetString().Should().Be("Org");
+        doc.RootElement.GetProperty("ref").GetString().Should().Be(refValue);
+    }
+
+    [Fact]
+    public async Task Delete_OnNonLeaf_Returns409_WithChildCount()
+    {
+        var org = await CreateAsync(null, ScopeType.Org, Slug("org:nonleaf"), "Org");
+        await CreateAsync(org.Id, ScopeType.Tenant, Slug("tenant:nonleaf"), "Tenant");
+
+        var resp = await _client.DeleteAsync($"/api/scopes/{org.Id}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var raw = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(raw);
+        doc.RootElement.GetProperty("errorCode").GetString().Should().Be("scope.has-descendants");
+        doc.RootElement.GetProperty("scopeNodeId").GetGuid().Should().Be(org.Id);
+        doc.RootElement.GetProperty("childCount").GetInt32().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task Create_WithMissingParent_Returns404()
+    {
+        var resp = await _client.PostAsJsonAsync("/api/scopes",
+            new { parentId = Guid.NewGuid(), type = "Tenant", @ref = Slug("tenant:orphan"), displayName = "Orphan" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task List_WithTypeFilter_ReturnsOnlyMatching()
+    {
+        var org = await CreateAsync(null, ScopeType.Org, Slug("org:list"), "Org");
+        await CreateAsync(org.Id, ScopeType.Tenant, Slug("tenant:list"), "Tenant");
+
+        var resp = await _client.GetFromJsonAsync<List<ScopeNodeDto>>(
+            "/api/scopes?type=Tenant", JsonOptions);
+
+        resp.Should().NotBeNull().And.NotBeEmpty();
+        resp!.All(n => n.Type == ScopeType.Tenant).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Effective_ReturnsEnvelopeWithScopeNodeIdAndPolicies()
+    {
+        // The resolution semantics are exercised exhaustively in
+        // BindingResolutionServiceTests; this assertion just confirms
+        // the REST surface forwards correctly and returns 200 with the
+        // expected envelope shape.
+        var org = await CreateAsync(null, ScopeType.Org, Slug("org:eff"), "Org");
+
+        var resp = await _client.GetFromJsonAsync<EffectivePolicySetDto>(
+            $"/api/scopes/{org.Id}/effective-policies", JsonOptions);
+
+        resp.Should().NotBeNull();
+        resp!.ScopeNodeId.Should().Be(org.Id);
+        resp.Policies.Should().BeEmpty("no bindings seeded against this org");
+    }
+
+    [Fact]
+    public async Task Effective_OnUnknownScope_Returns404()
+    {
+        var resp = await _client.GetAsync($"/api/scopes/{Guid.NewGuid()}/effective-policies");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Create_Returns201_WithLocationHeader()
+    {
+        var resp = await _client.PostAsJsonAsync("/api/scopes",
+            new { parentId = (Guid?)null, type = "Org", @ref = Slug("org:loc"), displayName = "Loc" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+        resp.Headers.Location.Should().NotBeNull();
+        resp.Headers.Location!.AbsolutePath.Should().StartWith("/api/scopes/");
+    }
+}


### PR DESCRIPTION
## Summary

Six new endpoints on `ScopesController`, sitting on top of `IScopeService` (P4.2) and `IBindingResolutionService` (P4.3):

```http
GET    /api/scopes?type=                   # list (optional type filter)
GET    /api/scopes/tree                    # full forest, nested
GET    /api/scopes/{id}                    # single node
GET    /api/scopes/{id}/effective-policies # resolved set (P4.3 fold)
POST   /api/scopes                         # create (ladder-enforced)
DELETE /api/scopes/{id}                    # leaf-only delete
```

The `ScopesController` is a thin wire-format adapter — every action delegates straight through; no business logic in the controller. All endpoints are `[Authorize]`'d.

`PolicyExceptionHandler` grew three typed-error mappings so the Cockpit + Angular client can branch on stable `errorCode` strings without parsing English messages:

- `InvalidScopeTypeException` → `400` with `type=/problems/scope-parent-type-mismatch` and `errorCode=scope.parent-type-mismatch`.
- `ScopeRefConflictException` → `409` with `errorCode=scope.ref-conflict` plus structured `scopeType` + `ref` extensions.
- `ScopeHasDescendantsException` → `409` with `errorCode=scope.has-descendants` and `childCount` in extensions.

Closes #33.

## Test plan
- [x] `dotnet test` — 259 unit + 244 integration pass; 6 E2E skipped (`E2E_ENABLED=0`).
- [x] 11 integration (`ScopesControllerTests`): full CRUD round-trip (create root + child, GET tree shape, DELETE root → 409 / DELETE child → 204 / DELETE root → 204), GET unknown id → 404, POST Team without parent → 400 + `scope.parent-type-mismatch`, POST Team under Org → 400, POST duplicate `(Type, Ref)` → 409 with structured extensions, DELETE non-leaf → 409 with `childCount`, POST with missing parent → 404, GET filter `?type=Tenant`, GET effective-policies envelope shape, effective-policies on unknown scope → 404, POST returns 201 with `Location` header.
- [x] OpenAPI snapshot regenerated (+285 lines) with the six new operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)