### PR TITLE
Implement P5.4 — IExperimentalOverridesGate + OverrideWriteGate filter (#56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Governance policy catalog for the Andy ecosystem. A versioned registry of struct
 - **Versioned policy documents** — structured envelope with immutable published versions.
 - **Lifecycle states** — `draft` / `active` / `winding-down` / `retired`.
 - **Bindings as metadata** — policy ↔ story template / repo / scope as structured data; no evaluation.
-- **Experimental scopes** — per-principal or per-cohort overrides with approver + expiry; a periodic reaper transitions approved overrides past their `expiresAt` into the `Expired` state automatically (P5.3, [#53](https://github.com/rivoli-ai/andy-policies/issues/53)).
+- **Experimental scopes** — per-principal or per-cohort overrides with approver + expiry; a periodic reaper transitions approved overrides past their `expiresAt` into the `Expired` state automatically (P5.3, [#53](https://github.com/rivoli-ai/andy-policies/issues/53)). Write operations (propose / approve / revoke) are gated behind the andy-settings toggle `andy.policies.experimentalOverridesEnabled` (default `false`); reads remain available regardless so the resolution algorithm keeps working when the toggle is off (P5.4, [#56](https://github.com/rivoli-ai/andy-policies/issues/56)).
 - **Edit RBAC** — who may author, who must approve a publish. Subject→permission checks delegate to [Andy RBAC](https://github.com/rivoli-ai/andy-rbac); the edit matrix itself lives here.
 - **Catalog change audit** — every edit, publish, transition, binding, and override recorded with actor, timestamp, structured field-level diff, required rationale, and tamper-evident chain. Reads are not audited.
 - **Bundle pinning** — consumers pin a bundle version for reproducibility.

--- a/src/Andy.Policies.Api/Filters/OverrideWriteGateAttribute.cs
+++ b/src/Andy.Policies.Api/Filters/OverrideWriteGateAttribute.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Settings;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Andy.Policies.Api.Filters;
+
+/// <summary>
+/// Action filter that rejects override <i>write</i> endpoints
+/// (propose, approve, revoke) with HTTP 403 when
+/// <see cref="IExperimentalOverridesGate.IsEnabled"/> is <c>false</c>
+/// (P5.4, story rivoli-ai/andy-policies#56). Stamps a structured
+/// ProblemDetails body with <c>errorCode = "override.disabled"</c>
+/// so clients can branch on the stable string.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Reads remain available</b> regardless of the gate — the filter
+/// is applied per-action rather than per-controller, so
+/// <c>POST /api/overrides</c>, <c>POST /api/overrides/{id}/approve</c>,
+/// and <c>POST /api/overrides/{id}/revoke</c> opt-in by stamping
+/// <c>[OverrideWriteGate]</c>; <c>GET</c> endpoints leave it off.
+/// </para>
+/// <para>
+/// <b>Surface parity:</b> MCP and gRPC apply the same gate at their
+/// own surface entrypoints (P5.6 / P5.7), each translating to the
+/// surface's equivalent of HTTP 403. The shared error code
+/// <c>override.disabled</c> is the contract.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false)]
+public sealed class OverrideWriteGateAttribute : Attribute, IAsyncActionFilter
+{
+    /// <summary>Stable error code surfaced in the ProblemDetails
+    /// extensions and matched by the equivalent MCP/gRPC error
+    /// envelopes.</summary>
+    public const string ErrorCode = "override.disabled";
+
+    public Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(next);
+
+        var gate = context.HttpContext.RequestServices
+            .GetRequiredService<IExperimentalOverridesGate>();
+
+        if (!gate.IsEnabled)
+        {
+            var problem = new ProblemDetails
+            {
+                Status = StatusCodes.Status403Forbidden,
+                Title = "Experimental overrides disabled",
+                Detail =
+                    "Override writes are disabled. Enable " +
+                    ExperimentalOverridesGateMetadata.SettingKey +
+                    " in andy-settings to proceed.",
+                Type = "/problems/override-disabled",
+                Instance = context.HttpContext.Request.Path,
+                Extensions = { [nameof(ErrorCode)] = ErrorCode },
+            };
+            // Standard "errorCode" key — matches the typed-error
+            // posture used elsewhere (PolicyExceptionHandler stamps it
+            // verbatim, the Cockpit Angular client branches on it).
+            problem.Extensions["errorCode"] = ErrorCode;
+            context.Result = new ObjectResult(problem)
+            {
+                StatusCode = StatusCodes.Status403Forbidden,
+            };
+            return Task.CompletedTask;
+        }
+
+        return next();
+    }
+}
+
+/// <summary>
+/// Mirror of the andy-settings key string used by the
+/// <c>ExperimentalOverridesGate</c> implementation, kept in the Api
+/// layer so the filter doesn't take a project reference on
+/// Infrastructure (the inversion would break the Clean Architecture
+/// dependency direction).
+/// </summary>
+internal static class ExperimentalOverridesGateMetadata
+{
+    public const string SettingKey = "andy.policies.experimentalOverridesEnabled";
+}

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -127,6 +127,12 @@ builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IRbacChecker, An
 // approved overrides past expiry. Cadence reads live from
 // andy-settings (key andy.policies.overrideExpiryReaperCadenceSeconds).
 builder.Services.AddHostedService<Andy.Policies.Infrastructure.BackgroundServices.OverrideExpiryReaper>();
+// P5.4 (#56): runtime gate over andy.policies.experimentalOverridesEnabled.
+// Singleton because the impl owns the OTel gauge meter; the underlying
+// ISettingsSnapshot is also a singleton. Surface filters (P5.5+) read
+// IExperimentalOverridesGate.IsEnabled per-request and translate "off"
+// to the surface's equivalent of HTTP 403.
+builder.Services.AddSingleton<Andy.Policies.Application.Settings.IExperimentalOverridesGate, Andy.Policies.Infrastructure.Settings.ExperimentalOverridesGate>();
 // P2.4 (#14): the rationale policy reads andy.policies.rationaleRequired from
 // the andy-settings snapshot on every check (fail-safe to required=true if the
 // snapshot has not yet observed the key). Registered as a singleton because it
@@ -159,7 +165,8 @@ builder.Services.AddOpenTelemetry()
                .AddHttpClientInstrumentation()
                .AddRuntimeInstrumentation()
                .AddMeter(Andy.Policies.Infrastructure.Services.AndySettingsRationalePolicy.MeterName)
-               .AddMeter(Andy.Policies.Infrastructure.BackgroundServices.OverrideExpiryReaper.MeterName);
+               .AddMeter(Andy.Policies.Infrastructure.BackgroundServices.OverrideExpiryReaper.MeterName)
+               .AddMeter(Andy.Policies.Infrastructure.Settings.ExperimentalOverridesGate.MeterName);
         if (!string.IsNullOrEmpty(otlpEndpoint))
             metrics.AddOtlpExporter(o => o.Endpoint = new Uri(otlpEndpoint));
     });

--- a/src/Andy.Policies.Application/Settings/IExperimentalOverridesGate.cs
+++ b/src/Andy.Policies.Application/Settings/IExperimentalOverridesGate.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.Settings;
+
+/// <summary>
+/// Runtime gate over <c>andy.policies.experimentalOverridesEnabled</c>
+/// (P5.4, story rivoli-ai/andy-policies#56). When the toggle is
+/// <c>false</c>, override <i>writes</i> (propose, approve, revoke)
+/// must be rejected at the surface layer with HTTP 403 / gRPC
+/// <c>PERMISSION_DENIED</c> / MCP error envelope <c>override.disabled</c>;
+/// reads remain available so consumers can still see existing
+/// approved overrides and the resolution algorithm (P4.3) keeps
+/// working.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Fail-closed:</b> when the underlying settings snapshot has not
+/// observed the key yet (cold start, andy-settings briefly
+/// unreachable), <see cref="IsEnabled"/> returns <c>false</c>. This
+/// matches the registered default of <c>false</c> and keeps the
+/// blast radius of an outage at the safer state.
+/// </para>
+/// <para>
+/// <b>Why a gate primitive rather than gating inside
+/// <c>OverrideService</c>?</b> The reaper (P5.3) reuses the same
+/// service to drive expiry. Gating at the service layer would force
+/// the reaper to bypass the gate, complicating the contract. Gating
+/// at the surface layer keeps the service gate-agnostic — the
+/// reaper, MCP, REST, and gRPC each apply the gate where it makes
+/// sense for their layer.
+/// </para>
+/// </remarks>
+public interface IExperimentalOverridesGate
+{
+    /// <summary>
+    /// <c>true</c> when override writes are currently allowed;
+    /// <c>false</c> when they should be rejected with the surface's
+    /// equivalent of HTTP 403.
+    /// </summary>
+    bool IsEnabled { get; }
+}

--- a/src/Andy.Policies.Infrastructure/Settings/ExperimentalOverridesGate.cs
+++ b/src/Andy.Policies.Infrastructure/Settings/ExperimentalOverridesGate.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Diagnostics.Metrics;
+using Andy.Policies.Application.Settings;
+using Andy.Settings.Client;
+
+namespace Andy.Policies.Infrastructure.Settings;
+
+/// <summary>
+/// Live <see cref="IExperimentalOverridesGate"/> backed by andy-settings
+/// (P5.4, rivoli-ai/andy-policies#56). Mirrors the
+/// <c>AndySettingsRationalePolicy</c> shape: read fresh from
+/// <see cref="ISettingsSnapshot"/> on every check, with an OTel gauge
+/// so operators can confirm the toggle reached the live process.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Fail-closed default:</b> if the snapshot has not yet observed the
+/// key (cold start, or andy-settings briefly unreachable),
+/// <see cref="IsEnabled"/> returns <c>false</c>. The setting is a
+/// feature flag; <c>false</c> is both the shipped default and the
+/// safer state when in doubt — turning experimental writes off can't
+/// break correctness, while the wrong default of <c>true</c> would.
+/// </para>
+/// <para>
+/// <b>Hot reload:</b> the snapshot is refreshed by andy-settings'
+/// hosted <c>SettingsRefreshService</c> on the configured cadence
+/// (default 60s). A flip in the andy-settings admin UI takes effect
+/// on the next override write after the next refresh, without an
+/// andy-policies restart.
+/// </para>
+/// </remarks>
+public sealed class ExperimentalOverridesGate : IExperimentalOverridesGate, IDisposable
+{
+    /// <summary>The andy-settings key, registered in
+    /// <c>config/registration.json</c> with default <c>false</c>.</summary>
+    public const string SettingKey = "andy.policies.experimentalOverridesEnabled";
+
+    /// <summary>OpenTelemetry meter name. <c>Program.cs</c> adds this
+    /// meter to the metrics pipeline so the toggle value is exported
+    /// to OTLP for operator visibility.</summary>
+    public const string MeterName = "Andy.Policies.ExperimentalOverridesGate";
+
+    private readonly ISettingsSnapshot _snapshot;
+    private readonly Meter _meter;
+
+    public ExperimentalOverridesGate(ISettingsSnapshot snapshot)
+    {
+        _snapshot = snapshot;
+        _meter = new Meter(MeterName);
+        _meter.CreateObservableGauge(
+            name: "andy_policies_experimental_overrides_enabled",
+            observeValue: () => IsEnabled ? 1 : 0,
+            description: "Current value of andy.policies.experimentalOverridesEnabled (1 = on, 0 = off).");
+    }
+
+    public bool IsEnabled => _snapshot.GetBool(SettingKey) ?? false;
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/tests/Andy.Policies.Tests.Integration/Filters/OverrideWriteGateAttributeTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Filters/OverrideWriteGateAttributeTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Api.Filters;
+using Andy.Policies.Application.Settings;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Filters;
+
+/// <summary>
+/// P5.4 (#56) — exercises <see cref="OverrideWriteGateAttribute"/>'s
+/// short-circuit behaviour with a constructed
+/// <see cref="ActionExecutingContext"/>. Lives in the Integration
+/// suite because the Tests.Unit project doesn't pull in
+/// Microsoft.AspNetCore.Mvc types.
+/// </summary>
+public class OverrideWriteGateAttributeTests
+{
+    private sealed class StubGate : IExperimentalOverridesGate
+    {
+        public bool IsEnabled { get; set; }
+    }
+
+    private static (ActionExecutingContext context, StubGate gate, NextDelegateProbe probe) NewContext(bool isEnabled)
+    {
+        var gate = new StubGate { IsEnabled = isEnabled };
+        var services = new ServiceCollection();
+        services.AddSingleton<IExperimentalOverridesGate>(gate);
+        var sp = services.BuildServiceProvider();
+
+        var http = new DefaultHttpContext { RequestServices = sp };
+        http.Request.Path = "/api/overrides";
+
+        var actionContext = new ActionContext(
+            http,
+            new RouteData(),
+            new ActionDescriptor());
+        var execContext = new ActionExecutingContext(
+            actionContext,
+            filters: new List<IFilterMetadata>(),
+            actionArguments: new Dictionary<string, object?>(),
+            controller: new object());
+        var probe = new NextDelegateProbe();
+        return (execContext, gate, probe);
+    }
+
+    [Fact]
+    public async Task OnActionExecutionAsync_GateEnabled_CallsNextOnce()
+    {
+        var attr = new OverrideWriteGateAttribute();
+        var (ctx, _, probe) = NewContext(isEnabled: true);
+
+        await attr.OnActionExecutionAsync(ctx, probe.Next);
+
+        probe.CallCount.Should().Be(1);
+        ctx.Result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task OnActionExecutionAsync_GateDisabled_ShortCircuitsWith403AndProblemDetails()
+    {
+        var attr = new OverrideWriteGateAttribute();
+        var (ctx, _, probe) = NewContext(isEnabled: false);
+
+        await attr.OnActionExecutionAsync(ctx, probe.Next);
+
+        probe.CallCount.Should().Be(0);
+        var result = ctx.Result.Should().BeOfType<ObjectResult>().Subject;
+        result.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        var problem = result.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problem.Status.Should().Be(StatusCodes.Status403Forbidden);
+        problem.Type.Should().Be("/problems/override-disabled");
+        problem.Extensions.Should().ContainKey("errorCode")
+            .WhoseValue.Should().Be(OverrideWriteGateAttribute.ErrorCode);
+    }
+
+    [Fact]
+    public void ErrorCode_IsStableContractString()
+    {
+        // Surface parity (P5.5–P5.7): MCP and gRPC return the same
+        // string in their error envelopes. Pin the constant so a
+        // rename is a deliberate cross-surface contract change.
+        OverrideWriteGateAttribute.ErrorCode.Should().Be("override.disabled");
+    }
+
+    private sealed class NextDelegateProbe
+    {
+        public int CallCount { get; private set; }
+
+        public Task<ActionExecutedContext> Next()
+        {
+            CallCount++;
+            // The filter doesn't inspect the returned ActionExecutedContext;
+            // returning a placeholder keeps the contract simple.
+            var http = new DefaultHttpContext();
+            var actionContext = new ActionContext(http, new RouteData(), new ActionDescriptor());
+            return Task.FromResult(new ActionExecutedContext(
+                actionContext, new List<IFilterMetadata>(), controller: new object()));
+        }
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Settings/ExperimentalOverridesGateTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Settings/ExperimentalOverridesGateTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Infrastructure.Settings;
+using Andy.Settings.Client;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Settings;
+
+/// <summary>
+/// Unit coverage for <see cref="ExperimentalOverridesGate"/> (P5.4,
+/// rivoli-ai/andy-policies#56). Drives the gate with a stub
+/// <see cref="ISettingsSnapshot"/> so each toggle state — on, off,
+/// unobserved — is tested without standing up the andy-settings
+/// client. Asserts the fail-closed default (unobserved → false) is
+/// what the production code path returns.
+/// </summary>
+public class ExperimentalOverridesGateTests
+{
+    private sealed class StubSnapshot : ISettingsSnapshot
+    {
+        public bool? Value { get; set; }
+
+        public bool? GetBool(string key) =>
+            key == ExperimentalOverridesGate.SettingKey ? Value : null;
+
+        public string? GetString(string key) => null;
+
+        public int? GetInt(string key) => null;
+
+        public IReadOnlyCollection<string> Keys => Array.Empty<string>();
+
+        public DateTimeOffset? LastRefreshedAt => null;
+    }
+
+    [Fact]
+    public void IsEnabled_True_WhenSnapshotReportsTrue()
+    {
+        var snapshot = new StubSnapshot { Value = true };
+        var gate = new ExperimentalOverridesGate(snapshot);
+
+        gate.IsEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsEnabled_False_WhenSnapshotReportsFalse()
+    {
+        var snapshot = new StubSnapshot { Value = false };
+        var gate = new ExperimentalOverridesGate(snapshot);
+
+        gate.IsEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsEnabled_FailsClosed_WhenSnapshotHasNotObservedKey()
+    {
+        // Cold start, or andy-settings briefly unreachable: the
+        // snapshot returns null for the key. The shipped default and
+        // the safer state both want this path to read false.
+        var snapshot = new StubSnapshot { Value = null };
+        var gate = new ExperimentalOverridesGate(snapshot);
+
+        gate.IsEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsEnabled_TracksLiveSnapshotChanges()
+    {
+        // Hot reload via andy-settings refresh: the snapshot value
+        // flips while the gate instance is alive. The next read picks
+        // up the new value without an andy-policies restart.
+        var snapshot = new StubSnapshot { Value = false };
+        var gate = new ExperimentalOverridesGate(snapshot);
+        gate.IsEnabled.Should().BeFalse();
+
+        snapshot.Value = true;
+        gate.IsEnabled.Should().BeTrue();
+
+        snapshot.Value = false;
+        gate.IsEnabled.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Runtime gate over `andy.policies.experimentalOverridesEnabled` (default `false`) for override **writes only**. Reads (`GET`) remain available regardless of the toggle so the P4.3 resolution algorithm keeps working when overrides are turned off.
- The reaper (P5.3) intentionally bypasses the gate — flipping the toggle off must not strand previously approved overrides past their expiry.
- The shared error code `override.disabled` is the cross-surface contract; MCP and gRPC return the same string in their error envelopes when those surfaces land in P5.5–P5.7.

## Components

- **`IExperimentalOverridesGate`** (Application) — single `bool` contract, fail-closed default.
- **`ExperimentalOverridesGate`** (Infrastructure) — reads `ISettingsSnapshot` on every check; mirrors the `AndySettingsRationalePolicy` shape. OTel observable gauge `andy_policies_experimental_overrides_enabled` exports 1/0 so operators can confirm the toggle reached the live process.
- **`OverrideWriteGateAttribute`** (Api) — `IAsyncActionFilter` that returns HTTP 403 + ProblemDetails (`type=/problems/override-disabled`, `errorCode=override.disabled`) when the gate is off. Opt-in per-action so reads aren't gated incidentally; `POST /api/overrides[/approve|/revoke]` in P5.5 stamps it.

## Coverage

- **4 unit tests** over the gate: on, off, fail-closed when the snapshot has not yet observed the key, hot-reload via live snapshot mutation.
- **3 filter tests** in the integration suite (which has the Api + Mvc references): pass-through when on, 403+ProblemDetails when off, error-code constant pin so a rename is a deliberate cross-surface contract change.
- Full unit (323) + integration (308) suites green locally.

## What lands in later stories

| Story | Wires the gate into |
|---|---|
| P5.5 | REST `POST /api/overrides[/approve|/revoke]` via `[OverrideWriteGate]` |
| P5.6 | MCP `policy.override.propose|approve|revoke` tool body |
| P5.7 | gRPC `OverrideService.Propose|Approve|Revoke` server interceptor |

## Test plan

- [x] `dotnet test tests/Andy.Policies.Tests.Unit` — 323 passed
- [x] `dotnet test tests/Andy.Policies.Tests.Integration` — 308 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)