### PR TITLE
Implement P7.3 — author cannot self-approve on publish (#55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,8 @@ Subject→permission evaluation delegates to [Andy RBAC](https://github.com/rivo
 
 The runtime adapter is `HttpRbacChecker` (P7.2, [#51](https://github.com/rivoli-ai/andy-policies/issues/51)) — a typed `HttpClient` that calls `POST {AndyRbac:BaseUrl}/api/check` with a 3-second timeout and a 60-second in-memory cache for successful decisions. **Fail-closed by default**: transport errors, timeouts, and non-2xx responses all collapse to `Allowed=false` so a governance catalog never opens up under adversity. The fail-closed branch is *not* cached, so a recovered andy-rbac is picked up on the very next call.
 
+**Author cannot self-approve** (P7.3, [#55](https://github.com/rivoli-ai/andy-policies/issues/55)). The publish endpoint rejects when the actor matches the version's `ProposerSubjectId` — even when andy-rbac would say *yes* to both `:author` and `:publish`. Domain invariant; admin override is deliberately absent. Returns **HTTP 403** with ProblemDetails `errorCode = "policy.publish_self_approval_forbidden"`, no state mutation. `WindingDown` and `Retire` are administrative hygiene transitions and do not apply this check.
+
 ### Permission catalog
 
 | Code | Resource | Held by |

--- a/src/Andy.Policies.Api/ExceptionHandlers/PolicyExceptionHandler.cs
+++ b/src/Andy.Policies.Api/ExceptionHandlers/PolicyExceptionHandler.cs
@@ -137,6 +137,30 @@ public sealed class PolicyExceptionHandler : IExceptionHandler
             return true;
         }
 
+        // P7.3 (#55): publish-time self-approval is a separate domain
+        // invariant from the override path above — admin override is
+        // deliberately absent, so the errorCode is distinct.
+        if (exception is PublishSelfApprovalException pax)
+        {
+            var problem403 = new ProblemDetails
+            {
+                Status = StatusCodes.Status403Forbidden,
+                Title = "Self-approval forbidden",
+                Detail = pax.Message,
+                Type = "/problems/publish-self-approval",
+                Instance = httpContext.Request.Path,
+                Extensions =
+                {
+                    ["errorCode"] = "policy.publish_self_approval_forbidden",
+                    ["policyVersionId"] = pax.PolicyVersionId,
+                    ["subjectId"] = pax.SubjectId,
+                },
+            };
+            httpContext.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await httpContext.Response.WriteAsJsonAsync(problem403, cancellationToken);
+            return true;
+        }
+
         if (exception is RbacDeniedException rdex)
         {
             var problem403 = new ProblemDetails

--- a/src/Andy.Policies.Application/Exceptions/PublishSelfApprovalException.cs
+++ b/src/Andy.Policies.Application/Exceptions/PublishSelfApprovalException.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.Exceptions;
+
+/// <summary>
+/// Thrown by <c>LifecycleTransitionService</c> when the publish actor's
+/// subject id matches the version's <c>ProposerSubjectId</c> (P7.3,
+/// story rivoli-ai/andy-policies#55). A domain invariant — fires even
+/// when the actor holds both <c>andy-policies:policy:author</c> and
+/// <c>andy-policies:policy:publish</c>. Distinct from
+/// <see cref="SelfApprovalException"/> (which guards override approval).
+/// API layer maps to HTTP 403 with
+/// <c>errorCode = "policy.publish_self_approval_forbidden"</c>.
+/// </summary>
+public sealed class PublishSelfApprovalException : Exception
+{
+    public Guid PolicyVersionId { get; }
+
+    public string SubjectId { get; }
+
+    public PublishSelfApprovalException(Guid policyVersionId, string subjectId)
+        : base($"Subject '{subjectId}' cannot publish their own draft (version {policyVersionId}).")
+    {
+        PolicyVersionId = policyVersionId;
+        SubjectId = subjectId;
+    }
+}

--- a/src/Andy.Policies.Infrastructure/Services/LifecycleTransitionService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/LifecycleTransitionService.cs
@@ -107,6 +107,17 @@ public sealed class LifecycleTransitionService : ILifecycleTransitionService
             throw new InvalidLifecycleTransitionException(version.State, target);
         }
 
+        // P7.3 (#55): an author cannot publish their own draft, even when
+        // they hold both andy-policies:policy:author and :publish. This
+        // is a domain invariant — admin override is deliberately absent.
+        // Wind-down and retire are administrative hygiene transitions and
+        // are not gated on proposer identity.
+        if (target == LifecycleState.Active
+            && string.Equals(version.ProposerSubjectId, actorSubjectId, StringComparison.Ordinal))
+        {
+            throw new PublishSelfApprovalException(version.Id, actorSubjectId);
+        }
+
         var now = _clock.GetUtcNow();
 
         switch (target)

--- a/tests/Andy.Policies.Tests.Integration/Api/OverridesControllerTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Api/OverridesControllerTests.cs
@@ -140,7 +140,7 @@ public class OverridesControllerTests : IDisposable
         draftResp.EnsureSuccessStatusCode();
         var draft = (await draftResp.Content.ReadFromJsonAsync<PolicyVersionDto>(JsonOptions))!;
 
-        var publishResp = await client.PostAsJsonAsync(
+        var publishResp = await client.PostAsJsonAsApproverAsync(
             $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
             new LifecycleTransitionRequest("go-live"));
         publishResp.EnsureSuccessStatusCode();

--- a/tests/Andy.Policies.Tests.Integration/Cli/CliLifecycleEndToEndTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Cli/CliLifecycleEndToEndTests.cs
@@ -48,8 +48,12 @@ public class CliLifecycleEndToEndTests : IClassFixture<PoliciesApiFactory>
 
     private async Task<PolicyVersionDto> CreateDraftAsync(string slug)
     {
+        // P7.3 (#55): pin the proposer to "test-creator" so the CLI's
+        // publish call (which goes through TestAuthHandler with the
+        // default subject "test-user") doesn't trip the self-approval
+        // guard.
         var client = _factory.CreateClient();
-        var resp = await client.PostAsJsonAsync("/api/policies", new
+        var resp = await client.PostAsJsonAsSubjectAsync("/api/policies", new
         {
             name = slug,
             description = (string?)null,
@@ -58,7 +62,7 @@ public class CliLifecycleEndToEndTests : IClassFixture<PoliciesApiFactory>
             severity = "Critical",
             scopes = Array.Empty<string>(),
             rulesJson = "{}",
-        });
+        }, "test-creator");
         resp.EnsureSuccessStatusCode();
         return (await resp.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
     }

--- a/tests/Andy.Policies.Tests.Integration/Controllers/BindingsControllerTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/BindingsControllerTests.cs
@@ -57,7 +57,7 @@ public class BindingsControllerTests : IClassFixture<PoliciesApiFactory>
 
     private async Task<PolicyVersionDto> PublishAsync(PolicyVersionDto draft)
     {
-        var resp = await _client.PostAsJsonAsync(
+        var resp = await _client.PostAsJsonAsApproverAsync(
             $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
             new LifecycleTransitionRequest("ship-it"));
         resp.EnsureSuccessStatusCode();

--- a/tests/Andy.Policies.Tests.Integration/Controllers/BindingsResolveTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/BindingsResolveTests.cs
@@ -48,7 +48,7 @@ public class BindingsResolveTests : IClassFixture<PoliciesApiFactory>
         var draft = await _client.PostAsJsonAsync("/api/policies", MinimalCreatePolicy(slug));
         draft.EnsureSuccessStatusCode();
         var created = (await draft.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
-        var publish = await _client.PostAsJsonAsync(
+        var publish = await _client.PostAsJsonAsApproverAsync(
             $"/api/policies/{created.PolicyId}/versions/{created.Id}/publish",
             new LifecycleTransitionRequest("ship"));
         publish.EnsureSuccessStatusCode();

--- a/tests/Andy.Policies.Tests.Integration/Controllers/BindingsTightenOnlyTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/BindingsTightenOnlyTests.cs
@@ -50,7 +50,7 @@ public class BindingsTightenOnlyTests : IClassFixture<PoliciesApiFactory>
         var draft = await _client.PostAsJsonAsync("/api/policies", MinimalCreatePolicy(slug));
         draft.EnsureSuccessStatusCode();
         var version = (await draft.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
-        var publish = await _client.PostAsJsonAsync(
+        var publish = await _client.PostAsJsonAsApproverAsync(
             $"/api/policies/{version.PolicyId}/versions/{version.Id}/publish",
             new LifecycleTransitionRequest("ship"));
         publish.EnsureSuccessStatusCode();

--- a/tests/Andy.Policies.Tests.Integration/Controllers/PolicyVersionsLifecycleControllerTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/PolicyVersionsLifecycleControllerTests.cs
@@ -60,7 +60,7 @@ public class PolicyVersionsLifecycleControllerTests : IClassFixture<PoliciesApiF
     {
         var draft = await CreateDraftAsync("publish-happy");
 
-        var response = await _client.PostAsJsonAsync(
+        var response = await _client.PostAsJsonAsApproverAsync(
             $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
             WithRationale());
 
@@ -74,14 +74,14 @@ public class PolicyVersionsLifecycleControllerTests : IClassFixture<PoliciesApiF
     public async Task Publish_NewerDraft_AutoSupersedesPreviousActive()
     {
         var v1 = await CreateDraftAsync("auto-supersede");
-        await _client.PostAsJsonAsync(
+        await _client.PostAsJsonAsApproverAsync(
             $"/api/policies/{v1.PolicyId}/versions/{v1.Id}/publish",
             WithRationale("v1-go-live"));
 
         // Bumping the published v1 mints a fresh Draft (v2) under the same policy.
         var v2 = await BumpDraftAsync(v1.PolicyId, v1.Id);
 
-        var response = await _client.PostAsJsonAsync(
+        var response = await _client.PostAsJsonAsApproverAsync(
             $"/api/policies/{v2.PolicyId}/versions/{v2.Id}/publish",
             WithRationale("v2-go-live"));
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -104,7 +104,7 @@ public class PolicyVersionsLifecycleControllerTests : IClassFixture<PoliciesApiF
     {
         var draft = await CreateDraftAsync("publish-no-rationale");
 
-        var response = await _client.PostAsJsonAsync(
+        var response = await _client.PostAsJsonAsApproverAsync(
             $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
             new LifecycleTransitionRequest(Rationale: "   "));
 
@@ -120,7 +120,7 @@ public class PolicyVersionsLifecycleControllerTests : IClassFixture<PoliciesApiF
     [Fact]
     public async Task Publish_OnUnknownPolicy_Returns404()
     {
-        var response = await _client.PostAsJsonAsync(
+        var response = await _client.PostAsJsonAsApproverAsync(
             $"/api/policies/{Guid.NewGuid()}/versions/{Guid.NewGuid()}/publish",
             WithRationale());
 
@@ -131,7 +131,7 @@ public class PolicyVersionsLifecycleControllerTests : IClassFixture<PoliciesApiF
     public async Task Publish_OnRetiredVersion_Returns409()
     {
         var draft = await CreateDraftAsync("publish-retired-blocked");
-        await _client.PostAsJsonAsync(
+        await _client.PostAsJsonAsApproverAsync(
             $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
             WithRationale("live"));
         // Active -> Retired is allowed and tombstones the version.
@@ -139,7 +139,7 @@ public class PolicyVersionsLifecycleControllerTests : IClassFixture<PoliciesApiF
             $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/retire",
             WithRationale("tomb"));
 
-        var response = await _client.PostAsJsonAsync(
+        var response = await _client.PostAsJsonAsApproverAsync(
             $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
             WithRationale("rezz"));
 
@@ -152,7 +152,7 @@ public class PolicyVersionsLifecycleControllerTests : IClassFixture<PoliciesApiF
     public async Task WindDown_OnActive_Returns200_AndState()
     {
         var draft = await CreateDraftAsync("wind-down-happy");
-        await _client.PostAsJsonAsync(
+        await _client.PostAsJsonAsApproverAsync(
             $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
             WithRationale("live"));
 
@@ -182,7 +182,7 @@ public class PolicyVersionsLifecycleControllerTests : IClassFixture<PoliciesApiF
     public async Task Retire_FromWindingDown_Returns200_AndStampsState()
     {
         var draft = await CreateDraftAsync("retire-from-winding");
-        await _client.PostAsJsonAsync(
+        await _client.PostAsJsonAsApproverAsync(
             $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
             WithRationale("live"));
         await _client.PostAsJsonAsync(

--- a/tests/Andy.Policies.Tests.Integration/Controllers/RationaleEnforcementTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/RationaleEnforcementTests.cs
@@ -135,7 +135,7 @@ public class RationaleEnforcementTests
         var client = factory.CreateClient();
         var draft = await CreateDraftAsync(client, "rationale-on");
 
-        var response = await client.PostAsJsonAsync(
+        var response = await client.PostAsJsonAsApproverAsync(
             $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
             new LifecycleTransitionRequest(""));
 
@@ -155,7 +155,7 @@ public class RationaleEnforcementTests
         var client = factory.CreateClient();
         var draft = await CreateDraftAsync(client, "rationale-off");
 
-        var response = await client.PostAsJsonAsync(
+        var response = await client.PostAsJsonAsApproverAsync(
             $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
             new LifecycleTransitionRequest(""));
 
@@ -172,7 +172,7 @@ public class RationaleEnforcementTests
         var draft = await CreateDraftAsync(client, "rationale-flip");
 
         // First attempt with toggle on + empty rationale → 400.
-        var first = await client.PostAsJsonAsync(
+        var first = await client.PostAsJsonAsApproverAsync(
             $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
             new LifecycleTransitionRequest(""));
         first.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -182,7 +182,7 @@ public class RationaleEnforcementTests
         // on every check, so the same client request now succeeds without a
         // restart.
         factory.Snapshot.RationaleRequired = false;
-        var second = await client.PostAsJsonAsync(
+        var second = await client.PostAsJsonAsApproverAsync(
             $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
             new LifecycleTransitionRequest(""));
         second.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -195,7 +195,7 @@ public class RationaleEnforcementTests
         var client = factory.CreateClient();
         var draft = await CreateDraftAsync(client, "rationale-coldstart");
 
-        var response = await client.PostAsJsonAsync(
+        var response = await client.PostAsJsonAsApproverAsync(
             $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
             new LifecycleTransitionRequest(""));
 

--- a/tests/Andy.Policies.Tests.Integration/Controllers/TestAuthHandler.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/TestAuthHandler.cs
@@ -21,6 +21,13 @@ public sealed class TestAuthHandler : AuthenticationHandler<AuthenticationScheme
     public const string TestSubjectId = "test-user";
 
     /// <summary>
+    /// Convenience constant for tests that need a second subject distinct
+    /// from <see cref="TestSubjectId"/> — typically the publish actor in
+    /// P7.3's "author cannot self-approve" flow ([#55]).
+    /// </summary>
+    public const string TestApproverSubjectId = "test-approver";
+
+    /// <summary>
     /// Optional request header that overrides <see cref="TestSubjectId"/>
     /// for a single request. P5.5 (#58) needs multi-actor scenarios
     /// (self-approval, propose-as-A + approve-as-B); the header lets

--- a/tests/Andy.Policies.Tests.Integration/Controllers/TestRequestExtensions.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/TestRequestExtensions.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net.Http.Json;
+
+namespace Andy.Policies.Tests.Integration.Controllers;
+
+/// <summary>
+/// HTTP client helpers for integration tests that need to issue
+/// requests as a specific subject. P7.3 (#55) introduced the
+/// "author cannot self-approve" invariant: tests that previously
+/// created and published with a single client now need to swap
+/// subjects on the publish call. The simplest readable mechanism
+/// is the <c>X-Test-Subject</c> header that <see cref="TestAuthHandler"/>
+/// already honours per-request.
+/// </summary>
+internal static class TestRequestExtensions
+{
+    /// <summary>POST a JSON body as <see cref="TestAuthHandler.TestApproverSubjectId"/>.</summary>
+    public static Task<HttpResponseMessage> PostAsJsonAsApproverAsync<T>(
+        this HttpClient client, string url, T body, CancellationToken ct = default)
+        => client.SendAsync(BuildPostJson(url, body, TestAuthHandler.TestApproverSubjectId), ct);
+
+    /// <summary>POST a JSON body as the named subject.</summary>
+    public static Task<HttpResponseMessage> PostAsJsonAsSubjectAsync<T>(
+        this HttpClient client, string url, T body, string subjectId, CancellationToken ct = default)
+        => client.SendAsync(BuildPostJson(url, body, subjectId), ct);
+
+    /// <summary>POST with no body as the named subject.</summary>
+    public static Task<HttpResponseMessage> PostEmptyAsSubjectAsync(
+        this HttpClient client, string url, string subjectId, CancellationToken ct = default)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, url);
+        req.Headers.Add(TestAuthHandler.SubjectHeader, subjectId);
+        return client.SendAsync(req, ct);
+    }
+
+    private static HttpRequestMessage BuildPostJson<T>(string url, T body, string subjectId)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = JsonContent.Create(body),
+        };
+        req.Headers.Add(TestAuthHandler.SubjectHeader, subjectId);
+        return req;
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/GrpcServices/BindingsGrpcServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/GrpcServices/BindingsGrpcServiceTests.cs
@@ -57,7 +57,11 @@ public class BindingsGrpcServiceTests : IClassFixture<PoliciesApiFactory>, IDisp
 
     private async Task<PolicyVersionMessage> CreateDraftAsync(string slug)
     {
-        var draft = await _policies.CreateDraftAsync(MinimalCreate(slug));
+        // P7.3 (#55): pin the proposer subject to "test-creator" so the
+        // default test subject "test-user" can act as the publisher
+        // without tripping the publish-time self-approval guard.
+        var metadata = new Metadata { { TestAuthHandler.SubjectHeader, "test-creator" } };
+        var draft = await _policies.CreateDraftAsync(MinimalCreate(slug), metadata);
         return draft.Version;
     }
 

--- a/tests/Andy.Policies.Tests.Integration/GrpcServices/LifecycleGrpcServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/GrpcServices/LifecycleGrpcServiceTests.cs
@@ -50,7 +50,12 @@ public class LifecycleGrpcServiceTests : IClassFixture<PoliciesApiFactory>, IDis
 
     private async Task<PolicyVersionMessage> CreateDraftAsync(string slug)
     {
-        var draft = await _policies.CreateDraftAsync(MinimalCreate(slug));
+        // P7.3 (#55): pin the proposer subject to "test-creator" so the
+        // default test subject "test-user" can act as the publisher
+        // without tripping the publish-time self-approval guard. The
+        // header is consumed by TestAuthHandler.
+        var metadata = new Metadata { { TestAuthHandler.SubjectHeader, "test-creator" } };
+        var draft = await _policies.CreateDraftAsync(MinimalCreate(slug), metadata);
         return draft.Version;
     }
 
@@ -84,12 +89,16 @@ public class LifecycleGrpcServiceTests : IClassFixture<PoliciesApiFactory>, IDis
             Rationale = "v1-live",
         });
 
-        // Bump v1 to mint v2 Draft under the same policy.
+        // Bump v1 to mint v2 Draft under the same policy. Same approver
+        // metadata as the create helper — keeps v2's proposer distinct
+        // from the default test subject so the v2 publish below is not
+        // self-approval.
+        var bumpMetadata = new Metadata { { TestAuthHandler.SubjectHeader, "test-creator" } };
         var v2Resp = await _policies.BumpDraftAsync(new BumpDraftRequest
         {
             PolicyId = v1.PolicyId,
             SourceVersionId = v1.Id,
-        });
+        }, bumpMetadata);
         var v2 = v2Resp.Version;
 
         await _lifecycle.PublishVersionAsync(new PublishVersionRequest

--- a/tests/Andy.Policies.Tests.Integration/GrpcServices/OverridesGrpcServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/GrpcServices/OverridesGrpcServiceTests.cs
@@ -157,7 +157,7 @@ public class OverridesGrpcServiceTests : IDisposable
         });
         resp.EnsureSuccessStatusCode();
         var draft = await resp.Content.ReadFromJsonAsync<DraftPayload>();
-        var publishResp = await _http.PostAsJsonAsync(
+        var publishResp = await _http.PostAsJsonAsApproverAsync(
             $"/api/policies/{draft!.PolicyId}/versions/{draft.Id}/publish",
             new { Rationale = "go-live" });
         publishResp.EnsureSuccessStatusCode();

--- a/tests/Andy.Policies.Tests.Integration/Lifecycle/PublishSelfApprovalTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Lifecycle/PublishSelfApprovalTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Tests.Integration.Controllers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Lifecycle;
+
+/// <summary>
+/// P7.3 (#55) — verifies the publish-time self-approval guard at the
+/// REST surface. Asserts the 403 response shape (typed errorCode,
+/// matched extensions) and the "no state mutation on reject" contract
+/// (the version stays Draft and no Active appears under the policy).
+/// </summary>
+public class PublishSelfApprovalTests : IClassFixture<PoliciesApiFactory>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly HttpClient _client;
+
+    public PublishSelfApprovalTests(PoliciesApiFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    private static CreatePolicyRequest MinimalCreate(string name) => new(
+        Name: name,
+        Description: null,
+        Summary: "summary",
+        Enforcement: "Must",
+        Severity: "Critical",
+        Scopes: Array.Empty<string>(),
+        RulesJson: "{}");
+
+    private async Task<PolicyVersionDto> CreateDraftAsAsync(string slug, string subjectId)
+    {
+        var resp = await _client.PostAsJsonAsSubjectAsync(
+            "/api/policies", MinimalCreate(slug), subjectId);
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<PolicyVersionDto>(JsonOptions))!;
+    }
+
+    [Fact]
+    public async Task Publish_BySameSubjectAsProposer_Returns403_AndDoesNotMutate()
+    {
+        var draft = await CreateDraftAsAsync(
+            $"selfapproval-blocked-{Guid.NewGuid():N}".Substring(0, 24), "user:alice");
+        draft.ProposerSubjectId.Should().Be("user:alice");
+
+        var resp = await _client.PostAsJsonAsSubjectAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
+            new LifecycleTransitionRequest("self-publish"),
+            "user:alice");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        var problem = await resp.Content.ReadFromJsonAsync<ProblemDetails>(JsonOptions);
+        problem!.Title.Should().Be("Self-approval forbidden");
+        problem.Type.Should().Be("/problems/publish-self-approval");
+        problem.Extensions["errorCode"]!.ToString().Should().Be("policy.publish_self_approval_forbidden");
+
+        // No Active version exists for the policy after the failed publish.
+        var activeResp = await _client.GetAsync(
+            $"/api/policies/{draft.PolicyId}/versions/active");
+        activeResp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        // The draft itself remains in Draft state.
+        var stillDraft = await _client.GetFromJsonAsync<PolicyVersionDto>(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}", JsonOptions);
+        stillDraft!.State.Should().Be("Draft");
+    }
+
+    [Fact]
+    public async Task Publish_ByDifferentSubject_Returns200_AndFlipsToActive()
+    {
+        var draft = await CreateDraftAsAsync(
+            $"selfapproval-allowed-{Guid.NewGuid():N}".Substring(0, 24), "user:alice");
+
+        var resp = await _client.PostAsJsonAsSubjectAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
+            new LifecycleTransitionRequest("ship-it"),
+            "user:bob");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await resp.Content.ReadFromJsonAsync<PolicyVersionDto>(JsonOptions);
+        dto!.State.Should().Be("Active");
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Overrides/OverridesGateToggleTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Overrides/OverridesGateToggleTests.cs
@@ -121,7 +121,7 @@ public class OverridesGateToggleTests : IDisposable
         resp.EnsureSuccessStatusCode();
         var draft = (await resp.Content.ReadFromJsonAsync<PolicyVersionDto>(JsonOptions))!;
 
-        var publishResp = await client.PostAsJsonAsync(
+        var publishResp = await client.PostAsJsonAsApproverAsync(
             $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
             new LifecycleTransitionRequest("go-live"));
         publishResp.EnsureSuccessStatusCode();

--- a/tests/Andy.Policies.Tests.Integration/Parity/BindingCrossSurfaceParityTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Parity/BindingCrossSurfaceParityTests.cs
@@ -80,7 +80,7 @@ public class BindingCrossSurfaceParityTests : IClassFixture<PoliciesApiFactory>,
         draft.EnsureSuccessStatusCode();
         var version = (await draft.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
 
-        var publish = await _restClient.PostAsJsonAsync(
+        var publish = await _restClient.PostAsJsonAsApproverAsync(
             $"/api/policies/{version.PolicyId}/versions/{version.Id}/publish",
             new LifecycleTransitionRequest("parity"));
         publish.EnsureSuccessStatusCode();

--- a/tests/Andy.Policies.Tests.Unit/Services/LifecycleTransitionServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/LifecycleTransitionServiceTests.cs
@@ -170,6 +170,87 @@ public class LifecycleTransitionServiceTests
         await act.Should().ThrowAsync<NotFoundException>();
     }
 
+    // P7.3 (#55) — author-cannot-self-approve invariant on publish.
+
+    [Fact]
+    public async Task TransitionAsync_PublishWithActorMatchingProposer_ThrowsPublishSelfApprovalException()
+    {
+        var (svc, db, events) = NewService();
+        var (policy, draft) = await SeedDraftAsync(db, "pub-self-blocked");
+        draft.ProposerSubjectId = "user:alice";
+        await db.SaveChangesAsync();
+
+        var act = async () => await svc.TransitionAsync(
+            policy.Id, draft.Id, LifecycleState.Active, "self-publish", "user:alice");
+
+        var assertion = await act.Should().ThrowAsync<PublishSelfApprovalException>();
+        assertion.Which.PolicyVersionId.Should().Be(draft.Id);
+        assertion.Which.SubjectId.Should().Be("user:alice");
+
+        // No state mutation, no events dispatched.
+        var reloaded = await db.PolicyVersions.AsNoTracking().FirstAsync(v => v.Id == draft.Id);
+        reloaded.State.Should().Be(LifecycleState.Draft);
+        reloaded.PublishedAt.Should().BeNull();
+        events.Events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task TransitionAsync_PublishWithDifferentActor_FlipsToActive()
+    {
+        var (svc, db, _) = NewService();
+        var (policy, draft) = await SeedDraftAsync(db, "pub-distinct-actor");
+        draft.ProposerSubjectId = "user:alice";
+        await db.SaveChangesAsync();
+
+        var dto = await svc.TransitionAsync(
+            policy.Id, draft.Id, LifecycleState.Active, "go-live", "user:bob");
+
+        dto.State.Should().Be("Active");
+        var reloaded = await db.PolicyVersions.AsNoTracking().FirstAsync(v => v.Id == draft.Id);
+        reloaded.State.Should().Be(LifecycleState.Active);
+        reloaded.PublishedBySubjectId.Should().Be("user:bob");
+    }
+
+    [Fact]
+    public async Task TransitionAsync_PublishOnNonDraft_ThrowsInvalidLifecycleBeforeSelfApproval()
+    {
+        // Publish-on-non-Draft must surface the matrix error first, not
+        // the self-approval one — the lifecycle gate runs before the
+        // domain invariant. Use a Retired version with proposer == actor;
+        // the matrix-only result keeps the error contract stable for
+        // upstream callers (P7.4 handler tests rely on this ordering).
+        var (svc, db, _) = NewService();
+        var (policy, _) = await SeedDraftAsync(db, "pub-on-retired");
+        var retired = PolicyBuilders.AVersion(policy.Id, number: 2, state: LifecycleState.Retired);
+        retired.ProposerSubjectId = "user:alice";
+        db.PolicyVersions.Add(retired);
+        await db.SaveChangesAsync();
+
+        var act = async () => await svc.TransitionAsync(
+            policy.Id, retired.Id, LifecycleState.Active, "rezz", "user:alice");
+
+        await act.Should().ThrowAsync<InvalidLifecycleTransitionException>();
+    }
+
+    [Fact]
+    public async Task TransitionAsync_WindDownByProposer_DoesNotApplySelfApprovalCheck()
+    {
+        // The self-approval guard is publish-specific. WindingDown and
+        // Retire are administrative hygiene transitions and run even
+        // when actor == proposer.
+        var (svc, db, _) = NewService();
+        var (policy, draft) = await SeedDraftAsync(db, "winddown-by-proposer");
+        draft.ProposerSubjectId = "user:alice";
+        await db.SaveChangesAsync();
+        await svc.TransitionAsync(
+            policy.Id, draft.Id, LifecycleState.Active, "go-live", "user:bob");
+
+        var dto = await svc.TransitionAsync(
+            policy.Id, draft.Id, LifecycleState.WindingDown, "sunset", "user:alice");
+
+        dto.State.Should().Be("WindingDown");
+    }
+
     private sealed class RecordingDispatcher : IDomainEventDispatcher
     {
         public List<object> Events { get; } = new();


### PR DESCRIPTION
## Summary

Closes #55. Add a domain invariant on the publish path: when the actor's `SubjectId` equals the `PolicyVersion.ProposerSubjectId`, the publish is rejected with HTTP 403 — even if andy-rbac would allow both `:author` and `:publish` for that subject. Admin override is deliberately absent. `WindingDown` and `Retire` are administrative hygiene transitions and do not apply this check.

> **Note**: `ProposerSubjectId` already exists on `PolicyVersion` (since P1.1) and is populated by `PolicyService.CreateDraftAsync` / `BumpDraftFromVersionAsync` from the JWT `sub` claim. No migration or service-capture work is needed here — the column was always there waiting for this guard.

## Changes

- **`PublishSelfApprovalException`** — new domain exception in `Andy.Policies.Application.Exceptions`; carries `PolicyVersionId` + `SubjectId`. Distinct from the override `SelfApprovalException` (different errorCode, different problem type).
- **`LifecycleTransitionService.TransitionAsync`** — when `target == Active` and `actor == proposer`, throw before any state mutation. The existing matrix check still fires first for non-Draft inputs (verified by ordering test).
- **`PolicyExceptionHandler`** — maps to ProblemDetails 403 with `errorCode = "policy.publish_self_approval_forbidden"`, `Type = "/problems/publish-self-approval"`.

## Tests

- **Unit (+4)** in `LifecycleTransitionServiceTests`:
  - Rejection path throws with correct ids; no state mutation, no events dispatched.
  - Different actor flips to Active.
  - Matrix-before-self-approval ordering (publish-on-Retired surfaces `InvalidLifecycleTransitionException`, not the self-approval error).
  - Wind-down by proposer is allowed (administrative hygiene).
- **Integration (+2)** in `PublishSelfApprovalTests`:
  - Same-subject publish → 403 with the right ProblemDetails shape; no Active version under the policy; draft stays Draft.
  - Different-subject publish → 200, state Active.

## Test scaffolding

The blast radius from this guard is broad — every existing test that created and published in the same flow would now self-block. Sweep:

- `TestAuthHandler.TestApproverSubjectId` constant added.
- `TestRequestExtensions` — `PostAsJsonAs{Approver,Subject}Async` helpers that inject the `X-Test-Subject` header.
- ~17 publish call sites across 10 REST test files updated to `PostAsJsonAsApproverAsync` (mostly via a perl one-liner).
- gRPC tests (`LifecycleGrpcServiceTests`, `BindingsGrpcServiceTests`) pin the `CreateDraft` / `BumpDraft` caller to a `test-creator` subject via gRPC metadata so the default `test-user` can publish.
- CLI test does the same on its draft-create helper via `PostAsJsonAsSubjectAsync`.

## Acceptance criteria

- [x] `PolicyVersion.ProposerSubjectId` populated from caller subject (already in place from P1.1).
- [x] `LifecycleTransitionService.TransitionAsync(target=Active)` throws `PublishSelfApprovalException` when actor == proposer, before any DB write or audit append.
- [x] `POST .../publish` with actor == proposer → 403 ProblemDetails `title: "Self-approval forbidden"`; no Active version created.
- [x] `POST .../publish` with actor != proposer → 200, prior Active superseded (P2.3 behaviour unchanged).
- [x] `WindingDown` and `Retire` do **not** apply the self-approval check (asserted by unit test).
- [x] `dotnet build` — 0 warnings, 0 errors with `TreatWarningsAsErrors=true`.

## Test plan

- [x] `dotnet test tests/Andy.Policies.Tests.Unit` — 456 passed (+4 new)
- [x] `dotnet test tests/Andy.Policies.Tests.Integration` — 455 passed (+2 new)
- [ ] CI green