### PR TITLE
Implement P7.1 — RBAC permission catalog in registration.json (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,35 @@ andy-policies-cli audit verify [--from N] [--to M] [--file export.ndjson]
 andy-policies-cli audit export --out audit.ndjson
 ```
 
+## Edit RBAC
+
+Subject→permission evaluation delegates to [Andy RBAC](https://github.com/rivoli-ai/andy-rbac); the permission *vocabulary* lives here in [`config/registration.json`](config/registration.json) (`rbac` block) and is mirrored in [`config/rbac-seed.json`](config/rbac-seed.json) for direct seeding. andy-rbac upserts the application, resource types, permissions, and role↔permission edges from this manifest on first boot.
+
+### Permission catalog
+
+| Code | Resource | Held by |
+|---|---|---|
+| `andy-policies:policy:read`        | policy   | author, approver, risk, viewer |
+| `andy-policies:policy:author`      | policy   | author |
+| `andy-policies:policy:publish`     | policy   | approver |
+| `andy-policies:policy:transition`  | policy   | approver |
+| `andy-policies:binding:read`       | binding  | author, approver, risk, viewer |
+| `andy-policies:binding:manage`     | binding  | approver |
+| `andy-policies:scope:read`         | scope    | author, approver, risk, viewer |
+| `andy-policies:scope:manage`       | scope    | (admin only) |
+| `andy-policies:override:read`      | override | author, approver, risk, viewer |
+| `andy-policies:override:propose`   | override | author |
+| `andy-policies:override:approve`   | override | approver |
+| `andy-policies:override:revoke`    | override | approver |
+| `andy-policies:bundle:read`        | bundle   | author, approver, risk, viewer |
+| `andy-policies:bundle:create`      | bundle   | approver |
+| `andy-policies:bundle:delete`      | bundle   | (admin only) |
+| `andy-policies:audit:read`         | audit    | author, approver, risk |
+| `andy-policies:audit:export`       | audit    | risk |
+| `andy-policies:audit:verify`       | audit    | risk |
+
+`admin` holds the `*` wildcard. Authoritative source: `config/registration.json`. ADR 0007 (P7.7, [#65](https://github.com/rivoli-ai/andy-policies/issues/65)) covers the delegation choice and the self-approval invariant.
+
 ## Ports
 
 Per the ecosystem registry at [`../andy-service-template/docs/ports.md`](../andy-service-template/docs/ports.md). Three deployment modes; the same host can run any combination because each mode uses a distinct port range.

--- a/config/rbac-seed.json
+++ b/config/rbac-seed.json
@@ -1,0 +1,109 @@
+{
+  "applicationCode": "andy-policies",
+  "applicationName": "Andy Policies",
+  "description": "Governance policy catalog — structured, versioned policy documents with lifecycle and audit trail.",
+  "resourceTypes": [
+    { "code": "policy",   "name": "Policy",          "supportsInstances": true  },
+    { "code": "binding",  "name": "Policy Binding",  "supportsInstances": true  },
+    { "code": "override", "name": "Policy Override", "supportsInstances": true  },
+    { "code": "scope",    "name": "Scope Node",      "supportsInstances": true  },
+    { "code": "bundle",   "name": "Policy Bundle",   "supportsInstances": true  },
+    { "code": "audit",    "name": "Audit Event",     "supportsInstances": true  },
+    { "code": "settings", "name": "Settings",        "supportsInstances": false }
+  ],
+  "permissions": [
+    { "code": "andy-policies:policy:read",       "name": "Read policies",            "resourceType": "policy"   },
+    { "code": "andy-policies:policy:author",     "name": "Author drafts",            "resourceType": "policy"   },
+    { "code": "andy-policies:policy:publish",    "name": "Publish a draft",          "resourceType": "policy"   },
+    { "code": "andy-policies:policy:transition", "name": "Wind-down / retire",       "resourceType": "policy"   },
+    { "code": "andy-policies:binding:read",      "name": "Read bindings",            "resourceType": "binding"  },
+    { "code": "andy-policies:binding:manage",    "name": "Create / delete bindings", "resourceType": "binding"  },
+    { "code": "andy-policies:scope:read",        "name": "Read scope tree",          "resourceType": "scope"    },
+    { "code": "andy-policies:scope:manage",      "name": "Create / delete scopes",   "resourceType": "scope"    },
+    { "code": "andy-policies:override:read",     "name": "Read overrides",           "resourceType": "override" },
+    { "code": "andy-policies:override:propose",  "name": "Propose an override",      "resourceType": "override" },
+    { "code": "andy-policies:override:approve",  "name": "Approve an override",      "resourceType": "override" },
+    { "code": "andy-policies:override:revoke",   "name": "Revoke an override",       "resourceType": "override" },
+    { "code": "andy-policies:bundle:read",       "name": "Read bundles",             "resourceType": "bundle"   },
+    { "code": "andy-policies:bundle:create",     "name": "Create a bundle",          "resourceType": "bundle"   },
+    { "code": "andy-policies:bundle:delete",     "name": "Soft-delete a bundle",     "resourceType": "bundle"   },
+    { "code": "andy-policies:audit:read",        "name": "Read audit events",        "resourceType": "audit"    },
+    { "code": "andy-policies:audit:export",      "name": "Export audit chain",       "resourceType": "audit"    },
+    { "code": "andy-policies:audit:verify",      "name": "Verify audit chain",       "resourceType": "audit"    }
+  ],
+  "roles": [
+    {
+      "code": "admin",
+      "name": "Administrator",
+      "description": "Full access: author, publish, transition, edit bindings, manage overrides.",
+      "isSystem": true,
+      "permissionCodes": ["*"]
+    },
+    {
+      "code": "author",
+      "name": "Policy Author",
+      "description": "May author drafts and propose publish; cannot approve own publishes.",
+      "isSystem": true,
+      "permissionCodes": [
+        "andy-policies:policy:read",
+        "andy-policies:policy:author",
+        "andy-policies:binding:read",
+        "andy-policies:scope:read",
+        "andy-policies:override:read",
+        "andy-policies:override:propose",
+        "andy-policies:bundle:read",
+        "andy-policies:audit:read"
+      ]
+    },
+    {
+      "code": "approver",
+      "name": "Publish Approver",
+      "description": "Approves transitions of drafts to active versions.",
+      "isSystem": true,
+      "permissionCodes": [
+        "andy-policies:policy:read",
+        "andy-policies:policy:publish",
+        "andy-policies:policy:transition",
+        "andy-policies:binding:read",
+        "andy-policies:binding:manage",
+        "andy-policies:scope:read",
+        "andy-policies:override:read",
+        "andy-policies:override:approve",
+        "andy-policies:override:revoke",
+        "andy-policies:bundle:read",
+        "andy-policies:bundle:create",
+        "andy-policies:audit:read"
+      ]
+    },
+    {
+      "code": "risk",
+      "name": "Risk / Compliance",
+      "description": "Read-all plus audit-export.",
+      "isSystem": true,
+      "permissionCodes": [
+        "andy-policies:policy:read",
+        "andy-policies:binding:read",
+        "andy-policies:scope:read",
+        "andy-policies:override:read",
+        "andy-policies:bundle:read",
+        "andy-policies:audit:read",
+        "andy-policies:audit:export",
+        "andy-policies:audit:verify"
+      ]
+    },
+    {
+      "code": "viewer",
+      "name": "Viewer",
+      "description": "Read-only access to active policies and public audit trail.",
+      "isSystem": true,
+      "permissionCodes": [
+        "andy-policies:policy:read",
+        "andy-policies:binding:read",
+        "andy-policies:scope:read",
+        "andy-policies:override:read",
+        "andy-policies:bundle:read"
+      ]
+    }
+  ],
+  "testUserRole": "admin"
+}

--- a/config/registration.json
+++ b/config/registration.json
@@ -58,15 +58,105 @@
     "resourceTypes": [
       { "code": "policy",   "name": "Policy",          "supportsInstances": true  },
       { "code": "binding",  "name": "Policy Binding",  "supportsInstances": true  },
+      { "code": "override", "name": "Policy Override", "supportsInstances": true  },
+      { "code": "scope",    "name": "Scope Node",      "supportsInstances": true  },
+      { "code": "bundle",   "name": "Policy Bundle",   "supportsInstances": true  },
       { "code": "audit",    "name": "Audit Event",     "supportsInstances": true  },
       { "code": "settings", "name": "Settings",        "supportsInstances": false }
     ],
+    "permissions": [
+      { "code": "andy-policies:policy:read",       "name": "Read policies",            "resourceType": "policy"   },
+      { "code": "andy-policies:policy:author",     "name": "Author drafts",            "resourceType": "policy"   },
+      { "code": "andy-policies:policy:publish",    "name": "Publish a draft",          "resourceType": "policy"   },
+      { "code": "andy-policies:policy:transition", "name": "Wind-down / retire",       "resourceType": "policy"   },
+      { "code": "andy-policies:binding:read",      "name": "Read bindings",            "resourceType": "binding"  },
+      { "code": "andy-policies:binding:manage",    "name": "Create / delete bindings", "resourceType": "binding"  },
+      { "code": "andy-policies:scope:read",        "name": "Read scope tree",          "resourceType": "scope"    },
+      { "code": "andy-policies:scope:manage",      "name": "Create / delete scopes",   "resourceType": "scope"    },
+      { "code": "andy-policies:override:read",     "name": "Read overrides",           "resourceType": "override" },
+      { "code": "andy-policies:override:propose",  "name": "Propose an override",      "resourceType": "override" },
+      { "code": "andy-policies:override:approve",  "name": "Approve an override",      "resourceType": "override" },
+      { "code": "andy-policies:override:revoke",   "name": "Revoke an override",       "resourceType": "override" },
+      { "code": "andy-policies:bundle:read",       "name": "Read bundles",             "resourceType": "bundle"   },
+      { "code": "andy-policies:bundle:create",     "name": "Create a bundle",          "resourceType": "bundle"   },
+      { "code": "andy-policies:bundle:delete",     "name": "Soft-delete a bundle",     "resourceType": "bundle"   },
+      { "code": "andy-policies:audit:read",        "name": "Read audit events",        "resourceType": "audit"    },
+      { "code": "andy-policies:audit:export",      "name": "Export audit chain",       "resourceType": "audit"    },
+      { "code": "andy-policies:audit:verify",      "name": "Verify audit chain",       "resourceType": "audit"    }
+    ],
     "roles": [
-      { "code": "admin",    "name": "Administrator",          "description": "Full access: author, publish, transition, edit bindings, manage overrides.", "isSystem": true },
-      { "code": "author",   "name": "Policy Author",          "description": "May author drafts and propose publish; cannot approve own publishes.",        "isSystem": true },
-      { "code": "approver", "name": "Publish Approver",       "description": "Approves transitions of drafts to active versions.",                          "isSystem": true },
-      { "code": "risk",     "name": "Risk / Compliance",      "description": "Read-all plus audit-export.",                                                  "isSystem": true },
-      { "code": "viewer",   "name": "Viewer",                 "description": "Read-only access to active policies and public audit trail.",                 "isSystem": true }
+      {
+        "code": "admin",
+        "name": "Administrator",
+        "description": "Full access: author, publish, transition, edit bindings, manage overrides.",
+        "isSystem": true,
+        "permissionCodes": ["*"]
+      },
+      {
+        "code": "author",
+        "name": "Policy Author",
+        "description": "May author drafts and propose publish; cannot approve own publishes.",
+        "isSystem": true,
+        "permissionCodes": [
+          "andy-policies:policy:read",
+          "andy-policies:policy:author",
+          "andy-policies:binding:read",
+          "andy-policies:scope:read",
+          "andy-policies:override:read",
+          "andy-policies:override:propose",
+          "andy-policies:bundle:read",
+          "andy-policies:audit:read"
+        ]
+      },
+      {
+        "code": "approver",
+        "name": "Publish Approver",
+        "description": "Approves transitions of drafts to active versions.",
+        "isSystem": true,
+        "permissionCodes": [
+          "andy-policies:policy:read",
+          "andy-policies:policy:publish",
+          "andy-policies:policy:transition",
+          "andy-policies:binding:read",
+          "andy-policies:binding:manage",
+          "andy-policies:scope:read",
+          "andy-policies:override:read",
+          "andy-policies:override:approve",
+          "andy-policies:override:revoke",
+          "andy-policies:bundle:read",
+          "andy-policies:bundle:create",
+          "andy-policies:audit:read"
+        ]
+      },
+      {
+        "code": "risk",
+        "name": "Risk / Compliance",
+        "description": "Read-all plus audit-export.",
+        "isSystem": true,
+        "permissionCodes": [
+          "andy-policies:policy:read",
+          "andy-policies:binding:read",
+          "andy-policies:scope:read",
+          "andy-policies:override:read",
+          "andy-policies:bundle:read",
+          "andy-policies:audit:read",
+          "andy-policies:audit:export",
+          "andy-policies:audit:verify"
+        ]
+      },
+      {
+        "code": "viewer",
+        "name": "Viewer",
+        "description": "Read-only access to active policies and public audit trail.",
+        "isSystem": true,
+        "permissionCodes": [
+          "andy-policies:policy:read",
+          "andy-policies:binding:read",
+          "andy-policies:scope:read",
+          "andy-policies:override:read",
+          "andy-policies:bundle:read"
+        ]
+      }
     ],
     "testUserRole": "admin"
   },

--- a/tests/Andy.Policies.Tests.Unit/Registration/ManifestTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Registration/ManifestTests.cs
@@ -1,0 +1,239 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Registration;
+
+/// <summary>
+/// P7.1 (#47) — pins the RBAC permission catalog declared in
+/// <c>config/registration.json</c> so any future epic that adds a
+/// catalog mutation without extending the manifest fails here.
+///
+/// Asserts:
+///   1. Completeness — every action in the P1–P6/P8 allow-list maps
+///      to exactly one permission code.
+///   2. Referential integrity — every <c>role.permissionCodes[]</c>
+///      entry references a declared permission (or the literal
+///      <c>"*"</c>); every <c>permissions[].resourceType</c>
+///      references a declared <c>resourceTypes[].code</c>.
+///   3. Role-shape invariants — admin holds <c>"*"</c>; viewer only
+///      holds <c>:read</c> codes; author does not hold
+///      <c>policy:publish</c>; approver does not hold
+///      <c>policy:author</c>.
+///   4. Seed parity — <c>config/rbac-seed.json</c> is byte-equal to
+///      the <c>rbac</c> sub-tree of <c>config/registration.json</c>
+///      (re-serialised from the same parsed object so JSON formatting
+///      differences don't matter, only semantic content does).
+/// </summary>
+public class ManifestTests
+{
+    private const string AdminWildcard = "*";
+
+    private static readonly string[] ExpectedActionAllowlist =
+    {
+        // P1 — drafting
+        "andy-policies:policy:read",
+        "andy-policies:policy:author",
+        // P2 — lifecycle transitions
+        "andy-policies:policy:publish",
+        "andy-policies:policy:transition",
+        // P3 — bindings
+        "andy-policies:binding:read",
+        "andy-policies:binding:manage",
+        // P4 — scope tree
+        "andy-policies:scope:read",
+        "andy-policies:scope:manage",
+        // P5 — overrides
+        "andy-policies:override:read",
+        "andy-policies:override:propose",
+        "andy-policies:override:approve",
+        "andy-policies:override:revoke",
+        // P6 — audit
+        "andy-policies:audit:read",
+        "andy-policies:audit:export",
+        "andy-policies:audit:verify",
+        // P8 — bundles
+        "andy-policies:bundle:read",
+        "andy-policies:bundle:create",
+        "andy-policies:bundle:delete",
+    };
+
+    private static string FindRepoFile(string relativePath)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Andy.Policies.sln")))
+        {
+            dir = dir.Parent;
+        }
+        dir.Should().NotBeNull("test must run from inside the andy-policies repo");
+        var path = Path.Combine(dir!.FullName, relativePath);
+        File.Exists(path).Should().BeTrue($"{relativePath} should exist at the repo root");
+        return path;
+    }
+
+    private static JsonElement LoadRbacBlock()
+    {
+        var path = FindRepoFile("config/registration.json");
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        var rbac = doc.RootElement.GetProperty("rbac");
+        return rbac.Clone();
+    }
+
+    private static JsonElement LoadRbacSeed()
+    {
+        var path = FindRepoFile("config/rbac-seed.json");
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        return doc.RootElement.Clone();
+    }
+
+    [Fact]
+    public void RegistrationJson_ParsesAndExposesRbacBlock()
+    {
+        var rbac = LoadRbacBlock();
+
+        rbac.GetProperty("applicationCode").GetString().Should().Be("andy-policies");
+        rbac.GetProperty("permissions").ValueKind.Should().Be(JsonValueKind.Array);
+        rbac.GetProperty("roles").ValueKind.Should().Be(JsonValueKind.Array);
+        rbac.GetProperty("resourceTypes").ValueKind.Should().Be(JsonValueKind.Array);
+    }
+
+    [Fact]
+    public void Permissions_CoverEveryActionInAllowlist()
+    {
+        var rbac = LoadRbacBlock();
+        var declared = rbac.GetProperty("permissions").EnumerateArray()
+            .Select(p => p.GetProperty("code").GetString())
+            .ToHashSet();
+
+        foreach (var action in ExpectedActionAllowlist)
+        {
+            declared.Should().Contain(action,
+                $"action '{action}' must map to a declared permission code");
+        }
+    }
+
+    [Fact]
+    public void Permissions_HaveNoDuplicateCodes()
+    {
+        var rbac = LoadRbacBlock();
+        var codes = rbac.GetProperty("permissions").EnumerateArray()
+            .Select(p => p.GetProperty("code").GetString()!)
+            .ToList();
+
+        codes.Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public void Permissions_ResourceType_ReferencesDeclaredType()
+    {
+        var rbac = LoadRbacBlock();
+        var resourceTypes = rbac.GetProperty("resourceTypes").EnumerateArray()
+            .Select(rt => rt.GetProperty("code").GetString()!)
+            .ToHashSet();
+
+        foreach (var perm in rbac.GetProperty("permissions").EnumerateArray())
+        {
+            var rt = perm.GetProperty("resourceType").GetString();
+            resourceTypes.Should().Contain(rt,
+                $"permission '{perm.GetProperty("code").GetString()}' references undeclared resourceType '{rt}'");
+        }
+    }
+
+    [Fact]
+    public void Roles_PermissionCodes_ReferenceDeclaredPermissions()
+    {
+        var rbac = LoadRbacBlock();
+        var declared = rbac.GetProperty("permissions").EnumerateArray()
+            .Select(p => p.GetProperty("code").GetString()!)
+            .ToHashSet();
+
+        foreach (var role in rbac.GetProperty("roles").EnumerateArray())
+        {
+            var roleCode = role.GetProperty("code").GetString();
+            var perms = role.GetProperty("permissionCodes").EnumerateArray()
+                .Select(p => p.GetString()!)
+                .ToList();
+
+            foreach (var perm in perms)
+            {
+                if (perm == AdminWildcard) continue;
+                declared.Should().Contain(perm,
+                    $"role '{roleCode}' references undeclared permission '{perm}'");
+            }
+        }
+    }
+
+    [Fact]
+    public void Admin_HoldsWildcardOnly()
+    {
+        var admin = GetRole("admin");
+        var perms = admin.GetProperty("permissionCodes").EnumerateArray()
+            .Select(p => p.GetString())
+            .ToList();
+
+        perms.Should().BeEquivalentTo(new[] { AdminWildcard });
+    }
+
+    [Fact]
+    public void Viewer_HoldsOnlyReadCodes()
+    {
+        var viewer = GetRole("viewer");
+        var perms = viewer.GetProperty("permissionCodes").EnumerateArray()
+            .Select(p => p.GetString()!)
+            .ToList();
+
+        perms.Should().NotBeEmpty();
+        perms.Should().OnlyContain(p => p.EndsWith(":read", StringComparison.Ordinal),
+            "viewer must hold only :read codes");
+    }
+
+    [Fact]
+    public void Author_DoesNotHoldPolicyPublish()
+    {
+        var author = GetRole("author");
+        var perms = author.GetProperty("permissionCodes").EnumerateArray()
+            .Select(p => p.GetString()!)
+            .ToList();
+
+        perms.Should().NotContain("andy-policies:policy:publish");
+    }
+
+    [Fact]
+    public void Approver_DoesNotHoldPolicyAuthor()
+    {
+        var approver = GetRole("approver");
+        var perms = approver.GetProperty("permissionCodes").EnumerateArray()
+            .Select(p => p.GetString()!)
+            .ToList();
+
+        perms.Should().NotContain("andy-policies:policy:author");
+    }
+
+    [Fact]
+    public void RbacSeedJson_IsSemanticProjectionOfRegistrationRbac()
+    {
+        var canonicalOpts = new JsonSerializerOptions { WriteIndented = false };
+
+        var fromRegistration = LoadRbacBlock();
+        var fromSeed = LoadRbacSeed();
+
+        // Re-serialise both through the same options so whitespace /
+        // key-order differences in the source files are normalised
+        // away — this asserts semantic equality, not byte equality.
+        var registrationCanonical = JsonSerializer.Serialize(fromRegistration, canonicalOpts);
+        var seedCanonical = JsonSerializer.Serialize(fromSeed, canonicalOpts);
+
+        seedCanonical.Should().Be(registrationCanonical,
+            "config/rbac-seed.json must be a 1:1 projection of the rbac block in config/registration.json");
+    }
+
+    private static JsonElement GetRole(string code)
+    {
+        var rbac = LoadRbacBlock();
+        return rbac.GetProperty("roles").EnumerateArray()
+            .Single(r => r.GetProperty("code").GetString() == code);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #47. Extend the RBAC manifest with the canonical permission vocabulary that andy-rbac seeds on first boot. No production C# changes — this story is purely about pinning the contract so downstream P7 stories (P7.2 IRbacChecker, P7.4 ASP.NET handlers) have a stable set of codes to reference.

## Changes

- **`config/registration.json`** — extend `rbac` block:
  - Add resource types `override`, `scope`, `bundle` (now 7 total).
  - Add `permissions` array (18 codes spanning P1–P6/P8 catalog mutations).
  - Add `permissionCodes` per role: `admin` holds `["*"]`, `viewer` only `:read` codes, `author` lacks `policy:publish`, `approver` lacks `policy:author`.
- **`config/rbac-seed.json`** *(new)* — 1:1 projection of the rbac block for direct dev seeding. The file was referenced by `CLAUDE.md` + `docs/security.md` + `AuditController` but did not actually exist.
- **`tests/Andy.Policies.Tests.Unit/Registration/ManifestTests.cs`** *(new)* — 10 tests:
  - Completeness against a P1–P6/P8 action allowlist (every action maps to one permission code).
  - Referential integrity (role → permission, permission → resourceType).
  - Role-shape invariants (admin wildcard, viewer read-only, author/approver disjoint codes).
  - Seed parity with the rbac block.
- **`README.md`** — new "Edit RBAC" section with a permission catalog table linking to the manifest.

## Acceptance criteria

- [x] `config/registration.json` declares 18 permissions under `rbac.permissions` with `code`/`name`/`resourceType`.
- [x] Resource types `policy`, `binding`, `override`, `scope`, `bundle`, `audit`, `settings` declared.
- [x] Every role has `permissionCodes`; `admin = ["*"]`; `viewer` only `:read`; `author` lacks `policy:publish`; `approver` lacks `policy:author`.
- [x] `config/rbac-seed.json` is a semantic projection of the rbac block (asserted at CI time).
- [x] `ManifestTests` covers completeness, referential integrity, and parse success.
- [x] `dotnet test` — Unit 444/444, Integration 451/451 locally.
- [x] `dotnet build` — 0 warnings, 0 errors with `TreatWarningsAsErrors=true`.

## Test plan

- [x] `dotnet test tests/Andy.Policies.Tests.Unit` — 444 passed (+10 new)
- [x] `dotnet test tests/Andy.Policies.Tests.Integration` — 451 passed
- [ ] CI green