### PR TITLE
Implement P5.1 — Override entity + EF migration with state machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ The docker-compose in this repo binds Mode 2 ports so it can coexist with a nati
 
 | Layer | Project | Entities / responsibilities |
 |-------|---------|-----------------------------|
-| Domain | `src/Andy.Policies.Domain` | `Policy`, `PolicyVersion`, `Binding` (P3.1, [#19](https://github.com/rivoli-ai/andy-policies/issues/19)), `ScopeNode` (P4.1, [#28](https://github.com/rivoli-ai/andy-policies/issues/28)), dimension enums (`EnforcementLevel`, `Severity`, `LifecycleState`, `BindingTargetType`, `BindStrength`, `ScopeType`); `Override` (P5), `AuditEvent` (P6), `Bundle` (P8) land with their respective epics |
+| Domain | `src/Andy.Policies.Domain` | `Policy`, `PolicyVersion`, `Binding` (P3.1, [#19](https://github.com/rivoli-ai/andy-policies/issues/19)), `ScopeNode` (P4.1, [#28](https://github.com/rivoli-ai/andy-policies/issues/28)), `Override` (P5.1, [#49](https://github.com/rivoli-ai/andy-policies/issues/49)), dimension enums (`EnforcementLevel`, `Severity`, `LifecycleState`, `BindingTargetType`, `BindStrength`, `ScopeType`, `OverrideScopeKind`, `OverrideEffect`, `OverrideState`); `AuditEvent` (P6), `Bundle` (P8) land with their respective epics |
 | Application | `src/Andy.Policies.Application` | `IPolicyService`; per-epic interfaces (`IBindingService`, `IScopeService`, `IOverrideService`, `IAuditChain`, `IBundleService`) added by later stories |
 | Infrastructure | `src/Andy.Policies.Infrastructure` | EF Core (`AppDbContext` + migrations), `PolicyService` implementation, `PolicySeeder` for the six stock policies, andy-rbac / andy-settings adapters |
 | API | `src/Andy.Policies.Api` | REST controllers, MCP tools, gRPC services, OIDC/JWT auth, OpenAPI generation, OpenTelemetry wiring |

--- a/src/Andy.Policies.Domain/Entities/Override.cs
+++ b/src/Andy.Policies.Domain/Entities/Override.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Domain.Enums;
+
+namespace Andy.Policies.Domain.Entities;
+
+/// <summary>
+/// Per-principal or per-cohort policy override (P5.1, story
+/// rivoli-ai/andy-policies#49). The escape hatch from
+/// stricter-tightens-only resolution: an approved override can
+/// either exempt a principal/cohort from a Mandatory binding or
+/// replace it with a different <see cref="PolicyVersion"/>, with
+/// approver, rationale, and expiry recorded for audit (P6).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>State machine</b> (P5.2 enforces transitions):
+/// <c>Proposed → Approved → (Revoked | Expired)</c>. The reaper
+/// (P5.3) is the only path into <c>Expired</c>; explicit revocation
+/// is operator-driven and stamps a non-null
+/// <see cref="RevocationReason"/>.
+/// </para>
+/// <para>
+/// <b>Effect invariants</b> (CHECK constraint at the DB layer):
+/// <see cref="OverrideEffect.Exempt"/> rows have null
+/// <see cref="ReplacementPolicyVersionId"/>;
+/// <see cref="OverrideEffect.Replace"/> rows carry a non-null one
+/// pointing at the alternate <c>PolicyVersion</c>.
+/// </para>
+/// <para>
+/// <b>Cohort membership is not stored here.</b> <see cref="ScopeRef"/>
+/// is an opaque consumer-defined string; this service never expands
+/// the cohort or resolves principal identities (per Epic P5
+/// Non-goals).
+/// </para>
+/// </remarks>
+public class Override
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid PolicyVersionId { get; set; }
+
+    public PolicyVersion PolicyVersion { get; set; } = default!;
+
+    public OverrideScopeKind ScopeKind { get; set; }
+
+    /// <summary>
+    /// Opaque consumer-defined reference identifying the principal
+    /// or cohort (e.g. <c>user:42</c>, <c>cohort:beta-testers</c>).
+    /// Capped at 256 chars; service-layer validation in P5.2
+    /// enforces non-empty + ≤256.
+    /// </summary>
+    public string ScopeRef { get; set; } = string.Empty;
+
+    public OverrideEffect Effect { get; set; }
+
+    /// <summary>
+    /// Non-null when <see cref="Effect"/> is
+    /// <see cref="OverrideEffect.Replace"/>; null when
+    /// <see cref="OverrideEffect.Exempt"/>. The CHECK constraint
+    /// <c>ck_overrides_effect_replacement</c> enforces this on
+    /// every insert/update.
+    /// </summary>
+    public Guid? ReplacementPolicyVersionId { get; set; }
+
+    public PolicyVersion? ReplacementPolicyVersion { get; set; }
+
+    public string ProposerSubjectId { get; set; } = string.Empty;
+
+    /// <summary>Non-null once the override transitions to
+    /// <see cref="OverrideState.Approved"/>. P5.2 enforces
+    /// approver != proposer.</summary>
+    public string? ApproverSubjectId { get; set; }
+
+    public OverrideState State { get; set; } = OverrideState.Proposed;
+
+    public DateTimeOffset ProposedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    public DateTimeOffset? ApprovedAt { get; set; }
+
+    public DateTimeOffset ExpiresAt { get; set; }
+
+    public string Rationale { get; set; } = string.Empty;
+
+    /// <summary>Non-null only after explicit revocation;
+    /// reaper-driven expiry leaves this null.</summary>
+    public string? RevocationReason { get; set; }
+
+    /// <summary>
+    /// Optimistic-concurrency token. Bumped manually in
+    /// <c>AppDbContext.SaveChangesAsync</c> on every modification,
+    /// matching the cross-provider pattern used by
+    /// <see cref="PolicyVersion"/>.
+    /// </summary>
+    public uint Revision { get; set; }
+}

--- a/src/Andy.Policies.Domain/Enums/OverrideEffect.cs
+++ b/src/Andy.Policies.Domain/Enums/OverrideEffect.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Domain.Enums;
+
+/// <summary>
+/// What an <see cref="Entities.Override"/> does to the policy that
+/// would otherwise apply (P5.1, story rivoli-ai/andy-policies#49):
+/// <list type="bullet">
+///   <item><see cref="Exempt"/> — temporarily skip the bound policy
+///     for the principal/cohort. Carries no replacement (CHECK
+///     constraint enforces null <c>ReplacementPolicyVersionId</c>).
+///   </item>
+///   <item><see cref="Replace"/> — substitute a different
+///     <see cref="PolicyVersion"/> while the override is active.
+///     Carries a non-null replacement (CHECK constraint enforces
+///     non-null <c>ReplacementPolicyVersionId</c>).
+///   </item>
+/// </list>
+/// </summary>
+public enum OverrideEffect
+{
+    Exempt = 0,
+    Replace = 1,
+}

--- a/src/Andy.Policies.Domain/Enums/OverrideScopeKind.cs
+++ b/src/Andy.Policies.Domain/Enums/OverrideScopeKind.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Domain.Enums;
+
+/// <summary>
+/// Granularity of an <see cref="Entities.Override"/>'s scope (P5.1,
+/// story rivoli-ai/andy-policies#49). <see cref="Principal"/>
+/// targets a single subject (e.g. a user or service account);
+/// <see cref="Cohort"/> targets a group whose membership is
+/// resolved by the consumer at read time (per Epic P5 Non-goals,
+/// andy-policies stores the opaque <c>scopeRef</c> and never
+/// expands the cohort here).
+/// <para>
+/// Persisted as <c>string</c> via <c>HasConversion&lt;string&gt;()</c>
+/// — the partial-index syntax in <see cref="Entities.Override"/>'s
+/// EF config relies on the string form being stable on disk.
+/// </para>
+/// </summary>
+public enum OverrideScopeKind
+{
+    Principal = 0,
+    Cohort = 1,
+}

--- a/src/Andy.Policies.Domain/Enums/OverrideState.cs
+++ b/src/Andy.Policies.Domain/Enums/OverrideState.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Domain.Enums;
+
+/// <summary>
+/// Lifecycle state of an <see cref="Entities.Override"/> (P5.1,
+/// story rivoli-ai/andy-policies#49). The four-state machine:
+/// <list type="bullet">
+///   <item><see cref="Proposed"/> — created by an author; awaiting
+///     approver. <c>ApproverSubjectId</c> + <c>ApprovedAt</c> are
+///     null in this state.</item>
+///   <item><see cref="Approved"/> — committed by an approver
+///     (P5.2 enforces approver != proposer). The override is in
+///     force until <c>ExpiresAt</c> or revocation.</item>
+///   <item><see cref="Revoked"/> — explicitly revoked by an
+///     approver before expiry; carries a non-null
+///     <c>RevocationReason</c>.</item>
+///   <item><see cref="Expired"/> — the reaper (P5.3) flipped the
+///     row when <c>ExpiresAt</c> passed; transition is automatic
+///     and irreversible.</item>
+/// </list>
+/// Persisted as <c>string</c> so the partial index
+/// <c>ix_overrides_expiry_approved</c> can filter on
+/// <c>"State" = 'Approved'</c> directly without an int-to-string
+/// cast.
+/// </summary>
+public enum OverrideState
+{
+    Proposed = 0,
+    Approved = 1,
+    Revoked = 2,
+    Expired = 3,
+}

--- a/src/Andy.Policies.Infrastructure/Data/AppDbContext.cs
+++ b/src/Andy.Policies.Infrastructure/Data/AppDbContext.cs
@@ -23,6 +23,8 @@ public class AppDbContext : DbContext
 
     public DbSet<ScopeNode> ScopeNodes => Set<ScopeNode>();
 
+    public DbSet<Override> Overrides => Set<Override>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -243,6 +245,72 @@ public class AppDbContext : DbContext
             entity.HasIndex(s => s.MaterializedPath)
                 .HasDatabaseName("ix_scope_nodes_materialized_path");
         });
+
+        // P5.1 (rivoli-ai/andy-policies#49) — Override entity. Per-
+        // principal or per-cohort escape hatch from stricter-tightens-
+        // only resolution.
+        // - HasConversion<string>() on the three enums so the partial
+        //   index can filter on "State" = 'Approved' directly without an
+        //   int-to-string cast (and so the persisted shape is human-
+        //   readable for forensic queries).
+        // - FK Restrict on PolicyVersionId AND ReplacementPolicyVersionId:
+        //   deleting a version with active overrides is rejected at the
+        //   DB layer; the override contract is reproducibility, not
+        //   cascade.
+        // - Two indexes:
+        //     ix_overrides_scope_state — every (P4-resolution / P5
+        //       service) read filters on (ScopeKind, ScopeRef, State);
+        //       the composite covering index keeps the hot path off
+        //       table scans.
+        //     ix_overrides_expiry_approved — partial index used by the
+        //       reaper (P5.3) to sweep `WHERE "State" = 'Approved'
+        //       AND "ExpiresAt" < now()` without scanning the whole
+        //       table. Postgres + SQLite both honour the same partial
+        //       index syntax (string column + literal compare).
+        // - CHECK constraint ck_overrides_effect_replacement: the
+        //   Replace/Exempt invariant — Replace iff
+        //   ReplacementPolicyVersionId is non-null. EF's HasCheckConstraint
+        //   uses the column name in quotes for case-sensitive Postgres
+        //   identifiers; SQLite is lenient about casing.
+        // - Revision uint concurrency token, bumped manually in
+        //   BumpRevisions below (matches the PolicyVersion pattern from
+        //   ADR 0001).
+        modelBuilder.Entity<Override>(entity =>
+        {
+            entity.ToTable("overrides", t =>
+            {
+                t.HasCheckConstraint(
+                    "ck_overrides_effect_replacement",
+                    "(\"Effect\" = 'Exempt' AND \"ReplacementPolicyVersionId\" IS NULL) OR " +
+                    "(\"Effect\" = 'Replace' AND \"ReplacementPolicyVersionId\" IS NOT NULL)");
+            });
+            entity.HasKey(o => o.Id);
+
+            entity.Property(o => o.ScopeKind).HasConversion<string>().HasMaxLength(16).IsRequired();
+            entity.Property(o => o.Effect).HasConversion<string>().HasMaxLength(16).IsRequired();
+            entity.Property(o => o.State).HasConversion<string>().HasMaxLength(16).IsRequired();
+            entity.Property(o => o.ScopeRef).IsRequired().HasMaxLength(256);
+            entity.Property(o => o.ProposerSubjectId).IsRequired().HasMaxLength(128);
+            entity.Property(o => o.ApproverSubjectId).HasMaxLength(128);
+            entity.Property(o => o.Rationale).IsRequired().HasMaxLength(2000);
+            entity.Property(o => o.RevocationReason).HasMaxLength(2000);
+            entity.Property(o => o.Revision).IsConcurrencyToken();
+
+            entity.HasOne(o => o.PolicyVersion)
+                .WithMany()
+                .HasForeignKey(o => o.PolicyVersionId)
+                .OnDelete(DeleteBehavior.Restrict);
+            entity.HasOne(o => o.ReplacementPolicyVersion)
+                .WithMany()
+                .HasForeignKey(o => o.ReplacementPolicyVersionId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasIndex(o => new { o.ScopeKind, o.ScopeRef, o.State })
+                .HasDatabaseName("ix_overrides_scope_state");
+            entity.HasIndex(o => o.ExpiresAt)
+                .HasDatabaseName("ix_overrides_expiry_approved")
+                .HasFilter("\"State\" = 'Approved'");
+        });
     }
 
     // Override only the `bool`-flavoured routing entry points. EF routes `SaveChanges()` →
@@ -316,6 +384,18 @@ public class AppDbContext : DbContext
     private void BumpRevisions()
     {
         foreach (var entry in ChangeTracker.Entries<PolicyVersion>())
+        {
+            if (entry.State == EntityState.Modified)
+            {
+                entry.Entity.Revision = unchecked(entry.Entity.Revision + 1);
+            }
+        }
+
+        // P5.1: Override carries the same uint Revision concurrency
+        // token; bump on every modification so the reaper (P5.3) and
+        // approval workflow (P5.2) surface optimistic-concurrency
+        // conflicts instead of silently overwriting each other.
+        foreach (var entry in ChangeTracker.Entries<Override>())
         {
             if (entry.State == EntityState.Modified)
             {

--- a/src/Andy.Policies.Infrastructure/Migrations/20260430232106_AddOverrides.Designer.cs
+++ b/src/Andy.Policies.Infrastructure/Migrations/20260430232106_AddOverrides.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Andy.Policies.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Andy.Policies.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430232106_AddOverrides")]
+    partial class AddOverrides
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Andy.Policies.Infrastructure/Migrations/20260430232106_AddOverrides.cs
+++ b/src/Andy.Policies.Infrastructure/Migrations/20260430232106_AddOverrides.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Andy.Policies.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOverrides : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "overrides",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    PolicyVersionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ScopeKind = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    ScopeRef = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Effect = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    ReplacementPolicyVersionId = table.Column<Guid>(type: "uuid", nullable: true),
+                    ProposerSubjectId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    ApproverSubjectId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    State = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    ProposedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ApprovedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    ExpiresAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Rationale = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false),
+                    RevocationReason = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    Revision = table.Column<long>(type: "bigint", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_overrides", x => x.Id);
+                    table.CheckConstraint("ck_overrides_effect_replacement", "(\"Effect\" = 'Exempt' AND \"ReplacementPolicyVersionId\" IS NULL) OR (\"Effect\" = 'Replace' AND \"ReplacementPolicyVersionId\" IS NOT NULL)");
+                    table.ForeignKey(
+                        name: "FK_overrides_policy_versions_PolicyVersionId",
+                        column: x => x.PolicyVersionId,
+                        principalTable: "policy_versions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_overrides_policy_versions_ReplacementPolicyVersionId",
+                        column: x => x.ReplacementPolicyVersionId,
+                        principalTable: "policy_versions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_overrides_expiry_approved",
+                table: "overrides",
+                column: "ExpiresAt",
+                filter: "\"State\" = 'Approved'");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_overrides_PolicyVersionId",
+                table: "overrides",
+                column: "PolicyVersionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_overrides_ReplacementPolicyVersionId",
+                table: "overrides",
+                column: "ReplacementPolicyVersionId");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_overrides_scope_state",
+                table: "overrides",
+                columns: new[] { "ScopeKind", "ScopeRef", "State" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "overrides");
+        }
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Migration/SqliteMigrationTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Migration/SqliteMigrationTests.cs
@@ -58,6 +58,7 @@ public class SqliteMigrationTests : IDisposable
         });
         applied.Should().Contain(name => name.EndsWith("_AddBindings"));
         applied.Should().Contain(name => name.EndsWith("_AddScopeNodes"));
