### PR TITLE
Implement P5.5 — REST OverridesController + ProblemDetails mapping (#58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,36 @@ For the *why* behind each design decision (typed 6-level, materialized
 path, dual write+read enforcement, structural cycle-impossibility),
 see [ADR 0004 — Scope hierarchy + tighten-only resolution](docs/adr/0004-scope-hierarchy.md).
 
+### Override endpoints
+
+REST surface for `Override` propose/approve/revoke + list/get/active
+(P5.5, [#58](https://github.com/rivoli-ai/andy-policies/issues/58)).
+Six endpoints sit on top of `IOverrideService`:
+
+```http
+POST  /api/overrides                                              # propose → 201
+POST  /api/overrides/{id}/approve                                 # approve → 200
+POST  /api/overrides/{id}/revoke                                  # revoke → 200
+GET   /api/overrides?state=&scopeKind=&scopeRef=&policyVersionId= # list
+GET   /api/overrides/{id}                                          # get → 200/404
+GET   /api/overrides/active?scopeKind=&scopeRef=                   # effective set
+```
+
+The three writes carry `[OverrideWriteGate]` (P5.4, [#56](https://github.com/rivoli-ai/andy-policies/issues/56))
+— when `andy.policies.experimentalOverridesEnabled` is `false` they
+return 403 with `errorCode: override.disabled`. Reads bypass the gate
+so the resolution algorithm (P4.3) keeps working when the toggle is
+off. `GET /api/overrides/active` returns only rows where
+`State == Approved` AND `ExpiresAt > now`; expired rows are excluded
+even before the next reaper tick.
+
+Approve-by-proposer returns 403 with `errorCode: override.self_approval_forbidden`
+(distinct from a generic 403 so MCP/gRPC/CLI can mirror the same
+contract). Revoke requires a non-empty `RevocationReason`. The reaper
+(P5.3, [#53](https://github.com/rivoli-ai/andy-policies/issues/53))
+is the only path into the `Expired` state — explicit revocation goes
+to `Revoked`.
+
 ## Ports
 
 Per the ecosystem registry at [`../andy-service-template/docs/ports.md`](../andy-service-template/docs/ports.md). Three deployment modes; the same host can run any combination because each mode uses a distinct port range.

--- a/docs/openapi/andy-policies-v1.yaml
+++ b/docs/openapi/andy-policies-v1.yaml
@@ -386,6 +386,273 @@ paths:
       responses:
         '200':
           description: OK
+  /api/overrides:
+    post:
+      tags:
+        - Overrides
+      summary: "Propose a new override. Inserts in `Proposed` state; the\r\napprover (a different subject) drives the next transition via\r\n`POST /api/overrides/{id}/approve`."
+      operationId: Overrides_Propose
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProposeOverrideRequest'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/ProposeOverrideRequest'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/ProposeOverrideRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OverrideDto'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+    get:
+      tags:
+        - Overrides
+      summary: "List overrides matching the optional filter. Returns rows in\r\nany state; use `state=Approved` for the live set or\r\n`GET /api/overrides/active` for the\r\nscope-narrowed-and-non-expired projection."
+      operationId: Overrides_List
+      parameters:
+        - name: state
+          in: query
+          schema:
+            $ref: '#/components/schemas/OverrideState'
+        - name: scopeKind
+          in: query
+          schema:
+            $ref: '#/components/schemas/OverrideScopeKind'
+        - name: scopeRef
+          in: query
+          schema:
+            type: string
+        - name: policyVersionId
+          in: query
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/OverrideDto'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+  '/api/overrides/{id}/approve':
+    post:
+      tags:
+        - Overrides
+      summary: "Approve a `Proposed` override. Returns 403 with errorCode\r\n`override.self_approval_forbidden` when the approver is\r\nalso the proposer; 409 if the row is already past\r\n`Proposed`."
+      operationId: Overrides_Approve
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OverrideDto'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+  '/api/overrides/{id}/revoke':
+    post:
+      tags:
+        - Overrides
+      summary: "Revoke a `Proposed` or `Approved` override. Requires\r\na non-empty `RevocationReason`; the reaper-driven\r\n`Expired` path goes through P5.3 instead."
+      operationId: Overrides_Revoke
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RevokeOverrideRequest'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/RevokeOverrideRequest'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/RevokeOverrideRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OverrideDto'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+  '/api/overrides/{id}':
+    get:
+      tags:
+        - Overrides
+      summary: "Fetch a single override by id. Returns 404 if the row does not\r\nexist; visibility is not state-gated (an Expired or Revoked\r\nrow is still readable for audit)."
+      operationId: Overrides_Get
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OverrideDto'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+  /api/overrides/active:
+    get:
+      tags:
+        - Overrides
+      summary: "Currently-effective overrides for the given (scopeKind, scopeRef)\r\npair. Returns only rows where `State == Approved` AND\r\n`ExpiresAt > now` — expired rows are excluded even if\r\nthe reaper has not yet ticked. Consumed by P4.3 chain\r\nresolution and by Conductor at admission time."
+      operationId: Overrides_Active
+      parameters:
+        - name: scopeKind
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/OverrideScopeKind'
+        - name: scopeRef
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/OverrideDto'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
   /api/Policies:
     get:
       tags:
@@ -1298,6 +1565,69 @@ components:
           nullable: true
       additionalProperties: false
       description: "Request payload for the lifecycle transition endpoints (P2.3, story\r\nrivoli-ai/andy-policies#13): publish, winding-down, retire. The single\r\n`rationale` field is forwarded to `ILifecycleTransitionService`\r\nwhere `IRationalePolicy` validates it against the\r\n`andy.policies.rationaleRequired` setting (P2.4 wires the dynamic\r\ngate; P2.3 ships with the require-non-empty default)."
+    OverrideDto:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        policyVersionId:
+          type: string
+          format: uuid
+        scopeKind:
+          $ref: '#/components/schemas/OverrideScopeKind'
+        scopeRef:
+          type: string
+          nullable: true
+        effect:
+          $ref: '#/components/schemas/OverrideEffect'
+        replacementPolicyVersionId:
+          type: string
+          format: uuid
+          nullable: true
+        proposerSubjectId:
+          type: string
+          nullable: true
+        approverSubjectId:
+          type: string
+          nullable: true
+        state:
+          $ref: '#/components/schemas/OverrideState'
+        proposedAt:
+          type: string
+          format: date-time
+        approvedAt:
+          type: string
+          format: date-time
+          nullable: true
+        expiresAt:
+          type: string
+          format: date-time
+        rationale:
+          type: string
+          nullable: true
+        revocationReason:
+          type: string
+          nullable: true
+      additionalProperties: false
+      description: "Wire-format projection of an `Override` (P5.2, story\r\nrivoli-ai/andy-policies#52). Surface controllers (REST P5.5,\r\nMCP/gRPC/CLI in P5.6 / P5.7) emit this shape directly so wire\r\nbehaviour stays uniform across surfaces."
+    OverrideEffect:
+      enum:
+        - Exempt
+        - Replace
+      type: string
+    OverrideScopeKind:
+      enum:
+        - Principal
+        - Cohort
+      type: string
+    OverrideState:
+      enum:
+        - Proposed
+        - Approved
+        - Revoked
+        - Expired
+      type: string
     PolicyDto:
       type: object
       properties:
@@ -1401,6 +1731,31 @@ components:
           type: string
           nullable: true
       additionalProperties: { }
+    ProposeOverrideRequest:
+      type: object
+      properties:
+        policyVersionId:
+          type: string
+          format: uuid
+        scopeKind:
+          $ref: '#/components/schemas/OverrideScopeKind'
+        scopeRef:
+          type: string
+          nullable: true
+        effect:
+          $ref: '#/components/schemas/OverrideEffect'
+        replacementPolicyVersionId:
+          type: string
+          format: uuid
+          nullable: true
+        expiresAt:
+          type: string
+          format: date-time
+        rationale:
+          type: string
+          nullable: true
+      additionalProperties: false
+      description: "Request payload for `IOverrideService.ProposeAsync` (P5.2,\r\nstory rivoli-ai/andy-policies#52). The service validates that\r\nAndy.Policies.Application.Dtos.ProposeOverrideRequest.Effect matches the presence of\r\nAndy.Policies.Application.Dtos.ProposeOverrideRequest.ReplacementPolicyVersionId: `Replace` requires\r\nnon-null, `Exempt` requires null. Both\r\nAndy.Policies.Application.Dtos.ProposeOverrideRequest.PolicyVersionId and (if present)\r\nAndy.Policies.Application.Dtos.ProposeOverrideRequest.ReplacementPolicyVersionId must reference an\r\nexisting `PolicyVersion`."
     ResolveBindingsResponse:
       type: object
       properties:
@@ -1463,6 +1818,14 @@ components:
           $ref: '#/components/schemas/BindStrength'
       additionalProperties: false
       description: "A consumer-ready binding projection (P3.4, story\r\nrivoli-ai/andy-policies#22). Joins the live `Binding` row to its\r\ntarget `PolicyVersion` and stable `Policy` identity so a\r\ncaller (Conductor's ActionBus, andy-tasks per-task gates) gets enough\r\ncontext to decide what to do without a second round-trip. Wire-format\r\ncasing follows ADR 0001 §6: `Enforcement` uppercase RFC 2119\r\ntokens, `Severity` lowercase, `VersionState` PascalCase."
+    RevokeOverrideRequest:
+      type: object
+      properties:
+        revocationReason:
+          type: string
+          nullable: true
+      additionalProperties: false
+      description: "Request payload for `IOverrideService.RevokeAsync` (P5.2).\r\nThe reason is required and persisted to\r\n`Override.RevocationReason`; reaper-driven expiry\r\n(`Expired`) leaves the column null."
     ScopeNodeDto:
       type: object
       properties:
@@ -1559,6 +1922,8 @@ tags:
     description: "REST surface for `Binding` mutation, single-id read, and target-side\r\nquery (P3.3, story rivoli-ai/andy-policies#21). Delegates to\r\nAndy.Policies.Application.Interfaces.IBindingService from P3.2 — same service powering MCP\r\n(P3.5), gRPC (P3.6), and CLI (P3.7). Service exceptions are mapped by\r\nthe global `PolicyExceptionHandler` (already covers\r\nAndy.Policies.Application.Exceptions.NotFoundException,\r\nAndy.Policies.Application.Exceptions.ConflictException, and\r\nAndy.Policies.Application.Exceptions.ValidationException; the\r\nAndy.Policies.Application.Exceptions.BindingRetiredVersionException\r\ninherits from Andy.Policies.Application.Exceptions.ConflictException so\r\nthe existing 409 mapping catches it)."
   - name: Help
     description: "Serves help content from markdown files in content/help/.\r\nConsumable by any client: Angular, Swift (Conductor), CLI, MCP."
+  - name: Overrides
+    description: "REST surface for `Override` propose/approve/revoke + list/get\r\n(P5.5, story rivoli-ai/andy-policies#58). Six endpoints sit on top\r\nof Andy.Policies.Application.Interfaces.IOverrideService; the controller is a thin\r\nwire-format adapter and never re-implements the state machine.\r\nService exceptions map via `PolicyExceptionHandler`:\r\nAndy.Policies.Application.Exceptions.ValidationException → 400,\r\nAndy.Policies.Application.Exceptions.NotFoundException → 404,\r\nAndy.Policies.Application.Exceptions.ConflictException → 409,\r\nAndy.Policies.Application.Exceptions.SelfApprovalException → 403\r\n(errorCode `override.self_approval_forbidden`),\r\nAndy.Policies.Application.Exceptions.RbacDeniedException → 403\r\n(errorCode `rbac.denied`)."
   - name: Policies
     description: "REST surface for the policy catalog (P1.5, story rivoli-ai/andy-policies#75).\r\nAll endpoints delegate to Andy.Policies.Application.Interfaces.IPolicyService; service exceptions are\r\nmapped to status codes by `PolicyExceptionHandler` (registered globally)."
   - name: PolicyVersionBindings

--- a/src/Andy.Policies.Api/Controllers/OverridesController.cs
+++ b/src/Andy.Policies.Api/Controllers/OverridesController.cs
@@ -1,0 +1,194 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Claims;
+using Andy.Policies.Api.Filters;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Enums;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Andy.Policies.Api.Controllers;
+
+/// <summary>
+/// REST surface for <c>Override</c> propose/approve/revoke + list/get
+/// (P5.5, story rivoli-ai/andy-policies#58). Six endpoints sit on top
+/// of <see cref="IOverrideService"/>; the controller is a thin
+/// wire-format adapter and never re-implements the state machine.
+/// Service exceptions map via <c>PolicyExceptionHandler</c>:
+/// <see cref="Application.Exceptions.ValidationException"/> → 400,
+/// <see cref="Application.Exceptions.NotFoundException"/> → 404,
+/// <see cref="Application.Exceptions.ConflictException"/> → 409,
+/// <see cref="Application.Exceptions.SelfApprovalException"/> → 403
+/// (errorCode <c>override.self_approval_forbidden</c>),
+/// <see cref="Application.Exceptions.RbacDeniedException"/> → 403
+/// (errorCode <c>rbac.denied</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Settings gate (P5.4):</b> the three write endpoints carry
+/// <see cref="OverrideWriteGateAttribute"/>; reads bypass the gate so
+/// the resolution algorithm can still consult existing approved
+/// overrides when <c>andy.policies.experimentalOverridesEnabled</c>
+/// is off (a security firewall — flipping the toggle off must not
+/// strand consumers that already rely on an override's effect).
+/// </para>
+/// <para>
+/// <b>RBAC (P7.2, #51):</b> per-action authorization (e.g.
+/// <c>andy-policies:override:approve</c>) is enforced inside
+/// <see cref="IOverrideService"/> via <see cref="IRbacChecker"/>.
+/// When the andy-rbac client lands, the same code path picks it up
+/// without changes here. The controller stays at simple
+/// <c>[Authorize]</c>; tightening to per-action policies happens with
+/// P7's policy-handler wiring.
+/// </para>
+/// </remarks>
+[ApiController]
+[Authorize]
+[Route("api/overrides")]
+[Produces("application/json")]
+[Tags("Overrides")]
+public sealed class OverridesController : ControllerBase
+{
+    private readonly IOverrideService _service;
+
+    public OverridesController(IOverrideService service)
+    {
+        _service = service;
+    }
+
+    /// <summary>
+    /// Propose a new override. Inserts in <c>Proposed</c> state; the
+    /// approver (a different subject) drives the next transition via
+    /// <c>POST /api/overrides/{id}/approve</c>.
+    /// </summary>
+    [HttpPost]
+    [OverrideWriteGate]
+    [ProducesResponseType(typeof(OverrideDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<OverrideDto>> Propose(
+        [FromBody] ProposeOverrideRequest request,
+        CancellationToken ct)
+    {
+        var subject = ResolveSubjectId();
+        if (subject is null) return Unauthorized();
+
+        var dto = await _service.ProposeAsync(request, subject, ct);
+        return CreatedAtAction(nameof(Get), new { id = dto.Id }, dto);
+    }
+
+    /// <summary>
+    /// Approve a <c>Proposed</c> override. Returns 403 with errorCode
+    /// <c>override.self_approval_forbidden</c> when the approver is
+    /// also the proposer; 409 if the row is already past
+    /// <c>Proposed</c>.
+    /// </summary>
+    [HttpPost("{id:guid}/approve")]
+    [OverrideWriteGate]
+    [ProducesResponseType(typeof(OverrideDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<OverrideDto>> Approve(Guid id, CancellationToken ct)
+    {
+        var subject = ResolveSubjectId();
+        if (subject is null) return Unauthorized();
+
+        return Ok(await _service.ApproveAsync(id, subject, ct));
+    }
+
+    /// <summary>
+    /// Revoke a <c>Proposed</c> or <c>Approved</c> override. Requires
+    /// a non-empty <c>RevocationReason</c>; the reaper-driven
+    /// <c>Expired</c> path goes through P5.3 instead.
+    /// </summary>
+    [HttpPost("{id:guid}/revoke")]
+    [OverrideWriteGate]
+    [ProducesResponseType(typeof(OverrideDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<OverrideDto>> Revoke(
+        Guid id,
+        [FromBody] RevokeOverrideRequest request,
+        CancellationToken ct)
+    {
+        var subject = ResolveSubjectId();
+        if (subject is null) return Unauthorized();
+
+        return Ok(await _service.RevokeAsync(id, request, subject, ct));
+    }
+
+    /// <summary>
+    /// List overrides matching the optional filter. Returns rows in
+    /// any state; use <c>state=Approved</c> for the live set or
+    /// <c>GET /api/overrides/active</c> for the
+    /// scope-narrowed-and-non-expired projection.
+    /// </summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(IReadOnlyList<OverrideDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<IReadOnlyList<OverrideDto>>> List(
+        [FromQuery] OverrideState? state,
+        [FromQuery] OverrideScopeKind? scopeKind,
+        [FromQuery] string? scopeRef,
+        [FromQuery] Guid? policyVersionId,
+        CancellationToken ct)
+    {
+        var filter = new OverrideListFilter(state, scopeKind, scopeRef, policyVersionId);
+        return Ok(await _service.ListAsync(filter, ct));
+    }
+
+    /// <summary>
+    /// Fetch a single override by id. Returns 404 if the row does not
+    /// exist; visibility is not state-gated (an Expired or Revoked
+    /// row is still readable for audit).
+    /// </summary>
+    [HttpGet("{id:guid}", Name = nameof(Get))]
+    [ProducesResponseType(typeof(OverrideDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<OverrideDto>> Get(Guid id, CancellationToken ct)
+    {
+        var dto = await _service.GetAsync(id, ct);
+        return dto is null ? NotFound() : Ok(dto);
+    }
+
+    /// <summary>
+    /// Currently-effective overrides for the given (scopeKind, scopeRef)
+    /// pair. Returns only rows where <c>State == Approved</c> AND
+    /// <c>ExpiresAt &gt; now</c> — expired rows are excluded even if
+    /// the reaper has not yet ticked. Consumed by P4.3 chain
+    /// resolution and by Conductor at admission time.
+    /// </summary>
+    [HttpGet("active")]
+    [ProducesResponseType(typeof(IReadOnlyList<OverrideDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<IReadOnlyList<OverrideDto>>> Active(
+        [FromQuery, BindRequired] OverrideScopeKind scopeKind,
+        [FromQuery, BindRequired] string scopeRef,
+        CancellationToken ct)
+        => Ok(await _service.GetActiveAsync(scopeKind, scopeRef, ct));
+
+    private string? ResolveSubjectId()
+    {
+        // Same posture as PolicyVersionsLifecycleController (#13): never
+        // write a fallback subject id into the catalog. JwtBearer maps
+        // `sub` to NameIdentifier; TestAuthHandler sets the Name claim.
+        // [Authorize] should already have returned 401 before we get
+        // here — this is the belt to the framework's braces.
+        var subject = User.FindFirstValue(ClaimTypes.NameIdentifier)
+                      ?? User.Identity?.Name;
+        return string.IsNullOrEmpty(subject) ? null : subject;
+    }
+}

--- a/src/Andy.Policies.Api/ExceptionHandlers/PolicyExceptionHandler.cs
+++ b/src/Andy.Policies.Api/ExceptionHandlers/PolicyExceptionHandler.cs
@@ -112,6 +112,54 @@ public sealed class PolicyExceptionHandler : IExceptionHandler
             return true;
         }
 
+        // P5.5 (#58): override-specific 403s carry typed errorCodes
+        // distinct from a generic 403 so MCP / gRPC / CLI surfaces can
+        // mirror the same contract (P5.6 / P5.7) and the Cockpit UI
+        // can branch on `errorCode` rather than parsing English.
+        if (exception is SelfApprovalException sax)
+        {
+            var problem403 = new ProblemDetails
+            {
+                Status = StatusCodes.Status403Forbidden,
+                Title = "Self-approval forbidden",
+                Detail = sax.Message,
+                Type = "/problems/override-self-approval",
+                Instance = httpContext.Request.Path,
+                Extensions =
+                {
+                    ["errorCode"] = "override.self_approval_forbidden",
+                    ["overrideId"] = sax.OverrideId,
+                    ["subjectId"] = sax.SubjectId,
+                },
+            };
+            httpContext.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await httpContext.Response.WriteAsJsonAsync(problem403, cancellationToken);
+            return true;
+        }
+
+        if (exception is RbacDeniedException rdex)
+        {
+            var problem403 = new ProblemDetails
+            {
+                Status = StatusCodes.Status403Forbidden,
+                Title = "RBAC denied",
+                Detail = rdex.Message,
+                Type = "/problems/rbac-denied",
+                Instance = httpContext.Request.Path,
+                Extensions =
+                {
+                    ["errorCode"] = "rbac.denied",
+                    ["subjectId"] = rdex.SubjectId,
+                    ["permission"] = rdex.Permission,
+                    ["resourceInstanceId"] = rdex.ResourceInstanceId,
+                    ["reason"] = rdex.Reason,
+                },
+            };
+            httpContext.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await httpContext.Response.WriteAsJsonAsync(problem403, cancellationToken);
+            return true;
+        }
+
         // P4.4: tighten-only violation carries the offending ancestor
         // binding id + scope node id so admins can triage from the
         // error response without a follow-up query. We inject the

--- a/src/Andy.Policies.Infrastructure/Services/OverrideService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/OverrideService.cs
@@ -373,14 +373,20 @@ public sealed class OverrideService : IOverrideService
         ArgumentException.ThrowIfNullOrEmpty(scopeRef);
 
         var now = _clock.GetUtcNow();
+        // Filter on (ScopeKind, ScopeRef, State) server-side (covered
+        // by ix_overrides_scope_state) and refine on ExpiresAt + order
+        // client-side. SQLite cannot translate DateTimeOffset
+        // comparisons or ordering — same posture as the rest of the
+        // codebase (see PolicyService list filters and the
+        // OverrideExpiryReaper sweep).
         var rows = await _db.Overrides.AsNoTracking()
             .Where(o => o.ScopeKind == scopeKind
                         && o.ScopeRef == scopeRef
-                        && o.State == OverrideState.Approved
-                        && o.ExpiresAt > now)
+                        && o.State == OverrideState.Approved)
             .ToListAsync(ct)
             .ConfigureAwait(false);
         return rows
+            .Where(o => o.ExpiresAt > now)
             .OrderBy(o => o.ApprovedAt)
             .Select(ToDto)
             .ToList();

--- a/tests/Andy.Policies.Tests.Integration/Api/OverridesControllerTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Api/OverridesControllerTests.cs
@@ -1,0 +1,426 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Settings;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Tests.Integration.Controllers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Andy.Policies.Infrastructure.Data;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Api;
+
+/// <summary>
+/// P5.5 (#58) — exercises the six override REST endpoints end-to-end
+/// against the SQLite-backed factory. Stands up a parallel
+/// <see cref="OverridesFactory"/> that swaps
+/// <see cref="IExperimentalOverridesGate"/> for a controllable stub
+/// so the gate can be flipped per-test without re-spinning the host.
+/// </summary>
+public class OverridesControllerTests : IDisposable
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private sealed class StubGate : IExperimentalOverridesGate
+    {
+        public bool IsEnabled { get; set; } = true;
+    }
+
+    private sealed class OverridesFactory : WebApplicationFactory<Program>
+    {
+        private readonly SqliteConnection _connection = new("DataSource=:memory:");
+
+        public StubGate Gate { get; } = new();
+
+        public OverridesFactory()
+        {
+            _connection.Open();
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Testing");
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Database:Provider"] = "Sqlite",
+                    ["AndyAuth:Authority"] = "https://test-auth.invalid",
+                    ["AndySettings:ApiBaseUrl"] = "https://test-settings.invalid",
+                });
+            });
+
+            builder.ConfigureServices(services =>
+            {
+                var ctxDescriptor = services.SingleOrDefault(d =>
+                    d.ServiceType == typeof(DbContextOptions<AppDbContext>));
+                if (ctxDescriptor is not null) services.Remove(ctxDescriptor);
+                services.AddDbContext<AppDbContext>(opts => opts.UseSqlite(_connection));
+
+                var gateDescriptor = services.SingleOrDefault(d =>
+                    d.ServiceType == typeof(IExperimentalOverridesGate));
+                if (gateDescriptor is not null) services.Remove(gateDescriptor);
+                services.AddSingleton<IExperimentalOverridesGate>(Gate);
+
+                services.AddAuthentication(TestAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                        TestAuthHandler.SchemeName, _ => { });
+                services.PostConfigure<AuthorizationOptions>(opts =>
+                {
+                    opts.DefaultPolicy = new AuthorizationPolicyBuilder(TestAuthHandler.SchemeName)
+                        .RequireAuthenticatedUser()
+                        .Build();
+                });
+
+                using var sp = services.BuildServiceProvider();
+                using var scope = sp.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+                db.Database.EnsureCreated();
+            });
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) _connection.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+
+    private readonly OverridesFactory _factory = new();
+    private HttpClient Client => _factory.CreateClient();
+
+    public void Dispose() => _factory.Dispose();
+
+    private async Task<PolicyVersionDto> CreateActivePolicyVersionAsync(HttpClient client, string slug)
+    {
+        var create = new CreatePolicyRequest(
+            Name: slug,
+            Description: null,
+            Summary: "summary",
+            Enforcement: "Must",
+            Severity: "Critical",
+            Scopes: Array.Empty<string>(),
+            RulesJson: "{}");
+        var draftResp = await client.PostAsJsonAsync("/api/policies", create);
+        draftResp.EnsureSuccessStatusCode();
+        var draft = (await draftResp.Content.ReadFromJsonAsync<PolicyVersionDto>(JsonOptions))!;
+
+        var publishResp = await client.PostAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
+            new LifecycleTransitionRequest("go-live"));
+        publishResp.EnsureSuccessStatusCode();
+        return (await publishResp.Content.ReadFromJsonAsync<PolicyVersionDto>(JsonOptions))!;
+    }
+
+    private static ProposeOverrideRequest ExemptRequest(
+        Guid policyVersionId,
+        string scopeRef = "user:42",
+        DateTimeOffset? expiresAt = null,
+        string rationale = "expedite review for vendor-blocked story")
+        => new(
+            PolicyVersionId: policyVersionId,
+            ScopeKind: OverrideScopeKind.Principal,
+            ScopeRef: scopeRef,
+            Effect: OverrideEffect.Exempt,
+            ReplacementPolicyVersionId: null,
+            ExpiresAt: expiresAt ?? DateTimeOffset.UtcNow.AddHours(24),
+            Rationale: rationale);
+
+    private static string Slug(string prefix) => $"{prefix}-{Guid.NewGuid():N}".Substring(0, 16);
+
+    private static HttpRequestMessage SignedAs(HttpMethod method, string path, string subject, object? body = null)
+    {
+        var req = new HttpRequestMessage(method, path);
+        req.Headers.Add(TestAuthHandler.SubjectHeader, subject);
+        if (body is not null)
+        {
+            req.Content = JsonContent.Create(body);
+        }
+        return req;
+    }
+
+    [Fact]
+    public async Task Propose_HappyPath_Returns201_WithLocationHeader()
+    {
+        var client = Client;
+        var version = await CreateActivePolicyVersionAsync(client, Slug("ovr-create"));
+
+        var resp = await client.PostAsJsonAsync("/api/overrides", ExemptRequest(version.Id));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+        resp.Headers.Location.Should().NotBeNull();
+        resp.Headers.Location!.AbsolutePath.Should().StartWith("/api/overrides/");
+        var dto = await resp.Content.ReadFromJsonAsync<OverrideDto>(JsonOptions);
+        dto!.State.Should().Be(OverrideState.Proposed);
+        dto.PolicyVersionId.Should().Be(version.Id);
+    }
+
+    [Fact]
+    public async Task Propose_GateOff_Returns403WithErrorCode()
+    {
+        var client = Client;
+        var version = await CreateActivePolicyVersionAsync(client, Slug("ovr-gate"));
+        _factory.Gate.IsEnabled = false;
+
+        var resp = await client.PostAsJsonAsync("/api/overrides", ExemptRequest(version.Id));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var problem = await resp.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        problem.GetProperty("type").GetString().Should().Be("/problems/override-disabled");
+        problem.GetProperty("errorCode").GetString().Should().Be("override.disabled");
+
+        _factory.Gate.IsEnabled = true; // restore for downstream tests
+    }
+
+    [Fact]
+    public async Task Propose_BlankRationale_Returns400()
+    {
+        var client = Client;
+        var version = await CreateActivePolicyVersionAsync(client, Slug("ovr-rationale"));
+        var bad = ExemptRequest(version.Id, rationale: "   ");
+
+        var resp = await client.PostAsJsonAsync("/api/overrides", bad);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Approve_BySomeoneOtherThanProposer_Returns200_AndTransitions()
+    {
+        var client = Client;
+        var version = await CreateActivePolicyVersionAsync(client, Slug("ovr-app-ok"));
+
+        // Propose as user A.
+        var proposeResp = await client.SendAsync(
+            SignedAs(HttpMethod.Post, "/api/overrides", "user:proposer", ExemptRequest(version.Id)));
+        proposeResp.EnsureSuccessStatusCode();
+        var proposed = (await proposeResp.Content.ReadFromJsonAsync<OverrideDto>(JsonOptions))!;
+
+        // Approve as user B.
+        var approveResp = await client.SendAsync(
+            SignedAs(HttpMethod.Post, $"/api/overrides/{proposed.Id}/approve", "user:approver"));
+
+        approveResp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var approved = await approveResp.Content.ReadFromJsonAsync<OverrideDto>(JsonOptions);
+        approved!.State.Should().Be(OverrideState.Approved);
+        approved.ApproverSubjectId.Should().Be("user:approver");
+    }
+
+    [Fact]
+    public async Task Approve_ByProposer_Returns403_WithSelfApprovalErrorCode()
+    {
+        var client = Client;
+        var version = await CreateActivePolicyVersionAsync(client, Slug("ovr-self"));
+
+        var proposeResp = await client.SendAsync(
+            SignedAs(HttpMethod.Post, "/api/overrides", "user:proposer", ExemptRequest(version.Id)));
+        proposeResp.EnsureSuccessStatusCode();
+        var proposed = (await proposeResp.Content.ReadFromJsonAsync<OverrideDto>(JsonOptions))!;
+
+        var approveResp = await client.SendAsync(
+            SignedAs(HttpMethod.Post, $"/api/overrides/{proposed.Id}/approve", "user:proposer"));
+
+        approveResp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var problem = await approveResp.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        problem.GetProperty("type").GetString().Should().Be("/problems/override-self-approval");
+        problem.GetProperty("errorCode").GetString().Should().Be("override.self_approval_forbidden");
+    }
+
+    [Fact]
+    public async Task Approve_AlreadyApproved_Returns409()
+    {
+        var client = Client;
+        var version = await CreateActivePolicyVersionAsync(client, Slug("ovr-9"));
+
+        var proposeResp = await client.SendAsync(
+            SignedAs(HttpMethod.Post, "/api/overrides", "user:p1", ExemptRequest(version.Id)));
+        proposeResp.EnsureSuccessStatusCode();
+        var proposed = (await proposeResp.Content.ReadFromJsonAsync<OverrideDto>(JsonOptions))!;
+
+        var firstApprove = await client.SendAsync(
+            SignedAs(HttpMethod.Post, $"/api/overrides/{proposed.Id}/approve", "user:p2"));
+        firstApprove.EnsureSuccessStatusCode();
+
+        var secondApprove = await client.SendAsync(
+            SignedAs(HttpMethod.Post, $"/api/overrides/{proposed.Id}/approve", "user:p3"));
+        secondApprove.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Approve_UnknownId_Returns404()
+    {
+        var client = Client;
+
+        var resp = await client.PostAsync($"/api/overrides/{Guid.NewGuid()}/approve", content: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Revoke_BlankReason_Returns400()
+    {
+        var client = Client;
+        var version = await CreateActivePolicyVersionAsync(client, Slug("ovr-rev0"));
+        var proposeResp = await client.PostAsJsonAsync("/api/overrides", ExemptRequest(version.Id));
+        proposeResp.EnsureSuccessStatusCode();
+        var proposed = (await proposeResp.Content.ReadFromJsonAsync<OverrideDto>(JsonOptions))!;
+
+        var resp = await client.PostAsJsonAsync(
+            $"/api/overrides/{proposed.Id}/revoke", new RevokeOverrideRequest("   "));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Revoke_HappyPath_FromProposed_Returns200()
+    {
+        var client = Client;
+        var version = await CreateActivePolicyVersionAsync(client, Slug("ovr-rev1"));
+        var proposeResp = await client.PostAsJsonAsync("/api/overrides", ExemptRequest(version.Id));
+        proposeResp.EnsureSuccessStatusCode();
+        var proposed = (await proposeResp.Content.ReadFromJsonAsync<OverrideDto>(JsonOptions))!;
+
+        var resp = await client.PostAsJsonAsync(
+            $"/api/overrides/{proposed.Id}/revoke", new RevokeOverrideRequest("withdrawn"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await resp.Content.ReadFromJsonAsync<OverrideDto>(JsonOptions);
+        dto!.State.Should().Be(OverrideState.Revoked);
+        dto.RevocationReason.Should().Be("withdrawn");
+    }
+
+    [Fact]
+    public async Task Get_UnknownId_Returns404()
+    {
+        var client = Client;
+
+        var resp = await client.GetAsync($"/api/overrides/{Guid.NewGuid()}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Get_ExistingId_Returns200()
+    {
+        var client = Client;
+        var version = await CreateActivePolicyVersionAsync(client, Slug("ovr-get"));
+        var proposeResp = await client.PostAsJsonAsync("/api/overrides", ExemptRequest(version.Id));
+        proposeResp.EnsureSuccessStatusCode();
+        var proposed = (await proposeResp.Content.ReadFromJsonAsync<OverrideDto>(JsonOptions))!;
+
+        var resp = await client.GetAsync($"/api/overrides/{proposed.Id}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await resp.Content.ReadFromJsonAsync<OverrideDto>(JsonOptions);
+        dto!.Id.Should().Be(proposed.Id);
+    }
+
+    [Fact]
+    public async Task List_FiltersByState()
+    {
+        var client = Client;
+        var version = await CreateActivePolicyVersionAsync(client, Slug("ovr-list"));
+        await client.PostAsJsonAsync("/api/overrides", ExemptRequest(version.Id, "user:1"));
+        var proposeB = await client.SendAsync(
+            SignedAs(HttpMethod.Post, "/api/overrides", "user:proposer-b",
+                ExemptRequest(version.Id, "user:2")));
+        var proposedB = (await proposeB.Content.ReadFromJsonAsync<OverrideDto>(JsonOptions))!;
+        await client.SendAsync(
+            SignedAs(HttpMethod.Post, $"/api/overrides/{proposedB.Id}/approve", "user:other"));
+
+        var resp = await client.GetAsync("/api/overrides?state=Approved");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dtos = await resp.Content.ReadFromJsonAsync<List<OverrideDto>>(JsonOptions);
+        dtos.Should().ContainSingle().Which.Id.Should().Be(proposedB.Id);
+    }
+
+    [Fact]
+    public async Task Active_RequiresBothQueryParams()
+    {
+        var client = Client;
+
+        var noKind = await client.GetAsync("/api/overrides/active?scopeRef=user:42");
+        var noRef = await client.GetAsync("/api/overrides/active?scopeKind=Principal");
+
+        noKind.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        noRef.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Active_FiltersToApprovedAndNonExpired()
+    {
+        var client = Client;
+        var version = await CreateActivePolicyVersionAsync(client, Slug("ovr-act"));
+
+        // Approved + far-future expiry: should appear.
+        var liveResp = await client.SendAsync(
+            SignedAs(HttpMethod.Post, "/api/overrides", "user:p1",
+                ExemptRequest(version.Id, "user:42",
+                    expiresAt: DateTimeOffset.UtcNow.AddHours(24))));
+        var live = (await liveResp.Content.ReadFromJsonAsync<OverrideDto>(JsonOptions))!;
+        await client.SendAsync(
+            SignedAs(HttpMethod.Post, $"/api/overrides/{live.Id}/approve", "user:approver"));
+
+        // Proposed but never approved: should NOT appear.
+        await client.SendAsync(
+            SignedAs(HttpMethod.Post, "/api/overrides", "user:p2",
+                ExemptRequest(version.Id, "user:42")));
+
+        // Different scope (user:99): should NOT appear.
+        var otherResp = await client.SendAsync(
+            SignedAs(HttpMethod.Post, "/api/overrides", "user:p3",
+                ExemptRequest(version.Id, "user:99")));
+        var other = (await otherResp.Content.ReadFromJsonAsync<OverrideDto>(JsonOptions))!;
+        await client.SendAsync(
+            SignedAs(HttpMethod.Post, $"/api/overrides/{other.Id}/approve", "user:approver"));
+
+        var resp = await client.GetAsync("/api/overrides/active?scopeKind=Principal&scopeRef=user:42");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dtos = await resp.Content.ReadFromJsonAsync<List<OverrideDto>>(JsonOptions);
+        dtos.Should().ContainSingle().Which.Id.Should().Be(live.Id);
+    }
+
+    [Fact]
+    public async Task ReadEndpoints_BypassGate()
+    {
+        // Settings gate off; reads must still respond 200 so the
+        // resolution algorithm (P4.3) keeps working when the toggle
+        // is flipped off — turning the feature off must not strand
+        // existing approved overrides for consumers.
+        var client = Client;
+        var version = await CreateActivePolicyVersionAsync(client, Slug("ovr-read-gate"));
+        var proposeResp = await client.PostAsJsonAsync("/api/overrides", ExemptRequest(version.Id));
+        proposeResp.EnsureSuccessStatusCode();
+
+        _factory.Gate.IsEnabled = false;
+        try
+        {
+            (await client.GetAsync("/api/overrides")).StatusCode.Should().Be(HttpStatusCode.OK);
+            (await client.GetAsync("/api/overrides/active?scopeKind=Principal&scopeRef=user:42"))
+                .StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+        finally
+        {
+            _factory.Gate.IsEnabled = true;
+        }
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Controllers/TestAuthHandler.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/TestAuthHandler.cs
@@ -20,6 +20,14 @@ public sealed class TestAuthHandler : AuthenticationHandler<AuthenticationScheme
     public const string SchemeName = "Test";
     public const string TestSubjectId = "test-user";
 
+    /// <summary>
+    /// Optional request header that overrides <see cref="TestSubjectId"/>
+    /// for a single request. P5.5 (#58) needs multi-actor scenarios
+    /// (self-approval, propose-as-A + approve-as-B); the header lets
+    /// tests pin the subject without spinning up a second factory.
+    /// </summary>
+    public const string SubjectHeader = "X-Test-Subject";
+
     public TestAuthHandler(
         IOptionsMonitor<AuthenticationSchemeOptions> options,
         ILoggerFactory logger,
@@ -28,7 +36,10 @@ public sealed class TestAuthHandler : AuthenticationHandler<AuthenticationScheme
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        var claims = new[] { new Claim(ClaimTypes.Name, TestSubjectId) };
+        var subjectId = Request.Headers.TryGetValue(SubjectHeader, out var override_) && !string.IsNullOrEmpty(override_)
+            ? override_.ToString()
+            : TestSubjectId;
+        var claims = new[] { new Claim(ClaimTypes.Name, subjectId) };
         var identity = new ClaimsIdentity(claims, SchemeName);
         var principal = new ClaimsPrincipal(identity);
         var ticket = new AuthenticationTicket(principal, SchemeName);


### PR DESCRIPTION
## Summary

Six REST endpoints on `/api/overrides` backed by `IOverrideService`:

| Endpoint | Auth | Gate | Status codes |
|---|---|---|---|
| `POST /api/overrides` | `[Authorize]` | yes | 201, 400, 401, 403 (gate), 404 |
| `POST /api/overrides/{id}/approve` | `[Authorize]` | yes | 200, 401, 403 (self / rbac / gate), 404, 409 |
| `POST /api/overrides/{id}/revoke` | `[Authorize]` | yes | 200, 400, 401, 403, 404, 409 |
| `GET /api/overrides` | `[Authorize]` | no | 200, 400, 401 |
| `GET /api/overrides/{id}` | `[Authorize]` | no | 200, 401, 404 |
| `GET /api/overrides/active` | `[Authorize]` | no | 200, 400 (missing query), 401 |

Reads bypass `[OverrideWriteGate]` so the P4.3 resolution algorithm keeps working when `andy.policies.experimentalOverridesEnabled` is off — turning the toggle off must not strand consumers that already rely on an override's effect. RBAC (per-action permissions like `andy-policies:override:approve`) is enforced inside the service via `IRbacChecker`; when P7.2 (#51) wires the real andy-rbac client, the same code path picks it up.

## Typed error contracts

| Exception | Status | `type` | `errorCode` |
|---|---|---|---|
| `SelfApprovalException` | 403 | `/problems/override-self-approval` | `override.self_approval_forbidden` |
| `RbacDeniedException` | 403 | `/problems/rbac-denied` | `rbac.denied` |
| Gate off (filter) | 403 | `/problems/override-disabled` | `override.disabled` |

These let the Cockpit Angular client and consumer gateways branch on stable strings instead of parsing English. P5.6 (MCP) and P5.7 (gRPC) mirror the same `errorCode` strings.

## Other changes

- `OverrideService.GetActiveAsync` — split the query: filter `(ScopeKind, ScopeRef, State == Approved)` server-side (covered by `ix_overrides_scope_state`) and refine on `ExpiresAt` + order client-side. SQLite cannot translate `DateTimeOffset` comparisons, same posture as the rest of the codebase (P4 list filters and the P5.3 reaper sweep).
- `TestAuthHandler` now honours an `X-Test-Subject` header so multi-actor scenarios (propose-as-A + approve-as-B; self-approval) can be tested through HTTP.
- OpenAPI snapshot regenerated — adds the six override paths to `docs/openapi/andy-policies-v1.yaml`.

## Coverage

15 integration tests across the six endpoints: propose 201 with `Location` header, propose-with-gate-off 403+errorCode, propose validation 400, approve happy path with two actors, approve-by-proposer 403 with `override.self_approval_forbidden`, approve already-approved 409, approve unknown 404, revoke validation 400, revoke happy path, get unknown 404, get existing 200, list state filter, active missing query 400, active filters to Approved+non-expired, reads-bypass-gate.

Full unit (323) + integration (323) suites green locally.

## Test plan

- [x] \`dotnet test tests/Andy.Policies.Tests.Unit\` — 323 passed
- [x] \`dotnet test tests/Andy.Policies.Tests.Integration\` — 323 passed
- [x] \`./scripts/export-openapi.sh\` — regenerated and committed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)