### PR TITLE
Implement P6.5 — audit verify REST endpoint + CLI (live + offline) (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,40 @@ durations (`+30d`, `+8h`, `+45m`); past values fail-fast at the CLI
 layer with a clear stderr message before round-tripping to the
 server.
 
+### Audit chain verification
+
+REST endpoint for verifying the catalog audit hash chain (P6.5,
+[#45](https://github.com/rivoli-ai/andy-policies/issues/45)):
+
+```http
+GET /api/audit/verify?fromSeq=&toSeq=
+```
+
+Returns 200 with a `ChainVerificationDto` (`{ valid,
+firstDivergenceSeq, inspectedCount, lastSeq }`) regardless of
+outcome — divergence is a queryable state, not an HTTP error.
+400 ProblemDetails (`type=/problems/audit-verify-range`,
+`errorCode=audit.verify.invalid_range`) on \`fromSeq > toSeq\` or
+non-positive bounds.
+
+The CLI mirrors the endpoint with both live and offline modes:
+
+```bash
+# Live — hits /api/audit/verify on the configured server
+andy-policies-cli audit verify --from 1 --to 10000
+
+# Offline — re-runs the chain verifier locally against an
+# NDJSON export. Required for external auditors handed an
+# archival copy; uses the same Shared CanonicalJson +
+# AuditEnvelopeHasher the live writer uses, so live and
+# offline produce byte-identical results.
+andy-policies-cli audit verify --file ./audit-export.ndjson
+```
+
+Exit code 0 on a valid chain, 6 (\`AuditDivergence\`) on
+divergence — distinct from 1 (transport) so cron / CI jobs can
+branch on "the chain itself is broken" vs "the API is unreachable."
+
 ## Ports
 
 Per the ecosystem registry at [`../andy-service-template/docs/ports.md`](../andy-service-template/docs/ports.md). Three deployment modes; the same host can run any combination because each mode uses a distinct port range.
@@ -387,7 +421,7 @@ The docker-compose in this repo binds Mode 2 ports so it can coexist with a nati
 | Layer | Project | Entities / responsibilities |
 |-------|---------|-----------------------------|
 | Domain | `src/Andy.Policies.Domain` | `Policy`, `PolicyVersion`, `Binding` (P3.1, [#19](https://github.com/rivoli-ai/andy-policies/issues/19)), `ScopeNode` (P4.1, [#28](https://github.com/rivoli-ai/andy-policies/issues/28)), `Override` (P5.1, [#49](https://github.com/rivoli-ai/andy-policies/issues/49)), `AuditEvent` (P6.1, [#41](https://github.com/rivoli-ai/andy-policies/issues/41) — append-only via DB triggers + role grants), dimension enums (`EnforcementLevel`, `Severity`, `LifecycleState`, `BindingTargetType`, `BindStrength`, `ScopeType`, `OverrideScopeKind`, `OverrideEffect`, `OverrideState`); `Bundle` (P8) lands with its respective epic |
-| Application | `src/Andy.Policies.Application` | `IPolicyService`, `IBindingService`, `IScopeService`, `IOverrideService` (P5.2, [#52](https://github.com/rivoli-ai/andy-policies/issues/52)), `IRbacChecker`; remaining per-epic interfaces (`IAuditChain`, `IBundleService`) added by later stories |
+| Application | `src/Andy.Policies.Application` | `IPolicyService`, `IBindingService`, `IScopeService`, `IOverrideService` (P5.2, [#52](https://github.com/rivoli-ai/andy-policies/issues/52)), `IRbacChecker`, `IAuditChain` + `IAuditDiffGenerator` (P6.2/P6.3, [#42](https://github.com/rivoli-ai/andy-policies/issues/42)/[#43](https://github.com/rivoli-ai/andy-policies/issues/43)); `IBundleService` lands with its respective epic |
 | Infrastructure | `src/Andy.Policies.Infrastructure` | EF Core (`AppDbContext` + migrations), `PolicyService` implementation, `PolicySeeder` for the six stock policies, andy-rbac / andy-settings adapters |
 | API | `src/Andy.Policies.Api` | REST controllers, MCP tools, gRPC services, OIDC/JWT auth, OpenAPI generation, OpenTelemetry wiring |
 | Shared | `src/Andy.Policies.Shared` | Cross-project DTOs, common enums |

--- a/docs/openapi/andy-policies-v1.yaml
+++ b/docs/openapi/andy-policies-v1.yaml
@@ -18,6 +18,50 @@ paths:
       responses:
         '200':
           description: OK
+  /api/audit/verify:
+    get:
+      tags:
+        - Audit
+      summary: "Verifies the catalog audit hash chain, optionally bounded\r\nto a `[fromSeq, toSeq]` range. Divergence is\r\nreported as `{ valid: false, firstDivergenceSeq: N }`\r\nin the body (HTTP 200) — divergence is a legitimate\r\nqueryable state, not an HTTP error."
+      operationId: Audit_Verify
+      parameters:
+        - name: fromSeq
+          in: query
+          description: "Inclusive lower bound. Defaults to\r\n            1 when omitted."
+          schema:
+            type: integer
+            format: int64
+        - name: toSeq
+          in: query
+          description: "Inclusive upper bound. Defaults to\r\n            MAX(seq) when omitted."
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: "Verification result. `valid`\r\n            may be true or false; `firstDivergenceSeq` is\r\n            non-null only when `valid` is false."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChainVerificationDto'
+        '400':
+          description: "When `fromSeq` >\r\n            `toSeq`, or either is < 1."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '401':
+          description: Caller is unauthenticated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: "Caller lacks the\r\n            `andy-policies:audit:verify` permission (P7.2)."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
   /api/bindings:
     post:
       tags:
@@ -1411,6 +1455,27 @@ components:
         - Tenant
         - Org
       type: string
+    ChainVerificationDto:
+      type: object
+      properties:
+        valid:
+          type: boolean
+          description: "True when the inspected range is\r\n            internally consistent — every row's `PrevHash` matches\r\n            the previous row's computed hash, and every row's `Hash`\r\n            matches the recomputed SHA-256."
+        firstDivergenceSeq:
+          type: integer
+          description: "When Andy.Policies.Application.Dtos.ChainVerificationDto.Valid is\r\n            false, the `Seq` of the first row whose hashes don't\r\n            line up. Null on a valid chain."
+          format: int64
+          nullable: true
+        inspectedCount:
+          type: integer
+          description: "Number of rows the verifier\r\n            walked."
+          format: int64
+        lastSeq:
+          type: integer
+          description: "Largest `Seq` observed by the\r\n            verifier (i.e. the right end of the inspected range, or 0\r\n            when the chain is empty)."
+          format: int64
+      additionalProperties: false
+      description: "Wire-format projection of\r\nAndy.Policies.Application.Interfaces.ChainVerificationResult (P6.5, story\r\nrivoli-ai/andy-policies#45). Returned by\r\n`GET /api/audit/verify` and the corresponding MCP /\r\ngRPC surfaces."
     CreateBindingRequest:
       type: object
       properties:
@@ -1960,6 +2025,8 @@ components:
 security:
   - Bearer: [ ]
 tags:
+  - name: Audit
+    description: "REST surface for the catalog audit chain (P6.5+). This file\r\nscaffolds the `verify` endpoint (P6.5, story\r\nrivoli-ai/andy-policies#45); list / get / export endpoints\r\nfollow in P6.6+."
   - name: Bindings
     description: "REST surface for `Binding` mutation, single-id read, and target-side\r\nquery (P3.3, story rivoli-ai/andy-policies#21). Delegates to\r\nAndy.Policies.Application.Interfaces.IBindingService from P3.2 — same service powering MCP\r\n(P3.5), gRPC (P3.6), and CLI (P3.7). Service exceptions are mapped by\r\nthe global `PolicyExceptionHandler` (already covers\r\nAndy.Policies.Application.Exceptions.NotFoundException,\r\nAndy.Policies.Application.Exceptions.ConflictException, and\r\nAndy.Policies.Application.Exceptions.ValidationException; the\r\nAndy.Policies.Application.Exceptions.BindingRetiredVersionException\r\ninherits from Andy.Policies.Application.Exceptions.ConflictException so\r\nthe existing 409 mapping catches it)."
   - name: Help

--- a/src/Andy.Policies.Api/Controllers/AuditController.cs
+++ b/src/Andy.Policies.Api/Controllers/AuditController.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Api.Filters;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Andy.Policies.Api.Controllers;
+
+/// <summary>
+/// REST surface for the catalog audit chain (P6.5+). This file
+/// scaffolds the <c>verify</c> endpoint (P6.5, story
+/// rivoli-ai/andy-policies#45); list / get / export endpoints
+/// follow in P6.6+.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>RBAC.</b> Per <c>config/rbac-seed.json</c> the audit
+/// surface belongs to the <c>risk</c> role. Today the API uses
+/// blanket <c>[Authorize]</c>; per-action permission gates
+/// (<c>andy-policies:audit:verify</c>, etc.) wire in P7.2 (#51)
+/// when the andy-rbac client lands. The seed has been pre-
+/// populated so the migration is purely a controller annotation
+/// at that point.
+/// </para>
+/// <para>
+/// <b>Read-only.</b> All endpoints in this controller are GETs
+/// — no mutations live here. The <see cref="SkipRationaleCheckAttribute"/>
+/// is therefore unnecessary, but the rationale filter
+/// short-circuits on GET anyway.
+/// </para>
+/// </remarks>
+[ApiController]
+[Authorize]
+[Route("api/audit")]
+[Produces("application/json")]
+[Tags("Audit")]
+public sealed class AuditController : ControllerBase
+{
+    private readonly IAuditChain _chain;
+
+    public AuditController(IAuditChain chain)
+    {
+        _chain = chain;
+    }
+
+    /// <summary>
+    /// Verifies the catalog audit hash chain, optionally bounded
+    /// to a <c>[fromSeq, toSeq]</c> range. Divergence is
+    /// reported as <c>{ valid: false, firstDivergenceSeq: N }</c>
+    /// in the body (HTTP 200) — divergence is a legitimate
+    /// queryable state, not an HTTP error.
+    /// </summary>
+    /// <param name="fromSeq">Inclusive lower bound. Defaults to
+    /// 1 when omitted.</param>
+    /// <param name="toSeq">Inclusive upper bound. Defaults to
+    /// MAX(seq) when omitted.</param>
+    /// <param name="ct">Request cancellation token.</param>
+    /// <response code="200">Verification result. <c>valid</c>
+    /// may be true or false; <c>firstDivergenceSeq</c> is
+    /// non-null only when <c>valid</c> is false.</response>
+    /// <response code="400">When <c>fromSeq</c> &gt;
+    /// <c>toSeq</c>, or either is &lt; 1.</response>
+    /// <response code="401">Caller is unauthenticated.</response>
+    /// <response code="403">Caller lacks the
+    /// <c>andy-policies:audit:verify</c> permission (P7.2).</response>
+    [HttpGet("verify")]
+    [ProducesResponseType(typeof(ChainVerificationDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult<ChainVerificationDto>> Verify(
+        [FromQuery] long? fromSeq,
+        [FromQuery] long? toSeq,
+        CancellationToken ct)
+    {
+        if (fromSeq is < 1)
+        {
+            return BadRequestRange("fromSeq must be >= 1.");
+        }
+        if (toSeq is < 1)
+        {
+            return BadRequestRange("toSeq must be >= 1.");
+        }
+        if (fromSeq is { } f && toSeq is { } t && f > t)
+        {
+            return BadRequestRange($"fromSeq ({f}) must be <= toSeq ({t}).");
+        }
+
+        var result = await _chain.VerifyChainAsync(fromSeq, toSeq, ct);
+        return Ok(new ChainVerificationDto(
+            result.Valid,
+            result.FirstDivergenceSeq,
+            result.InspectedCount,
+            result.LastSeq));
+    }
+
+    private ActionResult<ChainVerificationDto> BadRequestRange(string detail)
+    {
+        var problem = new ProblemDetails
+        {
+            Status = StatusCodes.Status400BadRequest,
+            Title = "Invalid verification range",
+            Detail = detail,
+            Type = "/problems/audit-verify-range",
+            Instance = HttpContext.Request.Path,
+            Extensions = { ["errorCode"] = "audit.verify.invalid_range" },
+        };
+        return BadRequest(problem);
+    }
+}

--- a/src/Andy.Policies.Application/Dtos/ChainVerificationDto.cs
+++ b/src/Andy.Policies.Application/Dtos/ChainVerificationDto.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.Dtos;
+
+/// <summary>
+/// Wire-format projection of
+/// <see cref="Interfaces.ChainVerificationResult"/> (P6.5, story
+/// rivoli-ai/andy-policies#45). Returned by
+/// <c>GET /api/audit/verify</c> and the corresponding MCP /
+/// gRPC surfaces.
+/// </summary>
+/// <param name="Valid">True when the inspected range is
+/// internally consistent — every row's <c>PrevHash</c> matches
+/// the previous row's computed hash, and every row's <c>Hash</c>
+/// matches the recomputed SHA-256.</param>
+/// <param name="FirstDivergenceSeq">When <see cref="Valid"/> is
+/// false, the <c>Seq</c> of the first row whose hashes don't
+/// line up. Null on a valid chain.</param>
+/// <param name="InspectedCount">Number of rows the verifier
+/// walked.</param>
+/// <param name="LastSeq">Largest <c>Seq</c> observed by the
+/// verifier (i.e. the right end of the inspected range, or 0
+/// when the chain is empty).</param>
+public sealed record ChainVerificationDto(
+    bool Valid,
+    long? FirstDivergenceSeq,
+    long InspectedCount,
+    long LastSeq);

--- a/src/Andy.Policies.Infrastructure/Andy.Policies.Infrastructure.csproj
+++ b/src/Andy.Policies.Infrastructure/Andy.Policies.Infrastructure.csproj
@@ -7,6 +7,11 @@
   <ItemGroup>
     <ProjectReference Include="..\Andy.Policies.Application\Andy.Policies.Application.csproj" />
     <ProjectReference Include="..\Andy.Policies.Domain\Andy.Policies.Domain.csproj" />
+    <!-- P6.5 (#45): CanonicalJson + AuditEnvelopeHasher live in
+         Shared so the CLI's offline verifier can compute identical
+         hashes without an EF / Npgsql dependency. Application
+         already references Shared transitively via DTOs. -->
+    <ProjectReference Include="..\Andy.Policies.Shared\Andy.Policies.Shared.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Andy.Policies.Infrastructure/Audit/AuditChain.cs
+++ b/src/Andy.Policies.Infrastructure/Audit/AuditChain.cs
@@ -2,15 +2,12 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Data;
-using System.Globalization;
-using System.Security.Cryptography;
-using System.Text.Json;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Domain.Entities;
 using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Shared.Auditing;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Andy.Policies.Infrastructure.Audit;
 
@@ -168,7 +165,7 @@ public sealed class AuditChain : IAuditChain
         var id = Guid.NewGuid();
         var timestamp = _clock.GetUtcNow();
         var roles = request.ActorRoles.ToArray();
-        var hash = ComputeHash(
+        var hash = AuditEnvelopeHasher.ComputeHash(
             prevHash,
             id,
             timestamp,
@@ -252,7 +249,7 @@ public sealed class AuditChain : IAuditChain
                 return new ChainVerificationResult(false, row.Seq, inspected, lastSeq);
             }
 
-            var recomputed = ComputeHash(
+            var recomputed = AuditEnvelopeHasher.ComputeHash(
                 prev,
                 row.Id,
                 row.Timestamp,
@@ -272,77 +269,6 @@ public sealed class AuditChain : IAuditChain
         }
 
         return new ChainVerificationResult(true, null, inspected, lastSeq);
-    }
-
-    /// <summary>
-    /// Computes <c>SHA-256(prevHash || canonicalJson(payload))</c>
-    /// where <c>payload</c> is the closed audit envelope. Public
-    /// so unit tests can pin golden vectors without going through
-    /// the full append path.
-    /// </summary>
-    public static byte[] ComputeHash(
-        byte[] prevHash,
-        Guid id,
-        DateTimeOffset timestamp,
-        string actorSubjectId,
-        IReadOnlyList<string> actorRoles,
-        string action,
-        string entityType,
-        string entityId,
-        string fieldDiffJson,
-        string? rationale)
-    {
-        // Embed the patch document as parsed JSON, not as a string —
-        // serialising it as a string would re-quote and miss the
-        // canonicalisation. JsonDocument must be wrapped in `using`
-        // to keep the underlying buffer alive while we read.
-        using var diffDoc = JsonDocument.Parse(string.IsNullOrEmpty(fieldDiffJson) ? "[]" : fieldDiffJson);
-
-        // Build the envelope as an in-memory JSON tree so
-        // CanonicalJson sorts keys and writes deterministic bytes.
-        using var stream = new MemoryStream();
-        using (var writer = new Utf8JsonWriter(stream))
-        {
-            writer.WriteStartObject();
-            writer.WriteString("action", action);
-            writer.WritePropertyName("actorRoles");
-            writer.WriteStartArray();
-            // Sort actorRoles lex order so insertion order doesn't
-            // change the hash. The canonicaliser also preserves
-            // array order, but pre-sorting bakes the contract into
-            // the input itself.
-            foreach (var r in actorRoles.OrderBy(s => s, StringComparer.Ordinal))
-            {
-                writer.WriteStringValue(r);
-            }
-            writer.WriteEndArray();
-            writer.WriteString("actorSubjectId", actorSubjectId);
-            writer.WriteString("entityId", entityId);
-            writer.WriteString("entityType", entityType);
-            writer.WritePropertyName("fieldDiff");
-            diffDoc.RootElement.WriteTo(writer);
-            writer.WriteString("id", id.ToString());
-            if (rationale is null)
-            {
-                writer.WriteNull("rationale");
-            }
-            else
-            {
-                writer.WriteString("rationale", rationale);
-            }
-            writer.WriteString("timestamp",
-                timestamp.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture));
-            writer.WriteEndObject();
-        }
-        stream.Position = 0;
-        using var doc = JsonDocument.Parse(stream);
-        var canonical = CanonicalJson.Serialize(doc.RootElement);
-
-        // SHA-256 of (prevHash || canonical).
-        using var sha = SHA256.Create();
-        sha.TransformBlock(prevHash, 0, prevHash.Length, null, 0);
-        sha.TransformFinalBlock(canonical, 0, canonical.Length);
-        return sha.Hash!;
     }
 
     private static bool ByteEquals(byte[] a, byte[] b)

--- a/src/Andy.Policies.Shared/Auditing/AuditEnvelopeHasher.cs
+++ b/src/Andy.Policies.Shared/Auditing/AuditEnvelopeHasher.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace Andy.Policies.Shared.Auditing;
+
+/// <summary>
+/// Pure SHA-256 hasher for the audit envelope (P6.2 chain
+/// linkage; P6.5 offline verification). Lives in Shared so the
+/// CLI's offline verifier (P6.5) and the Infrastructure
+/// <c>AuditChain</c> writer compute identical hashes for
+/// identical inputs — without the CLI inheriting an EF / Npgsql
+/// dependency.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Envelope shape.</b> The canonicalised JSON is the closed
+/// catalog audit envelope: <c>action</c>, <c>actorRoles</c> (sorted
+/// lex order), <c>actorSubjectId</c>, <c>entityId</c>,
+/// <c>entityType</c>, <c>fieldDiff</c> (parsed JSON, not a string),
+/// <c>id</c>, <c>rationale</c> (null permitted), <c>timestamp</c>
+/// (ISO 8601 with millisecond precision, always UTC). The
+/// canonicaliser sorts keys lex order at every level; any
+/// re-shaping of this envelope must be paired with a chain-
+/// migration story (today there is none — the chain is append-only
+/// and the schema is pinned).
+/// </para>
+/// <para>
+/// <b>Genesis.</b> The first row's <c>prevHash</c> is 32 zero
+/// bytes. Both the writer (AuditChain.AppendCoreAsync) and the
+/// offline verifier seed the chain with that constant.
+/// </para>
+/// </remarks>
+public static class AuditEnvelopeHasher
+{
+    /// <summary>
+    /// Computes <c>SHA-256(prevHash || canonicalJson(envelope))</c>.
+    /// </summary>
+    /// <param name="prevHash">32-byte SHA-256 of the previous
+    /// row's hash (or 32 zero bytes for genesis).</param>
+    /// <param name="id">The event's stable random GUID.</param>
+    /// <param name="timestamp">UTC instant the event was
+    /// written; serialised at millisecond precision.</param>
+    /// <param name="actorSubjectId">JWT <c>sub</c> claim of the
+    /// actor.</param>
+    /// <param name="actorRoles">RBAC roles snapshot. Sorted lex
+    /// order before hashing so iteration order doesn't change
+    /// the hash.</param>
+    /// <param name="action">Dotted action code.</param>
+    /// <param name="entityType">Canonical type of the mutated
+    /// entity.</param>
+    /// <param name="entityId">String form of the mutated row's
+    /// primary key.</param>
+    /// <param name="fieldDiffJson">RFC 6902 JSON Patch document.
+    /// Embedded as parsed JSON (not as a string) so canonical
+    /// re-serialisation kicks in.</param>
+    /// <param name="rationale">Free-text rationale; null is
+    /// permitted (the rationale-required toggle is enforced
+    /// elsewhere).</param>
+    /// <returns>32-byte SHA-256 output.</returns>
+    public static byte[] ComputeHash(
+        byte[] prevHash,
+        Guid id,
+        DateTimeOffset timestamp,
+        string actorSubjectId,
+        IReadOnlyList<string> actorRoles,
+        string action,
+        string entityType,
+        string entityId,
+        string fieldDiffJson,
+        string? rationale)
+    {
+        using var diffDoc = JsonDocument.Parse(string.IsNullOrEmpty(fieldDiffJson) ? "[]" : fieldDiffJson);
+
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("action", action);
+            writer.WritePropertyName("actorRoles");
+            writer.WriteStartArray();
+            foreach (var r in actorRoles.OrderBy(s => s, StringComparer.Ordinal))
+            {
+                writer.WriteStringValue(r);
+            }
+            writer.WriteEndArray();
+            writer.WriteString("actorSubjectId", actorSubjectId);
+            writer.WriteString("entityId", entityId);
+            writer.WriteString("entityType", entityType);
+            writer.WritePropertyName("fieldDiff");
+            diffDoc.RootElement.WriteTo(writer);
+            writer.WriteString("id", id.ToString());
+            if (rationale is null)
+            {
+                writer.WriteNull("rationale");
+            }
+            else
+            {
+                writer.WriteString("rationale", rationale);
+            }
+            writer.WriteString("timestamp",
+                timestamp.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture));
+            writer.WriteEndObject();
+        }
+        stream.Position = 0;
+        using var doc = JsonDocument.Parse(stream);
+        var canonical = CanonicalJson.Serialize(doc.RootElement);
+
+        using var sha = SHA256.Create();
+        sha.TransformBlock(prevHash, 0, prevHash.Length, null, 0);
+        sha.TransformFinalBlock(canonical, 0, canonical.Length);
+        return sha.Hash!;
+    }
+}

--- a/src/Andy.Policies.Shared/Auditing/CanonicalJson.cs
+++ b/src/Andy.Policies.Shared/Auditing/CanonicalJson.cs
@@ -5,7 +5,7 @@ using System.Buffers;
 using System.Text;
 using System.Text.Json;
 
-namespace Andy.Policies.Infrastructure.Audit;
+namespace Andy.Policies.Shared.Auditing;
 
 /// <summary>
 /// Canonical JSON serializer for the audit hash envelope (P6.2,
@@ -33,7 +33,7 @@ namespace Andy.Policies.Infrastructure.Audit;
 /// fixtures we control. ADR 0006 documents the trade-off.
 /// </para>
 /// </remarks>
-internal static class CanonicalJson
+public static class CanonicalJson
 {
     /// <summary>
     /// Serialise a <see cref="JsonElement"/> graph to the canonical

--- a/tests/Andy.Policies.Tests.Integration/Audit/AuditVerifyEndpointTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Audit/AuditVerifyEndpointTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Json;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Tests.Integration.Controllers;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Audit;
+
+/// <summary>
+/// P6.5 (#45) — exercises <c>GET /api/audit/verify</c> over
+/// the SQLite-backed factory. Asserts the contract pinned by
+/// the issue: 200 with <see cref="ChainVerificationDto"/> on
+/// success (regardless of <c>valid</c>), 400 on bad range, and
+/// 401 unauthenticated.
+/// </summary>
+public class AuditVerifyEndpointTests : IClassFixture<PoliciesApiFactory>
+{
+    private readonly PoliciesApiFactory _factory;
+    private readonly HttpClient _client;
+
+    public AuditVerifyEndpointTests(PoliciesApiFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    private async Task<int> SeedEventsAsync(int count)
+    {
+        // Drive the chain via IAuditChain.AppendAsync directly so
+        // the tests don't depend on which mutating service has
+        // been wired up to write audit rows. P6.6 lands the
+        // catalog-mutation -> audit-row plumbing for the listed
+        // services; for now the chain is the only writer.
+        using var scope = _factory.Services.CreateScope();
+        var chain = scope.ServiceProvider.GetRequiredService<IAuditChain>();
+        for (var i = 1; i <= count; i++)
+        {
+            await chain.AppendAsync(new AuditAppendRequest(
+                Action: "policy.update",
+                EntityType: "Policy",
+                EntityId: $"00000000-0000-0000-0000-{i:D12}",
+                FieldDiffJson: $"[{{\"op\":\"replace\",\"path\":\"/n\",\"value\":{i}}}]",
+                Rationale: $"event #{i}",
+                ActorSubjectId: "user:test",
+                ActorRoles: new[] { "admin" }), CancellationToken.None);
+        }
+        return count;
+    }
+
+    [Fact]
+    public async Task Verify_FullChain_Returns200WithValid()
+    {
+        await SeedEventsAsync(5);
+
+        var resp = await _client.GetAsync("/api/audit/verify");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await resp.Content.ReadFromJsonAsync<ChainVerificationDto>();
+        dto!.Valid.Should().BeTrue();
+        dto.FirstDivergenceSeq.Should().BeNull();
+        dto.InspectedCount.Should().BeGreaterOrEqualTo(5);
+        dto.LastSeq.Should().BeGreaterOrEqualTo(5);
+    }
+
+    [Fact]
+    public async Task Verify_BoundedRange_HonorsFromAndTo()
+    {
+        // Fill the chain enough that we have a [from, to] range
+        // strictly inside the chain. The factory is shared across
+        // tests in the class so the chain may already have rows
+        // from earlier; we read LastSeq first and chain-extend
+        // from there.
+        var firstResp = await _client.GetAsync("/api/audit/verify");
+        var initial = await firstResp.Content.ReadFromJsonAsync<ChainVerificationDto>();
+        var baseline = initial!.LastSeq;
+        await SeedEventsAsync(5);
+
+        var lower = baseline + 2;
+        var upper = baseline + 4;
+
+        var resp = await _client.GetAsync($"/api/audit/verify?fromSeq={lower}&toSeq={upper}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await resp.Content.ReadFromJsonAsync<ChainVerificationDto>();
+        dto!.Valid.Should().BeTrue();
+        dto.InspectedCount.Should().Be(3, "fromSeq=baseline+2, toSeq=baseline+4 → 3 rows");
+        dto.LastSeq.Should().Be(upper);
+    }
+
+    [Fact]
+    public async Task Verify_FromGreaterThanTo_Returns400()
+    {
+        var resp = await _client.GetAsync("/api/audit/verify?fromSeq=10&toSeq=5");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var problem = await resp.Content.ReadFromJsonAsync<System.Text.Json.JsonElement>();
+        problem.GetProperty("type").GetString().Should().Be("/problems/audit-verify-range");
+        problem.GetProperty("errorCode").GetString().Should().Be("audit.verify.invalid_range");
+    }
+
+    [Theory]
+    [InlineData("fromSeq=0")]
+    [InlineData("fromSeq=-1")]
+    [InlineData("toSeq=0")]
+    public async Task Verify_NonPositiveBounds_Returns400(string queryString)
+    {
+        var resp = await _client.GetAsync($"/api/audit/verify?{queryString}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Verify_EmptyChain_ReturnsValidWithZeroCounts()
+    {
+        // Fresh factory so the chain is empty.
+        await using var freshFactory = new PoliciesApiFactory();
+        var freshClient = freshFactory.CreateClient();
+
+        var resp = await freshClient.GetAsync("/api/audit/verify");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await resp.Content.ReadFromJsonAsync<ChainVerificationDto>();
+        dto!.Valid.Should().BeTrue();
+        dto.InspectedCount.Should().Be(0);
+        dto.LastSeq.Should().Be(0);
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Audit/AuditChainHashTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Audit/AuditChainHashTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-using Andy.Policies.Infrastructure.Audit;
+using Andy.Policies.Shared.Auditing;
 using FluentAssertions;
 using Xunit;
 
@@ -9,7 +9,7 @@ namespace Andy.Policies.Tests.Unit.Audit;
 
 /// <summary>
 /// P6.2 (#42) — golden-vector tests for
-/// <see cref="AuditChain.ComputeHash"/>. Pin a small set of
+/// <see cref="AuditEnvelopeHasher.ComputeHash"/>. Pin a small set of
 /// (prevHash, payload) → expected SHA-256 hex outputs so any
 /// change to the canonical-JSON envelope shape (key set, key
 /// names, ordering, timestamp format, etc.) becomes a noisy
@@ -23,7 +23,7 @@ public class AuditChainHashTests
     [Fact]
     public void GenesisHash_IsDeterministic_AcrossInvocations()
     {
-        var a = AuditChain.ComputeHash(
+        var a = AuditEnvelopeHasher.ComputeHash(
             Genesis32,
             id: Guid.Parse("11111111-1111-1111-1111-111111111111"),
             timestamp: new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero),
@@ -35,7 +35,7 @@ public class AuditChainHashTests
             fieldDiffJson: "[]",
             rationale: "first event");
 
-        var b = AuditChain.ComputeHash(
+        var b = AuditEnvelopeHasher.ComputeHash(
             Genesis32,
             id: Guid.Parse("11111111-1111-1111-1111-111111111111"),
             timestamp: new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero),
@@ -57,7 +57,7 @@ public class AuditChainHashTests
         // The hash must depend on something other than the
         // 32-zero-byte prevHash; a zeroed output would imply a bug
         // in the SHA-256 invocation or the canonical JSON pipeline.
-        var hash = AuditChain.ComputeHash(
+        var hash = AuditEnvelopeHasher.ComputeHash(
             Genesis32,
             id: Guid.NewGuid(),
             timestamp: DateTimeOffset.UtcNow,
@@ -89,11 +89,11 @@ public class AuditChainHashTests
             entityId = "00000000-0000-0000-0000-000000000002",
             fieldDiffJson = "[]",
         };
-        var withFoo = AuditChain.ComputeHash(
+        var withFoo = AuditEnvelopeHasher.ComputeHash(
             Genesis32, common.id, common.timestamp, common.actorSubjectId,
             common.actorRoles, common.action, common.entityType, common.entityId,
             common.fieldDiffJson, "rationale foo");
-        var withBar = AuditChain.ComputeHash(
+        var withBar = AuditEnvelopeHasher.ComputeHash(
             Genesis32, common.id, common.timestamp, common.actorSubjectId,
             common.actorRoles, common.action, common.entityType, common.entityId,
             common.fieldDiffJson, "rationale bar");
@@ -113,11 +113,11 @@ public class AuditChainHashTests
             id = Guid.Parse("33333333-3333-3333-3333-333333333333"),
             timestamp = new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero),
         };
-        var alpha = AuditChain.ComputeHash(
+        var alpha = AuditEnvelopeHasher.ComputeHash(
             Genesis32, common.id, common.timestamp, "user:test",
             new[] { "admin", "author" }, "policy.update", "Policy",
             "00000000-0000-0000-0000-000000000003", "[]", null);
-        var omega = AuditChain.ComputeHash(
+        var omega = AuditEnvelopeHasher.ComputeHash(
             Genesis32, common.id, common.timestamp, "user:test",
             new[] { "author", "admin" }, "policy.update", "Policy",
             "00000000-0000-0000-0000-000000000003", "[]", null);
@@ -131,11 +131,11 @@ public class AuditChainHashTests
         // The chain treats string.Empty / null / "[]" as the same
         // empty-patch payload. The hash output must be identical
         // for all three.
-        var withExplicit = AuditChain.ComputeHash(
+        var withExplicit = AuditEnvelopeHasher.ComputeHash(
             Genesis32, Guid.Empty,
             new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
             "u", new[] { "r" }, "a", "Policy", "id", "[]", null);
-        var withWhitespace = AuditChain.ComputeHash(
+        var withWhitespace = AuditEnvelopeHasher.ComputeHash(
             Genesis32, Guid.Empty,
             new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
             "u", new[] { "r" }, "a", "Policy", "id", "  []  ", null);
@@ -151,15 +151,15 @@ public class AuditChainHashTests
         // Compute three hashes in sequence: each row's prevHash
         // equals the previous row's hash. Verifies the linking
         // contract that drives VerifyChainAsync.
-        var h1 = AuditChain.ComputeHash(
+        var h1 = AuditEnvelopeHasher.ComputeHash(
             Genesis32, Guid.Parse("00000000-0000-0000-0000-000000000001"),
             new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero),
             "u1", new[] { "r" }, "policy.create", "Policy", "p1", "[]", null);
-        var h2 = AuditChain.ComputeHash(
+        var h2 = AuditEnvelopeHasher.ComputeHash(
             h1, Guid.Parse("00000000-0000-0000-0000-000000000002"),
             new DateTimeOffset(2026, 5, 1, 12, 0, 1, TimeSpan.Zero),
             "u2", new[] { "r" }, "policy.update", "Policy", "p1", "[]", null);
-        var h3 = AuditChain.ComputeHash(
+        var h3 = AuditEnvelopeHasher.ComputeHash(
             h2, Guid.Parse("00000000-0000-0000-0000-000000000003"),
             new DateTimeOffset(2026, 5, 1, 12, 0, 2, TimeSpan.Zero),
             "u1", new[] { "r" }, "policy.publish", "Policy", "p1", "[]", null);
@@ -181,9 +181,9 @@ public class AuditChainHashTests
             .AddTicks(4567);
         var t2 = new DateTimeOffset(2026, 5, 1, 12, 0, 0, 123, TimeSpan.Zero);
 
-        var h1 = AuditChain.ComputeHash(
+        var h1 = AuditEnvelopeHasher.ComputeHash(
             Genesis32, Guid.Empty, t1, "u", new[] { "r" }, "a", "T", "id", "[]", null);
-        var h2 = AuditChain.ComputeHash(
+        var h2 = AuditEnvelopeHasher.ComputeHash(
             Genesis32, Guid.Empty, t2, "u", new[] { "r" }, "a", "T", "id", "[]", null);
 
         h1.Should().Equal(h2);

--- a/tests/Andy.Policies.Tests.Unit/Audit/CanonicalJsonTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Audit/CanonicalJsonTests.cs
@@ -3,7 +3,7 @@
 
 using System.Text;
 using System.Text.Json;
-using Andy.Policies.Infrastructure.Audit;
+using Andy.Policies.Shared.Auditing;
 using FluentAssertions;
 using Xunit;
 

--- a/tests/Andy.Policies.Tests.Unit/Cli/AuditCommandsTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Cli/AuditCommandsTests.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.CommandLine;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Andy.Policies.Cli.Commands;
+using Andy.Policies.Shared.Auditing;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Cli;
+
+/// <summary>
+/// P6.5 (#45) — command-tree shape + offline-verification
+/// behaviour for <see cref="AuditCommands"/>. The live-mode
+/// path is exercised by the integration suite (it needs a real
+/// HttpClient against the test server); these tests cover the
+/// pure offline NDJSON verifier and the option set.
+/// </summary>
+public class AuditCommandsTests
+{
+    private static Command BuildAuditRoot()
+    {
+        var apiUrl = new Option<string>("--api-url", () => "https://test");
+        var token = new Option<string?>("--token");
+        var output = new Option<string>("--output", () => "table");
+        var root = new Command("audit", "Inspect the catalog audit chain");
+        AuditCommands.Register(root, apiUrl, token, output);
+        return root;
+    }
+
+    [Fact]
+    public void Audit_RegistersVerifySubcommand()
+    {
+        var root = BuildAuditRoot();
+        root.Subcommands.Select(c => c.Name).Should().Contain("verify");
+    }
+
+    [Fact]
+    public void Verify_HasFromToFileOptions_NoneRequired()
+    {
+        var root = BuildAuditRoot();
+        var verify = root.Subcommands.First(c => c.Name == "verify");
+
+        verify.Options.Select(o => o.Name).Should().Contain(new[] { "from", "to", "file" });
+        verify.Options.Where(o => o.IsRequired).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Verify_OfflineFile_NotFound_ExitCode2()
+    {
+        var rootCmd = BuildAuditRoot();
+        // System.CommandLine returns exit code 2 by convention for
+        // failed file-binding/argument errors. We invoke with a
+        // non-existent path that's *valid* as a path string so the
+        // command handler runs (FileInfo doesn't fail to bind on
+        // missing files); the handler emits its own message.
+        var nonexistent = Path.Combine(Path.GetTempPath(), $"never-{Guid.NewGuid():n}.ndjson");
+        var result = await rootCmd.InvokeAsync(new[] { "verify", "--file", nonexistent });
+        result.Should().Be(2 /* ExitCodes.BadArguments */);
+    }
+
+    [Fact]
+    public async Task Verify_OfflineFile_ValidChain_ExitCode0()
+    {
+        // Build a valid 3-event chain to disk via the same hasher
+        // the production code uses, then verify offline.
+        var path = WriteTempChain(3, tamperAt: null);
+        try
+        {
+            var rootCmd = BuildAuditRoot();
+            var result = await rootCmd.InvokeAsync(new[] { "verify", "--file", path });
+            result.Should().Be(0 /* ExitCodes.Success */);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task Verify_OfflineFile_TamperedChain_ExitCode6()
+    {
+        // Tamper with row 2's hash byte; the verifier must report
+        // divergence and exit 6 (AuditDivergence).
+        var path = WriteTempChain(5, tamperAt: 2);
+        try
+        {
+            var rootCmd = BuildAuditRoot();
+            var result = await rootCmd.InvokeAsync(new[] { "verify", "--file", path });
+            result.Should().Be(6 /* ExitCodes.AuditDivergence */);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task Verify_OfflineFile_BoundedRange_RespectsFromTo()
+    {
+        var path = WriteTempChain(5, tamperAt: null);
+        try
+        {
+            var rootCmd = BuildAuditRoot();
+            var result = await rootCmd.InvokeAsync(new[]
+            {
+                "verify", "--file", path, "--from", "2", "--to", "4",
+            });
+            result.Should().Be(0 /* ExitCodes.Success */);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// Materialises a <paramref name="count"/>-event NDJSON chain on disk
+    /// using the production hasher; optionally flips a single byte of the
+    /// hash at <paramref name="tamperAt"/> (1-indexed seq).
+    /// </summary>
+    private static string WriteTempChain(int count, long? tamperAt)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"audit-{Guid.NewGuid():n}.ndjson");
+        var sb = new StringBuilder();
+        var prev = new byte[32];
+        for (var i = 1; i <= count; i++)
+        {
+            var id = Guid.Parse($"00000000-0000-0000-0000-{i:D12}");
+            var ts = new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero).AddSeconds(i);
+            var hash = AuditEnvelopeHasher.ComputeHash(
+                prev, id, ts, "user:test", new[] { "admin" }, "policy.update",
+                "Policy", $"00000000-0000-0000-0000-{i:D12}", "[]", $"event #{i}");
+
+            var hashHex = Convert.ToHexString(hash).ToLowerInvariant();
+            if (tamperAt is { } t && t == i)
+            {
+                // Flip the first byte of the hash hex so the reader
+                // sees a divergent stored hash. The chain is otherwise
+                // pristine — VerifyChain should pinpoint this seq.
+                var bytes = Convert.FromHexString(hashHex);
+                bytes[0] ^= 0xFF;
+                hashHex = Convert.ToHexString(bytes).ToLowerInvariant();
+            }
+
+            var dto = new
+            {
+                id,
+                seq = (long)i,
+                prevHashHex = Convert.ToHexString(prev).ToLowerInvariant(),
+                hashHex,
+                timestamp = ts,
+                actorSubjectId = "user:test",
+                actorRoles = new[] { "admin" },
+                action = "policy.update",
+                entityType = "Policy",
+                entityId = $"00000000-0000-0000-0000-{i:D12}",
+                fieldDiffJson = "[]",
+                rationale = $"event #{i}",
+            };
+            sb.AppendLine(JsonSerializer.Serialize(dto, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
+            prev = hash;
+        }
+        File.WriteAllText(path, sb.ToString());
+        return path;
+    }
+}

--- a/tools/Andy.Policies.Cli/Andy.Policies.Cli.csproj
+++ b/tools/Andy.Policies.Cli/Andy.Policies.Cli.csproj
@@ -11,6 +11,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- P6.5 (#45): the offline mode of `audit verify` re-computes
+         hashes against an NDJSON export. Shared exposes the
+         CanonicalJson + AuditEnvelopeHasher pure helpers so the
+         CLI inherits no EF / Npgsql dependency. -->
+    <ProjectReference Include="..\..\src\Andy.Policies.Shared\Andy.Policies.Shared.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="Andy.Policies.Tests.Unit" />
     <!-- P2.7 (#17): integration tests drive the CLI command tree against a
          WebApplicationFactory<Program>, swapping the production HttpClient

--- a/tools/Andy.Policies.Cli/Commands/AuditCommands.cs
+++ b/tools/Andy.Policies.Cli/Commands/AuditCommands.cs
@@ -1,0 +1,211 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.CommandLine;
+using System.Globalization;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Andy.Policies.Cli.Http;
+using Andy.Policies.Cli.Output;
+using Andy.Policies.Shared.Auditing;
+
+namespace Andy.Policies.Cli.Commands;
+
+/// <summary>
+/// <c>andy-policies-cli audit verify [--from N] [--to N] [--file path]</c>
+/// (P6.5, story rivoli-ai/andy-policies#45). Two modes:
+/// <list type="bullet">
+///   <item><b>Live</b> — hits <c>GET /api/audit/verify</c> on
+///     the configured server. The user's bearer token (via
+///     <c>--token</c> or <c>ANDY_CLI_TOKEN</c>) is forwarded.</item>
+///   <item><b>Offline</b> — reads an NDJSON export of audit
+///     events (one <c>AuditEventDto</c> per line) and re-runs
+///     the chain verifier locally using the Shared
+///     <c>AuditEnvelopeHasher</c>. Required for external
+///     auditors handed an archival copy.</item>
+/// </list>
+/// Online and offline verification on the same inputs produce
+/// identical results — the canonical JSON serialiser and SHA-256
+/// helper are the same code on both sides.
+/// </summary>
+internal static class AuditCommands
+{
+    private static readonly JsonSerializerOptions NdjsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    public static void Register(
+        Command parent,
+        Option<string> apiUrlOption,
+        Option<string?> tokenOption,
+        Option<string> outputOption)
+    {
+        parent.AddCommand(BuildVerify(apiUrlOption, tokenOption, outputOption));
+    }
+
+    private static Command BuildVerify(Option<string> apiUrl, Option<string?> token, Option<string> output)
+    {
+        var command = new Command("verify", "Verify the audit hash chain.");
+        var fromOpt = new Option<long?>(
+            aliases: new[] { "--from" },
+            description: "Inclusive lower seq bound. Defaults to 1.");
+        var toOpt = new Option<long?>(
+            aliases: new[] { "--to" },
+            description: "Inclusive upper seq bound. Defaults to MAX(seq).");
+        var fileOpt = new Option<FileInfo?>(
+            aliases: new[] { "--file" },
+            description: "Path to an NDJSON export (one AuditEventDto per line). " +
+                         "When supplied, verification is offline and the API is not contacted.");
+        command.AddOption(fromOpt);
+        command.AddOption(toOpt);
+        command.AddOption(fileOpt);
+
+        command.SetHandler(async ctx =>
+        {
+            var api = ctx.ParseResult.GetValueForOption(apiUrl)!;
+            var tok = ctx.ParseResult.GetValueForOption(token);
+            var fmt = ctx.ParseResult.GetValueForOption(output) ?? "table";
+            var from = ctx.ParseResult.GetValueForOption(fromOpt);
+            var to = ctx.ParseResult.GetValueForOption(toOpt);
+            var file = ctx.ParseResult.GetValueForOption(fileOpt);
+            var ct = ctx.GetCancellationToken();
+
+            ctx.ExitCode = file is null
+                ? await VerifyLiveAsync(api, tok, fmt, from, to, ct).ConfigureAwait(false)
+                : await VerifyOfflineAsync(file, fmt, from, to, ct).ConfigureAwait(false);
+        });
+        return command;
+    }
+
+    private static async Task<int> VerifyLiveAsync(
+        string api, string? token, string format, long? from, long? to, CancellationToken ct)
+    {
+        using var http = ClientFactory.Create(api, token);
+        var qs = Querystring.Build(
+            ("fromSeq", from?.ToString(CultureInfo.InvariantCulture)),
+            ("toSeq", to?.ToString(CultureInfo.InvariantCulture)));
+        var resp = await http.GetAsync($"/api/audit/verify{qs}", ct).ConfigureAwait(false);
+        if (!resp.IsSuccessStatusCode)
+        {
+            return await ExitCodes.HandleAsync(resp, ct).ConfigureAwait(false);
+        }
+        var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        OutputRenderer.Write(body, format,
+            new[] { "valid", "firstDivergenceSeq", "inspectedCount", "lastSeq" });
+        // Exit non-zero on divergence so CI / cron jobs can branch.
+        var dto = JsonSerializer.Deserialize<VerifyDto>(body, NdjsonOptions);
+        return dto is { Valid: false } ? ExitCodes.AuditDivergence : ExitCodes.Success;
+    }
+
+    private static async Task<int> VerifyOfflineAsync(
+        FileInfo file, string format, long? from, long? to, CancellationToken ct)
+    {
+        if (!file.Exists)
+        {
+            await Console.Error.WriteLineAsync($"File not found: {file.FullName}").ConfigureAwait(false);
+            return ExitCodes.BadArguments;
+        }
+
+        var rows = new List<AuditEventNdjson>();
+        using (var stream = file.OpenRead())
+        using (var reader = new StreamReader(stream))
+        {
+            string? line;
+            while ((line = await reader.ReadLineAsync(ct).ConfigureAwait(false)) is not null)
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                var row = JsonSerializer.Deserialize<AuditEventNdjson>(line, NdjsonOptions)
+                    ?? throw new InvalidOperationException(
+                        $"Failed to deserialize NDJSON line: {line}");
+                rows.Add(row);
+            }
+        }
+        rows.Sort((a, b) => a.Seq.CompareTo(b.Seq));
+
+        var lower = from is { } f && f > 1 ? f : 1;
+        var prev = lower > 1
+            ? rows.Where(r => r.Seq == lower - 1)
+                  .Select(r => Convert.FromHexString(r.PrevHashHex))
+                  .FirstOrDefault() ?? new byte[32]
+            : new byte[32];
+        // Re-seat: when lower>1, prev should be the *hash* of (lower-1), not its prev.
+        if (lower > 1)
+        {
+            var seed = rows.FirstOrDefault(r => r.Seq == lower - 1);
+            prev = seed is null ? new byte[32] : Convert.FromHexString(seed.HashHex);
+            if (seed is null)
+            {
+                var unverifiable = new VerifyDto(false, lower, 0, 0);
+                Render(unverifiable, format);
+                return ExitCodes.AuditDivergence;
+            }
+        }
+
+        long inspected = 0;
+        long lastSeq = lower > 1 ? lower - 1 : 0;
+        foreach (var row in rows.Where(r => r.Seq >= lower).Where(r => to is not { } t || r.Seq <= t))
+        {
+            inspected++;
+            lastSeq = row.Seq;
+
+            var rowPrev = Convert.FromHexString(row.PrevHashHex);
+            if (!rowPrev.AsSpan().SequenceEqual(prev))
+            {
+                Render(new VerifyDto(false, row.Seq, inspected, lastSeq), format);
+                return ExitCodes.AuditDivergence;
+            }
+
+            var recomputed = AuditEnvelopeHasher.ComputeHash(
+                prev,
+                row.Id,
+                row.Timestamp,
+                row.ActorSubjectId,
+                row.ActorRoles,
+                row.Action,
+                row.EntityType,
+                row.EntityId,
+                row.FieldDiffJson,
+                row.Rationale);
+            var rowHash = Convert.FromHexString(row.HashHex);
+            if (!recomputed.AsSpan().SequenceEqual(rowHash))
+            {
+                Render(new VerifyDto(false, row.Seq, inspected, lastSeq), format);
+                return ExitCodes.AuditDivergence;
+            }
+
+            prev = rowHash;
+        }
+
+        Render(new VerifyDto(true, null, inspected, lastSeq), format);
+        return ExitCodes.Success;
+    }
+
+    private static void Render(VerifyDto dto, string format)
+    {
+        var json = JsonSerializer.Serialize(dto, NdjsonOptions);
+        OutputRenderer.Write(json, format,
+            new[] { "valid", "firstDivergenceSeq", "inspectedCount", "lastSeq" });
+    }
+
+    private sealed record VerifyDto(
+        bool Valid,
+        long? FirstDivergenceSeq,
+        long InspectedCount,
+        long LastSeq);
+
+    private sealed record AuditEventNdjson(
+        Guid Id,
+        long Seq,
+        string PrevHashHex,
+        string HashHex,
+        DateTimeOffset Timestamp,
+        string ActorSubjectId,
+        IReadOnlyList<string> ActorRoles,
+        string Action,
+        string EntityType,
+        string EntityId,
+        string FieldDiffJson,
+        string? Rationale);
+}

--- a/tools/Andy.Policies.Cli/Output/ExitCodes.cs
+++ b/tools/Andy.Policies.Cli/Output/ExitCodes.cs
@@ -18,6 +18,12 @@ internal static class ExitCodes
     public const int Auth = 3;
     public const int NotFound = 4;
     public const int Conflict = 5;
+    /// <summary>P6.5 (#45) — chain divergence detected. Distinct
+    /// from <see cref="Transport"/> so cron jobs can branch on
+    /// "the chain itself is broken" vs. "the API is unreachable."
+    /// Audit-export tooling treats <c>6</c> as the canonical
+    /// "chain integrity failed" signal.</summary>
+    public const int AuditDivergence = 6;
 
     public static int FromStatus(HttpStatusCode status) => status switch
     {

--- a/tools/Andy.Policies.Cli/Program.cs
+++ b/tools/Andy.Policies.Cli/Program.cs
@@ -72,6 +72,10 @@ internal static class Program
         OverrideCommands.Register(overridesCommand, apiUrlOption, tokenOption, outputOption);
         rootCommand.AddCommand(overridesCommand);
 
+        var auditCommand = new Command("audit", "Inspect the catalog audit chain");
+        AuditCommands.Register(auditCommand, apiUrlOption, tokenOption, outputOption);
+        rootCommand.AddCommand(auditCommand);
+
         return await rootCommand.InvokeAsync(args);
     }
 }


### PR DESCRIPTION
## Summary

Surfaces \`IAuditChain.VerifyChainAsync\` over REST + CLI (P6.5). The CLI ships both **live** and **offline** modes; offline parses an NDJSON export and re-runs the chain verifier locally for external auditors handed an archival copy.

## REST

\`GET /api/audit/verify?fromSeq=&toSeq=\` returns 200 with \`ChainVerificationDto\` (\`{ valid, firstDivergenceSeq, inspectedCount, lastSeq }\`) regardless of outcome — divergence is a queryable state, not an HTTP error. 400 ProblemDetails (\`type=/problems/audit-verify-range\`, \`errorCode=audit.verify.invalid_range\`) on \`fromSeq > toSeq\` or non-positive bounds.

## CLI

\`\`\`bash
andy-policies-cli audit verify --from 1 --to 10000        # live
andy-policies-cli audit verify --file ./export.ndjson    # offline
\`\`\`

| Exit code | Meaning |
|---|---|
| 0 | Chain valid |
| 1 | Transport / unexpected |
| 2 | Bad arguments / file not found |
| 3 | Auth |
| **6** | **AuditDivergence** — distinct from 1 so cron/CI can branch on "chain broken" vs "API unreachable" |

Live and offline produce byte-identical results because both use the same Shared \`CanonicalJson\` + \`AuditEnvelopeHasher\`.

## Refactor: moved canonical-json + hasher to Shared

- \`Andy.Policies.Shared.Auditing.CanonicalJson\` — same algorithm, now \`public\` so the CLI can reach it without an EF / Npgsql dependency.
- \`Andy.Policies.Shared.Auditing.AuditEnvelopeHasher\` — pure static \`ComputeHash\` extracted from \`AuditChain\`. Both the live writer (\`AuditChain.AppendCoreAsync\` / \`VerifyChainAsync\`) and the CLI offline verifier consume it.
- \`AuditChain\` stays in Infrastructure; its old \`ComputeHash\` deleted (it now delegates).
- P6.2 tests updated to import the new namespace.

## Coverage

| Suite | Tests | Notes |
|---|---|---|
| Integration | 7 | Full chain valid; bounded range honors \`from+to\`; \`fromSeq>toSeq\` → 400; non-positive bounds → 400; empty chain → \`Valid=true\` with zero counts. |
| Unit (CLI) | 6 | Command-tree shape; non-existent file → \`ExitCodes.BadArguments\`; valid 3-event chain → exit 0; tampered chain (one byte flipped at \`seq=2\`) → exit 6 \`AuditDivergence\`; bounded range honored. |

Full unit (411) + integration (404, excl. Perf) suites green locally.

## Test plan

- [x] \`dotnet test tests/Andy.Policies.Tests.Unit\` — 411 passed
- [x] \`dotnet test tests/Andy.Policies.Tests.Integration --filter "Category!=Perf"\` — 404 passed
- [x] \`./scripts/export-openapi.sh\` — regenerated and committed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)