+        applied.Should().Contain(name => name.EndsWith("_AddOverrides"));
     }
 
     [Fact]
@@ -89,7 +90,7 @@ public class SqliteMigrationTests : IDisposable
                 "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name <> '__EFMigrationsHistory'")
             .ToListAsync();
 
-        tables.Should().Contain(new[] { "policies", "policy_versions", "bindings", "scope_nodes" });
+        tables.Should().Contain(new[] { "policies", "policy_versions", "bindings", "scope_nodes", "overrides" });
     }
 
     [Fact]

--- a/tests/Andy.Policies.Tests.Integration/Persistence/OverrideMigrationTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Persistence/OverrideMigrationTests.cs
@@ -1,0 +1,291 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Persistence;
+
+/// <summary>
+/// P5.1 (#49) integration tests for the <see cref="Override"/>
+/// table: migration applies cleanly on Sqlite, the partial index
+/// over Approved-only rows is present, the FK Restrict on both
+/// <c>PolicyVersionId</c> + <c>ReplacementPolicyVersionId</c> rejects
+/// inserts against unknown versions, and the
+/// <c>ck_overrides_effect_replacement</c> CHECK constraint enforces
+/// the Replace ↔ replacement-non-null contract.
+/// </summary>
+public class OverrideMigrationTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly SqliteConnection _connection;
+
+    public OverrideMigrationTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"andy-policies-overmig-{Guid.NewGuid():N}.db");
+        _connection = new SqliteConnection($"Data Source={_dbPath};Foreign Keys=true");
+        _connection.Open();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        if (File.Exists(_dbPath)) File.Delete(_dbPath);
+    }
+
+    private DbContextOptions<AppDbContext> NewOptions() =>
+        new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+    private async Task<(Guid policyId, Guid versionId)> SeedPolicyAndDraftAsync(AppDbContext db)
+    {
+        var policy = new Policy
+        {
+            Id = Guid.NewGuid(),
+            Name = $"override-{Guid.NewGuid():N}".Substring(0, 24),
+            CreatedBySubjectId = "test",
+        };
+        var version = new PolicyVersion
+        {
+            Id = Guid.NewGuid(),
+            PolicyId = policy.Id,
+            Version = 1,
+            State = LifecycleState.Active,
+            Enforcement = EnforcementLevel.Should,
+            Severity = Severity.Moderate,
+            Scopes = new List<string>(),
+            Summary = "fixture",
+            RulesJson = "{}",
+            CreatedBySubjectId = "test",
+            ProposerSubjectId = "test",
+            PublishedAt = DateTimeOffset.UtcNow,
+            PublishedBySubjectId = "test",
+        };
+        db.Policies.Add(policy);
+        db.PolicyVersions.Add(version);
+        await db.SaveChangesAsync();
+        return (policy.Id, version.Id);
+    }
+
+    [Fact]
+    public async Task Migration_CreatesOverridesTable_WithExpectedIndexes()
+    {
+        await using var db = new AppDbContext(NewOptions());
+        await db.Database.MigrateAsync();
+
+        var indexes = await db.Database.SqlQueryRaw<string>(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='overrides'")
+            .ToListAsync();
+
+        indexes.Should().Contain(new[]
+        {
+            "ix_overrides_scope_state",
+            "ix_overrides_expiry_approved",
+        });
+    }
+
+    [Fact]
+    public async Task Insert_ExemptOverride_WithNoReplacement_RoundTripsAllFields()
+    {
+        await using var db = new AppDbContext(NewOptions());
+        await db.Database.MigrateAsync();
+        var (_, versionId) = await SeedPolicyAndDraftAsync(db);
+
+        var ovr = new Override
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = versionId,
+            ScopeKind = OverrideScopeKind.Principal,
+            ScopeRef = "user:42",
+            Effect = OverrideEffect.Exempt,
+            ProposerSubjectId = "alice",
+            Rationale = "experimentation",
+            ProposedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(7),
+            State = OverrideState.Proposed,
+        };
+        db.Overrides.Add(ovr);
+        await db.SaveChangesAsync();
+
+        var reloaded = await db.Overrides.AsNoTracking().FirstAsync(o => o.Id == ovr.Id);
+        reloaded.PolicyVersionId.Should().Be(versionId);
+        reloaded.ScopeKind.Should().Be(OverrideScopeKind.Principal);
+        reloaded.ScopeRef.Should().Be("user:42");
+        reloaded.Effect.Should().Be(OverrideEffect.Exempt);
+        reloaded.ReplacementPolicyVersionId.Should().BeNull();
+        reloaded.State.Should().Be(OverrideState.Proposed);
+    }
+
+    [Fact]
+    public async Task Insert_ReplaceOverride_WithReplacement_RoundTripsAllFields()
+    {
+        await using var db = new AppDbContext(NewOptions());
+        await db.Database.MigrateAsync();
+        var (_, originalVersionId) = await SeedPolicyAndDraftAsync(db);
+        var (_, replacementVersionId) = await SeedPolicyAndDraftAsync(db);
+
+        var ovr = new Override
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = originalVersionId,
+            ScopeKind = OverrideScopeKind.Cohort,
+            ScopeRef = "cohort:beta",
+            Effect = OverrideEffect.Replace,
+            ReplacementPolicyVersionId = replacementVersionId,
+            ProposerSubjectId = "alice",
+            Rationale = "swap to canary",
+            ProposedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(7),
+            State = OverrideState.Proposed,
+        };
+        db.Overrides.Add(ovr);
+        await db.SaveChangesAsync();
+
+        var reloaded = await db.Overrides.AsNoTracking().FirstAsync(o => o.Id == ovr.Id);
+        reloaded.Effect.Should().Be(OverrideEffect.Replace);
+        reloaded.ReplacementPolicyVersionId.Should().Be(replacementVersionId);
+    }
+
+    [Fact]
+    public async Task Insert_ReplaceOverride_WithoutReplacement_ViolatesCheckConstraint()
+    {
+        await using var db = new AppDbContext(NewOptions());
+        await db.Database.MigrateAsync();
+        var (_, versionId) = await SeedPolicyAndDraftAsync(db);
+
+        db.Overrides.Add(new Override
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = versionId,
+            ScopeKind = OverrideScopeKind.Principal,
+            ScopeRef = "user:42",
+            Effect = OverrideEffect.Replace,   // Replace requires non-null replacement
+            ReplacementPolicyVersionId = null,
+            ProposerSubjectId = "alice",
+            Rationale = "bad",
+            ProposedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(7),
+            State = OverrideState.Proposed,
+        });
+
+        var act = async () => await db.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    [Fact]
+    public async Task Insert_ExemptOverride_WithReplacement_ViolatesCheckConstraint()
+    {
+        await using var db = new AppDbContext(NewOptions());
+        await db.Database.MigrateAsync();
+        var (_, originalVersionId) = await SeedPolicyAndDraftAsync(db);
+        var (_, replacementVersionId) = await SeedPolicyAndDraftAsync(db);
+
+        db.Overrides.Add(new Override
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = originalVersionId,
+            ScopeKind = OverrideScopeKind.Principal,
+            ScopeRef = "user:42",
+            Effect = OverrideEffect.Exempt,    // Exempt requires null replacement
+            ReplacementPolicyVersionId = replacementVersionId,
+            ProposerSubjectId = "alice",
+            Rationale = "bad",
+            ProposedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(7),
+            State = OverrideState.Proposed,
+        });
+
+        var act = async () => await db.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    [Fact]
+    public async Task Insert_OverrideWithUnknownPolicyVersionId_ThrowsDbUpdateException()
+    {
+        await using var db = new AppDbContext(NewOptions());
+        await db.Database.MigrateAsync();
+
+        db.Overrides.Add(new Override
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = Guid.NewGuid(),  // never seeded
+            ScopeKind = OverrideScopeKind.Principal,
+            ScopeRef = "user:42",
+            Effect = OverrideEffect.Exempt,
+            ProposerSubjectId = "alice",
+            Rationale = "orphan",
+            ProposedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(7),
+            State = OverrideState.Proposed,
+        });
+
+        var act = async () => await db.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    [Fact]
+    public async Task Insert_OverrideWithUnknownReplacementVersionId_ThrowsDbUpdateException()
+    {
+        await using var db = new AppDbContext(NewOptions());
+        await db.Database.MigrateAsync();
+        var (_, versionId) = await SeedPolicyAndDraftAsync(db);
+
+        db.Overrides.Add(new Override
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = versionId,
+            ScopeKind = OverrideScopeKind.Principal,
+            ScopeRef = "user:42",
+            Effect = OverrideEffect.Replace,
+            ReplacementPolicyVersionId = Guid.NewGuid(),  // never seeded
+            ProposerSubjectId = "alice",
+            Rationale = "orphan-replacement",
+            ProposedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(7),
+            State = OverrideState.Proposed,
+        });
+
+        var act = async () => await db.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    [Fact]
+    public async Task Update_BumpsRevisionToken_ForOptimisticConcurrency()
+    {
+        await using var db = new AppDbContext(NewOptions());
+        await db.Database.MigrateAsync();
+        var (_, versionId) = await SeedPolicyAndDraftAsync(db);
+
+        var ovr = new Override
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = versionId,
+            ScopeKind = OverrideScopeKind.Principal,
+            ScopeRef = "user:revision",
+            Effect = OverrideEffect.Exempt,
+            ProposerSubjectId = "alice",
+            Rationale = "bump",
+            ProposedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(7),
+            State = OverrideState.Proposed,
+        };
+        db.Overrides.Add(ovr);
+        await db.SaveChangesAsync();
+
+        ovr.Rationale = "bump 2";
+        await db.SaveChangesAsync();
+
+        ovr.Revision.Should().BeGreaterThan(0,
+            "BumpRevisions wires Override into the same revision-token cycle as PolicyVersion");
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Domain/OverrideEntityTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Domain/OverrideEntityTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Domain;
+
+/// <summary>
+/// P5.1 (#49) acceptance for the <see cref="Override"/> entity.
+/// Locks down the default-field initialisers, the persisted-string
+/// stability of the three enums (existing rows on disk depend on
+/// the textual form for the partial index), and the optional-replacement
+/// shape that distinguishes Exempt from Replace.
+/// </summary>
+public class OverrideEntityTests
+{
+    [Fact]
+    public void New_Override_HasNonEmptyId()
+    {
+        var ovr = new Override();
+
+        ovr.Id.Should().NotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public void New_Override_DefaultsStateToProposed()
+    {
+        var ovr = new Override();
+
+        ovr.State.Should().Be(OverrideState.Proposed);
+    }
+
+    [Fact]
+    public void New_Override_HasUtcProposedAt()
+    {
+        var before = DateTimeOffset.UtcNow.AddSeconds(-1);
+        var ovr = new Override();
+        var after = DateTimeOffset.UtcNow.AddSeconds(1);
+
+        ovr.ProposedAt.Should().BeOnOrAfter(before).And.BeOnOrBefore(after);
+        ovr.ProposedAt.Offset.Should().Be(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void New_Override_HasNullApproverAndRevocationFields()
+    {
+        var ovr = new Override();
+
+        ovr.ApproverSubjectId.Should().BeNull();
+        ovr.ApprovedAt.Should().BeNull();
+        ovr.RevocationReason.Should().BeNull();
+        ovr.ReplacementPolicyVersionId.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(OverrideScopeKind.Principal, "Principal")]
+    [InlineData(OverrideScopeKind.Cohort, "Cohort")]
+    public void OverrideScopeKind_HasExpectedToStringForm(OverrideScopeKind value, string expected)
+    {
+        // EF persists via HasConversion<string>(); the string form is
+        // load-bearing on disk for the composite index lookup.
+        value.ToString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(OverrideEffect.Exempt, "Exempt")]
+    [InlineData(OverrideEffect.Replace, "Replace")]
+    public void OverrideEffect_HasExpectedToStringForm(OverrideEffect value, string expected)
+    {
+        value.ToString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(OverrideState.Proposed, "Proposed")]
+    [InlineData(OverrideState.Approved, "Approved")]
+    [InlineData(OverrideState.Revoked, "Revoked")]
+    [InlineData(OverrideState.Expired, "Expired")]
+    public void OverrideState_HasExpectedToStringForm(OverrideState value, string expected)
+    {
+        // Critical: the partial index "ix_overrides_expiry_approved"
+        // filters on "State" = 'Approved' — a rename of this enum
+        // member would silently invalidate the index without changing
+        // any test that doesn't pin the string form.
+        value.ToString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(OverrideScopeKind.Principal, 0)]
+    [InlineData(OverrideScopeKind.Cohort, 1)]
+    public void OverrideScopeKind_HasStableOrdinalDefinition(OverrideScopeKind value, int expected)
+    {
+        // The ordinal is documentary (HasConversion<string>() means the
+        // int value isn't persisted), but renaming or reordering would
+        // break references in downstream consumers that bind to
+        // `OverrideScopeKind.Principal` by name.
+        ((int)value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(OverrideEffect.Exempt, 0)]
+    [InlineData(OverrideEffect.Replace, 1)]
+    public void OverrideEffect_HasStableOrdinalDefinition(OverrideEffect value, int expected)
+    {
+        ((int)value).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Summary

Lays down the per-principal / per-cohort policy override entity that becomes the only escape hatch from stricter-tightens-only resolution (P4.4). Approval workflow + reaper land in P5.2 / P5.3; this story ships the schema + state-machine columns + indexes.

**Domain:**
- `OverrideScopeKind` enum (`Principal=0`, `Cohort=1`).
- `OverrideEffect` enum (`Exempt=0`, `Replace=1`).
- `OverrideState` enum (`Proposed=0`, `Approved=1`, `Revoked=2`, `Expired=3`).
- `Override` entity: `Id`, `PolicyVersionId` (FK Restrict), `ScopeKind`, `ScopeRef`, `Effect`, `ReplacementPolicyVersionId` (nullable, FK Restrict to a different `PolicyVersion`), `ProposerSubjectId`, `ApproverSubjectId` (nullable), `State`, `ProposedAt`, `ApprovedAt` (nullable), `ExpiresAt`, `Rationale`, `RevocationReason` (nullable), `Revision` uint concurrency token.

All three enums use `HasConversion<string>()` so the partial index `ix_overrides_expiry_approved` can filter on `"State" = 'Approved'` directly without an int-to-string cast.

**Infrastructure:**
- `DbSet<Override>` on `AppDbContext`.
- `OnModelCreating` registers the table, two FKs (both `Restrict`), two indexes, and a CHECK constraint:
  - `ix_overrides_scope_state` — composite on `(ScopeKind, ScopeRef, State)` for the hot read path (P4 resolution + P5 service queries).
  - `ix_overrides_expiry_approved` — **partial** index over Approved-only rows by `ExpiresAt`; the reaper (P5.3) sweeps via this index.
  - `ck_overrides_effect_replacement` — `Replace` iff `ReplacementPolicyVersionId` non-null; `Exempt` iff null.
- `BumpRevisions` extended to bump `Override.Revision` on every modification (matches the `PolicyVersion` concurrency-token cycle established in ADR 0001).
- `AddOverrides` EF migration (PostgreSQL + SQLite).

Surfaces (REST / MCP / gRPC / CLI) and the override lookup in the resolver land in P5.2-P5.7.

Closes #49.

## Test plan
- [x] `dotnet test` — 289 unit + 300 integration pass; 6 E2E skipped.
- [x] `OverrideEntityTests` (10 unit): default-field initialisers, state defaults to Proposed, UTC `ProposedAt`, null approver/revocation fields, enum `ToString` stability (load-bearing for the partial index), enum ordinal stability.
- [x] `OverrideMigrationTests` (8 integration): migration applies on SQLite, two indexes physically present, Exempt/Replace round-trip, Replace-without-replacement violates the CHECK constraint, Exempt-with-replacement violates the CHECK constraint, FK Restrict on `PolicyVersionId`, FK Restrict on `ReplacementPolicyVersionId`, Revision token bumps on update.
- [x] `SqliteMigrationTests` extended to assert the `overrides` table + `AddOverrides` migration apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)