### PR TITLE
Implement P6.4 — RationaleRequiredFilter for defense-in-depth (#44)

### DIFF
--- a/src/Andy.Policies.Api/Filters/RationaleAttribute.cs
+++ b/src/Andy.Policies.Api/Filters/RationaleAttribute.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Api.Filters;
+
+/// <summary>
+/// Marks the rationale property on a request DTO so
+/// <see cref="RationaleRequiredFilter"/> can find it without
+/// relying solely on the property name (P6.4, story
+/// rivoli-ai/andy-policies#44). Most DTOs already use the
+/// canonical name <c>Rationale</c>; this attribute exists for
+/// the cases where the field is named differently
+/// (<c>Reason</c>, <c>Note</c>, etc.).
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+public sealed class RationaleAttribute : Attribute
+{
+}

--- a/src/Andy.Policies.Api/Filters/RationaleRequiredFilter.cs
+++ b/src/Andy.Policies.Api/Filters/RationaleRequiredFilter.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Reflection;
+using Andy.Policies.Application.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Andy.Policies.Api.Filters;
+
+/// <summary>
+/// MVC action filter that rejects mutating requests whose DTOs
+/// carry a rationale field but supply an empty / whitespace-only
+/// value (P6.4, story rivoli-ai/andy-policies#44). Reads
+/// <see cref="IRationalePolicy.IsRequired"/> on every request so
+/// flipping <c>andy.policies.rationaleRequired</c> in andy-settings
+/// takes effect on the next mutation without a restart.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why a filter instead of relying on the service-layer
+/// check?</b> The service layer (P2's <c>LifecycleTransitionService</c>,
+/// P3's <c>BindingService</c>, etc.) already raises
+/// <see cref="Application.Exceptions.RationaleRequiredException"/>
+/// when called with an empty rationale. The filter is a
+/// defense-in-depth move: it catches the violation before any
+/// service code runs, gives a uniform 400 ProblemDetails response
+/// across all mutating endpoints, and means a future service
+/// added without the existing check still inherits the
+/// guarantee.
+/// </para>
+/// <para>
+/// <b>Discovery.</b> The filter inspects every action argument
+/// for a property either named exactly <c>Rationale</c> or
+/// decorated with <see cref="RationaleAttribute"/>. Action
+/// arguments without such a property are passed through (some
+/// mutations, like a tombstone-by-id, legitimately have no
+/// rationale concept; those endpoints can carry
+/// <see cref="SkipRationaleCheckAttribute"/> for clarity).
+/// </para>
+/// <para>
+/// <b>Method scope.</b> Only mutating HTTP methods are
+/// inspected — GET / HEAD / OPTIONS pass through unconditionally
+/// because the audit chain doesn't care about reads.
+/// </para>
+/// </remarks>
+public sealed class RationaleRequiredFilter : IAsyncActionFilter
+{
+    /// <summary>Stable error code stamped on the ProblemDetails
+    /// response. Matches the <c>errorCode</c> extension shape
+    /// used elsewhere in the API.</summary>
+    public const string ErrorCode = "rationale.required";
+
+    public async Task OnActionExecutionAsync(
+        ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(next);
+
+        var method = context.HttpContext.Request.Method;
+        if (string.Equals(method, HttpMethods.Get, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(method, HttpMethods.Head, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(method, HttpMethods.Options, StringComparison.OrdinalIgnoreCase))
+        {
+            await next().ConfigureAwait(false);
+            return;
+        }
+
+        if (HasSkipAttribute(context.ActionDescriptor))
+        {
+            await next().ConfigureAwait(false);
+            return;
+        }
+
+        var policy = context.HttpContext.RequestServices.GetService<IRationalePolicy>();
+        if (policy is null || !policy.IsRequired)
+        {
+            await next().ConfigureAwait(false);
+            return;
+        }
+
+        foreach (var (_, arg) in context.ActionArguments)
+        {
+            if (arg is null) continue;
+
+            var rationale = TryReadRationale(arg);
+            if (rationale is null) continue; // DTO doesn't carry a rationale field
+
+            if (string.IsNullOrWhiteSpace(rationale.Value))
+            {
+                context.Result = BuildBadRequest(rationale.PropertyName, context.HttpContext.Request.Path);
+                return;
+            }
+        }
+
+        await next().ConfigureAwait(false);
+    }
+
+    private static bool HasSkipAttribute(Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor descriptor)
+    {
+        if (descriptor is not ControllerActionDescriptor controllerAction)
+        {
+            return false;
+        }
+        if (controllerAction.MethodInfo.GetCustomAttribute<SkipRationaleCheckAttribute>() is not null)
+        {
+            return true;
+        }
+        if (controllerAction.ControllerTypeInfo.GetCustomAttribute<SkipRationaleCheckAttribute>() is not null)
+        {
+            return true;
+        }
+        return false;
+    }
+
+    private static RationaleField? TryReadRationale(object arg)
+    {
+        // Properties decorated with [Rationale] win; otherwise the
+        // canonical name "Rationale" is matched. Private setters
+        // and init-only setters are both readable via GetValue —
+        // we only need read access here.
+        var props = arg.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead);
+        var attributed = props.FirstOrDefault(p =>
+            p.GetCustomAttribute<RationaleAttribute>() is not null);
+        var canonical = attributed ?? props.FirstOrDefault(p =>
+            string.Equals(p.Name, "Rationale", StringComparison.Ordinal));
+        if (canonical is null || canonical.PropertyType != typeof(string))
+        {
+            return null;
+        }
+        var value = canonical.GetValue(arg) as string;
+        return new RationaleField(canonical.Name, value);
+    }
+
+    private static BadRequestObjectResult BuildBadRequest(string propertyName, PathString path)
+    {
+        var problem = new ValidationProblemDetails(new Dictionary<string, string[]>
+        {
+            [propertyName.Length > 0
+                ? char.ToLowerInvariant(propertyName[0]) + propertyName[1..]
+                : propertyName] = new[] { "Rationale is required and may not be empty or whitespace." },
+        })
+        {
+            Status = StatusCodes.Status400BadRequest,
+            Title = "Rationale required",
+            Type = "/problems/rationale-required",
+            Instance = path,
+            Detail =
+                "andy.policies.rationaleRequired is enabled; include a non-empty rationale.",
+        };
+        problem.Extensions["errorCode"] = ErrorCode;
+        return new BadRequestObjectResult(problem);
+    }
+
+    private sealed record RationaleField(string PropertyName, string? Value);
+}

--- a/src/Andy.Policies.Api/Filters/SkipRationaleCheckAttribute.cs
+++ b/src/Andy.Policies.Api/Filters/SkipRationaleCheckAttribute.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Api.Filters;
+
+/// <summary>
+/// Opts an action (or whole controller) out of
+/// <see cref="RationaleRequiredFilter"/> (P6.4, story
+/// rivoli-ai/andy-policies#44). Reserved for endpoints whose
+/// payloads legitimately have no rationale concept (e.g. system
+/// triggers, agent automation hooks, internal diagnostics);
+/// every other mutating endpoint must carry a rationale when
+/// <c>andy.policies.rationaleRequired</c> is on.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class,
+    AllowMultiple = false, Inherited = true)]
+public sealed class SkipRationaleCheckAttribute : Attribute
+{
+}

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -182,7 +182,17 @@ builder.Services.AddOpenTelemetry()
     });
 
 // --- Swagger ---
-builder.Services.AddControllers()
+builder.Services.AddControllers(options =>
+    {
+        // P6.4 (#44): defense-in-depth rationale enforcement.
+        // The filter checks IRationalePolicy.IsRequired on every
+        // mutating request and rejects empty / whitespace-only
+        // rationales with 400 ProblemDetails *before* the service
+        // layer runs. The service-level RationaleRequiredException
+        // path remains as a second guarantee for code paths that
+        // bypass the filter (e.g. background workers).
+        options.Filters.Add<Andy.Policies.Api.Filters.RationaleRequiredFilter>();
+    })
     .AddJsonOptions(options =>
     {
         options.JsonSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());

--- a/tests/Andy.Policies.Tests.Integration/Filters/RationaleRequiredFilterTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Filters/RationaleRequiredFilterTests.cs
@@ -1,0 +1,281 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Api.Filters;
+using Andy.Policies.Application.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Filters;
+
+/// <summary>
+/// P6.4 (#44) — exercises <see cref="RationaleRequiredFilter"/>'s
+/// short-circuit behaviour with constructed
+/// <see cref="ActionExecutingContext"/>s. Lives in the Integration
+/// suite because the Tests.Unit project doesn't pull in
+/// Microsoft.AspNetCore.Mvc types.
+/// </summary>
+public class RationaleRequiredFilterTests
+{
+    private sealed class StubPolicy : IRationalePolicy
+    {
+        public bool IsRequired { get; set; } = true;
+
+        public string? ValidateRationale(string? rationale) => null;
+    }
+
+    private sealed class DtoWithRationale
+    {
+        public string Rationale { get; set; } = string.Empty;
+    }
+
+    private sealed class DtoWithAttributedRationale
+    {
+        [Rationale]
+        public string Reason { get; set; } = string.Empty;
+    }
+
+    private sealed class DtoWithoutRationale
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class FakeController
+    {
+        public void Mutate() { }
+        [SkipRationaleCheck]
+        public void SkipMe() { }
+    }
+
+    [SkipRationaleCheck]
+    private sealed class FakeSkipController
+    {
+        public void AnyAction() { }
+    }
+
+    private static (ActionExecutingContext ctx, NextProbe probe) NewContext(
+        string method, object? arg, IRationalePolicy policy, MethodInfo? actionMethod = null)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IRationalePolicy>(policy);
+        var sp = services.BuildServiceProvider();
+
+        var http = new DefaultHttpContext { RequestServices = sp };
+        http.Request.Method = method;
+        http.Request.Path = "/api/policies/test";
+
+        var actionContext = new ActionContext(
+            http,
+            new RouteData(),
+            actionMethod is not null
+                ? new ControllerActionDescriptor
+                {
+                    MethodInfo = actionMethod,
+                    ControllerTypeInfo = actionMethod.DeclaringType!.GetTypeInfo(),
+                }
+                : new ActionDescriptor());
+        var execContext = new ActionExecutingContext(
+            actionContext,
+            filters: new List<IFilterMetadata>(),
+            actionArguments: arg is null
+                ? new Dictionary<string, object?>()
+                : new Dictionary<string, object?> { ["request"] = arg },
+            controller: new object());
+        var probe = new NextProbe();
+        return (execContext, probe);
+    }
+
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("HEAD")]
+    [InlineData("OPTIONS")]
+    public async Task ReadMethods_AlwaysPassThrough(string method)
+    {
+        var filter = new RationaleRequiredFilter();
+        var (ctx, probe) = NewContext(method, new DtoWithRationale { Rationale = "" }, new StubPolicy());
+
+        await filter.OnActionExecutionAsync(ctx, probe.Next);
+
+        probe.CallCount.Should().Be(1);
+        ctx.Result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PolicyOff_PassesThrough_EvenWithEmptyRationale()
+    {
+        var filter = new RationaleRequiredFilter();
+        var (ctx, probe) = NewContext(
+            "POST",
+            new DtoWithRationale { Rationale = "" },
+            new StubPolicy { IsRequired = false });
+
+        await filter.OnActionExecutionAsync(ctx, probe.Next);
+
+        probe.CallCount.Should().Be(1);
+        ctx.Result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PolicyOn_NullRationale_ShortCircuitsWith400()
+    {
+        var filter = new RationaleRequiredFilter();
+        var dto = new DtoWithRationale { Rationale = null! };
+        var (ctx, probe) = NewContext("POST", dto, new StubPolicy { IsRequired = true });
+
+        await filter.OnActionExecutionAsync(ctx, probe.Next);
+
+        probe.CallCount.Should().Be(0);
+        var result = ctx.Result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var problem = result.Value.Should().BeOfType<ValidationProblemDetails>().Subject;
+        problem.Status.Should().Be(StatusCodes.Status400BadRequest);
+        problem.Type.Should().Be("/problems/rationale-required");
+        problem.Extensions.Should().ContainKey("errorCode")
+            .WhoseValue.Should().Be(RationaleRequiredFilter.ErrorCode);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t\n")]
+    public async Task PolicyOn_BlankRationale_ShortCircuitsWith400(string blank)
+    {
+        var filter = new RationaleRequiredFilter();
+        var (ctx, probe) = NewContext(
+            "POST",
+            new DtoWithRationale { Rationale = blank },
+            new StubPolicy { IsRequired = true });
+
+        await filter.OnActionExecutionAsync(ctx, probe.Next);
+
+        probe.CallCount.Should().Be(0);
+        ctx.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task PolicyOn_NonEmptyRationale_PassesThrough()
+    {
+        var filter = new RationaleRequiredFilter();
+        var (ctx, probe) = NewContext(
+            "POST",
+            new DtoWithRationale { Rationale = "legal review complete" },
+            new StubPolicy { IsRequired = true });
+
+        await filter.OnActionExecutionAsync(ctx, probe.Next);
+
+        probe.CallCount.Should().Be(1);
+        ctx.Result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PolicyOn_DtoWithoutRationaleField_PassesThrough()
+    {
+        // Some mutating endpoints (e.g. tombstone-by-id) don't
+        // carry a rationale concept. The filter must pass them
+        // through rather than fabricate a 400.
+        var filter = new RationaleRequiredFilter();
+        var (ctx, probe) = NewContext(
+            "POST",
+            new DtoWithoutRationale { Name = "x" },
+            new StubPolicy { IsRequired = true });
+
+        await filter.OnActionExecutionAsync(ctx, probe.Next);
+
+        probe.CallCount.Should().Be(1);
+        ctx.Result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PolicyOn_AttributedRationaleProperty_IsDiscovered()
+    {
+        // [Rationale] on a non-canonical name must be honoured.
+        var filter = new RationaleRequiredFilter();
+        var (ctx, probe) = NewContext(
+            "POST",
+            new DtoWithAttributedRationale { Reason = "" },
+            new StubPolicy { IsRequired = true });
+
+        await filter.OnActionExecutionAsync(ctx, probe.Next);
+
+        probe.CallCount.Should().Be(0);
+        ctx.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task SkipRationaleCheck_OnAction_ShortCircuitsTheFilter()
+    {
+        var filter = new RationaleRequiredFilter();
+        var skipMethod = typeof(FakeController).GetMethod(nameof(FakeController.SkipMe))!;
+        var (ctx, probe) = NewContext(
+            "POST",
+            new DtoWithRationale { Rationale = "" },
+            new StubPolicy { IsRequired = true },
+            actionMethod: skipMethod);
+
+        await filter.OnActionExecutionAsync(ctx, probe.Next);
+
+        probe.CallCount.Should().Be(1);
+        ctx.Result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SkipRationaleCheck_OnControllerType_ShortCircuitsTheFilter()
+    {
+        var filter = new RationaleRequiredFilter();
+        var anyMethod = typeof(FakeSkipController).GetMethod(nameof(FakeSkipController.AnyAction))!;
+        var (ctx, probe) = NewContext(
+            "POST",
+            new DtoWithRationale { Rationale = "" },
+            new StubPolicy { IsRequired = true },
+            actionMethod: anyMethod);
+
+        await filter.OnActionExecutionAsync(ctx, probe.Next);
+
+        probe.CallCount.Should().Be(1);
+        ctx.Result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PolicyMissingFromContainer_PassesThrough()
+    {
+        // If IRationalePolicy isn't registered (unlikely in
+        // production, but keeps the filter robust on a partially-
+        // configured test host), pass through rather than block
+        // every mutating endpoint.
+        var filter = new RationaleRequiredFilter();
+        var http = new DefaultHttpContext { RequestServices = new ServiceCollection().BuildServiceProvider() };
+        http.Request.Method = "POST";
+        var ctx = new ActionExecutingContext(
+            new ActionContext(http, new RouteData(), new ActionDescriptor()),
+            new List<IFilterMetadata>(),
+            new Dictionary<string, object?>(),
+            controller: new object());
+        var probe = new NextProbe();
+
+        await filter.OnActionExecutionAsync(ctx, probe.Next);
+
+        probe.CallCount.Should().Be(1);
+    }
+
+    private sealed class NextProbe
+    {
+        public int CallCount { get; private set; }
+
+        public Task<ActionExecutedContext> Next()
+        {
+            CallCount++;
+            var http = new DefaultHttpContext();
+            return Task.FromResult(new ActionExecutedContext(
+                new ActionContext(http, new RouteData(), new ActionDescriptor()),
+                new List<IFilterMetadata>(),
+                controller: new object()));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

MVC action filter that rejects mutating requests with empty / whitespace-only rationale **before** the service layer runs, when \`andy.policies.rationaleRequired\` is on. Existing service-layer \`RationaleRequiredException\` paths (P2's \`LifecycleTransitionService\` etc.) remain as a second guarantee for code paths that bypass MVC.

## Components

- **\`[Rationale]\`** marker attribute — for DTOs whose rationale field isn't named exactly \`Rationale\` (e.g. \`Reason\`).
- **\`[SkipRationaleCheck]\`** attribute — opts an action or whole controller out of the filter.
- **\`RationaleRequiredFilter\`** (\`IAsyncActionFilter\`):
  - GET / HEAD / OPTIONS pass through unconditionally.
  - Reads \`IRationalePolicy.IsRequired\` on every request — flips in andy-settings take effect on the next mutation without a restart.
  - Reflects each action argument for a \`[Rationale]\`-decorated or canonically-named \`Rationale\` property; returns 400 \`ValidationProblemDetails\` (\`type=/problems/rationale-required\`, \`errorCode=rationale.required\`) when blank.
  - DTOs without a rationale property pass through (some mutations legitimately have no rationale concept).
  - Robust to a missing \`IRationalePolicy\` registration — passes through rather than blocking every mutating endpoint.

Registered globally via \`options.Filters.Add<RationaleRequiredFilter>()\` in \`AddControllers\`.

## Coverage

14 tests covering:

| Case | Result |
|---|---|
| GET / HEAD / OPTIONS | pass-through |
| Policy off | pass-through (even with empty rationale) |
| Policy on, null rationale | 400 with typed error |
| Policy on, empty / whitespace / tab-newline | 400 |
| Policy on, non-empty rationale | pass-through |
| DTO without rationale property | pass-through |
| \`[Rationale]\` on non-canonical name | discovered correctly |
| \`[SkipRationaleCheck]\` on action | bypass |
| \`[SkipRationaleCheck]\` on controller type | bypass |
| Missing \`IRationalePolicy\` registration | pass-through |

Full unit (405) + integration (397, excl. Perf) suites green locally — including all existing service-layer rationale tests, which still exercise the deeper RationaleRequiredException path through their non-filter test factories.

## Test plan

- [x] \`dotnet test tests/Andy.Policies.Tests.Unit\` — 405 passed
- [x] \`dotnet test tests/Andy.Policies.Tests.Integration --filter "Category!=Perf"\` — 397 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)