### PR TITLE
Implement P7.4 — ASP.NET authorization handlers + per-code policies (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,8 @@ The runtime adapter is `HttpRbacChecker` (P7.2, [#51](https://github.com/rivoli-
 
 **Author cannot self-approve** (P7.3, [#55](https://github.com/rivoli-ai/andy-policies/issues/55)). The publish endpoint rejects when the actor matches the version's `ProposerSubjectId` — even when andy-rbac would say *yes* to both `:author` and `:publish`. Domain invariant; admin override is deliberately absent. Returns **HTTP 403** with ProblemDetails `errorCode = "policy.publish_self_approval_forbidden"`, no state mutation. `WindingDown` and `Retire` are administrative hygiene transitions and do not apply this check.
 
+**Per-action policy attributes** (P7.4, [#57](https://github.com/rivoli-ai/andy-policies/issues/57)). Every REST controller action carries `[Authorize(Policy = "andy-policies:…")]` naming a permission code from the catalog above. `RbacAuthorizationHandler` extracts the subject id (`sub` / `NameIdentifier` / `Identity.Name`), the JWT `groups` claim, and a route-derived resource instance (`{type}:{routeId}`), then delegates to `IRbacChecker`. A denied or fail-closed decision means the action returns 403; an allowed decision lets the request proceed. MCP and gRPC interceptors (P7.6) reuse the same handler.
+
 ### Permission catalog
 
 | Code | Resource | Held by |

--- a/src/Andy.Policies.Api/Authorization/RbacAuthorizationHandler.cs
+++ b/src/Andy.Policies.Api/Authorization/RbacAuthorizationHandler.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Claims;
+using Andy.Policies.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Policies.Api.Authorization;
+
+/// <summary>
+/// Centralised <see cref="IRbacChecker"/> bridge for ASP.NET's policy
+/// authorization pipeline (P7.4, story rivoli-ai/andy-policies#57).
+/// Pulls the subject id and groups from the validated
+/// <see cref="ClaimsPrincipal"/> and the resource-instance id from the
+/// current route, then delegates the decision to andy-rbac via
+/// <c>HttpRbacChecker</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Per CLAUDE.md (#103) there is <b>no auth-bypass branch</b>. The
+/// handler always calls <see cref="IRbacChecker"/>; tests substitute a
+/// stub checker via DI. If the production andy-rbac is unreachable,
+/// <c>HttpRbacChecker</c>'s fail-closed default surfaces here as
+/// <see cref="RbacDecision.Allowed"/> = <c>false</c>, which the
+/// pipeline then maps to HTTP 403.
+/// </para>
+/// <para>
+/// Subject extraction tries
+/// <see cref="ClaimTypes.NameIdentifier"/> (JWT <c>sub</c> after the
+/// ASP.NET default claim mapping), then the raw <c>sub</c> claim (in
+/// case mapping has been disabled), then
+/// <see cref="System.Security.Principal.IIdentity.Name"/> (the
+/// <see cref="ClaimTypes.Name"/> claim used by the integration test
+/// auth scheme). This mirrors the controller-level fallback already
+/// present at write sites such as
+/// <see cref="Controllers.PolicyVersionsLifecycleController"/>.
+/// </para>
+/// </remarks>
+public sealed class RbacAuthorizationHandler : AuthorizationHandler<RbacRequirement>
+{
+    private readonly IRbacChecker _rbac;
+    private readonly IHttpContextAccessor _httpContext;
+    private readonly ILogger<RbacAuthorizationHandler> _log;
+
+    public RbacAuthorizationHandler(
+        IRbacChecker rbac,
+        IHttpContextAccessor httpContext,
+        ILogger<RbacAuthorizationHandler> log)
+    {
+        _rbac = rbac;
+        _httpContext = httpContext;
+        _log = log;
+    }
+
+    protected override async Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        RbacRequirement requirement)
+    {
+        var ctx = _httpContext.HttpContext;
+        if (ctx is null)
+        {
+            return;
+        }
+
+        var subjectId = ResolveSubjectId(context.User);
+        if (string.IsNullOrWhiteSpace(subjectId))
+        {
+            // Authentication ran but no subject claim — let the
+            // framework convert this into 403. (401 is the
+            // authentication layer's job; we don't see unauthenticated
+            // calls here.)
+            return;
+        }
+
+        var groups = context.User.FindAll("groups").Select(c => c.Value).ToList();
+        var resourceInstanceId = RouteResourceResolver.Resolve(ctx, requirement.PermissionCode);
+
+        var decision = await _rbac.CheckAsync(
+            subjectId,
+            requirement.PermissionCode,
+            groups,
+            resourceInstanceId,
+            ctx.RequestAborted).ConfigureAwait(false);
+
+        if (decision.Allowed)
+        {
+            context.Succeed(requirement);
+            return;
+        }
+
+        _log.LogInformation(
+            "rbac deny subject={Subject} permission={Permission} instance={Instance} reason={Reason}",
+            subjectId, requirement.PermissionCode, resourceInstanceId ?? "(none)", decision.Reason);
+    }
+
+    private static string? ResolveSubjectId(ClaimsPrincipal user)
+        => user.FindFirstValue(ClaimTypes.NameIdentifier)
+        ?? user.FindFirstValue("sub")
+        ?? user.Identity?.Name;
+}

--- a/src/Andy.Policies.Api/Authorization/RbacRequirement.cs
+++ b/src/Andy.Policies.Api/Authorization/RbacRequirement.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Microsoft.AspNetCore.Authorization;
+
+namespace Andy.Policies.Api.Authorization;
+
+/// <summary>
+/// Authorization requirement that names a single permission code from
+/// the P7.1 RBAC manifest (<c>config/registration.json</c>). One
+/// requirement is registered per code so policy names round-trip via
+/// the standard <c>[Authorize(Policy = "andy-policies:…")]</c>
+/// attribute (P7.4, story rivoli-ai/andy-policies#57).
+/// </summary>
+public sealed class RbacRequirement(string permissionCode) : IAuthorizationRequirement
+{
+    public string PermissionCode { get; } = permissionCode;
+}

--- a/src/Andy.Policies.Api/Authorization/RouteResourceResolver.cs
+++ b/src/Andy.Policies.Api/Authorization/RouteResourceResolver.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Andy.Policies.Api.Authorization;
+
+/// <summary>
+/// Best-effort lift of the resource-instance id from the current request
+/// route values. Maps a permission code's resource-type prefix
+/// (<c>policy:</c>, <c>binding:</c>, …) to the conventional route
+/// parameter names used by the controllers and returns the canonical
+/// <c>"{resourceType}:{routeValue}"</c> string. Returns <c>null</c> when
+/// no candidate is present — the call then targets the application
+/// scope rather than a specific instance.
+/// </summary>
+public static class RouteResourceResolver
+{
+    private static readonly (string TypePrefix, string ResourceType, string[] RouteKeys)[] Mappings =
+    {
+        ("andy-policies:policy:",   "policy",   new[] { "id", "policyId" }),
+        ("andy-policies:binding:",  "binding",  new[] { "id", "bindingId" }),
+        ("andy-policies:scope:",    "scope",    new[] { "id", "scopeId" }),
+        ("andy-policies:override:", "override", new[] { "id", "overrideId" }),
+        ("andy-policies:bundle:",   "bundle",   new[] { "id", "bundleId" }),
+        ("andy-policies:audit:",    "audit",    new[] { "id", "eventId", "seq" }),
+    };
+
+    public static string? Resolve(HttpContext httpContext, string permissionCode)
+    {
+        foreach (var (typePrefix, resourceType, routeKeys) in Mappings)
+        {
+            if (!permissionCode.StartsWith(typePrefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+            foreach (var key in routeKeys)
+            {
+                if (httpContext.Request.RouteValues.TryGetValue(key, out var value)
+                    && value is not null)
+                {
+                    var v = value.ToString();
+                    if (!string.IsNullOrEmpty(v))
+                    {
+                        return $"{resourceType}:{v}";
+                    }
+                }
+            }
+            return null;
+        }
+        return null;
+    }
+}

--- a/src/Andy.Policies.Api/Controllers/AuditController.cs
+++ b/src/Andy.Policies.Api/Controllers/AuditController.cs
@@ -73,6 +73,7 @@ public sealed class AuditController : ControllerBase
     /// <response code="403">Caller lacks the
     /// <c>andy-policies:audit:verify</c> permission (P7.2).</response>
     [HttpGet("verify")]
+    [Authorize(Policy = "andy-policies:audit:verify")]
     [ProducesResponseType(typeof(ChainVerificationDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
@@ -123,6 +124,7 @@ public sealed class AuditController : ControllerBase
     /// 500.</param>
     /// <param name="ct">Request cancellation token.</param>
     [HttpGet]
+    [Authorize(Policy = "andy-policies:audit:read")]
     [ProducesResponseType(typeof(AuditPageDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]

--- a/src/Andy.Policies.Api/Controllers/BindingsController.cs
+++ b/src/Andy.Policies.Api/Controllers/BindingsController.cs
@@ -44,6 +44,7 @@ public sealed class BindingsController : ControllerBase
     /// <c>targetRef</c> returns 400.
     /// </summary>
     [HttpPost]
+    [Authorize(Policy = "andy-policies:binding:manage")]
     [ProducesResponseType(typeof(BindingDto), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
@@ -66,6 +67,7 @@ public sealed class BindingsController : ControllerBase
     /// investigators can inspect their <c>DeletedAt</c> stamp.
     /// </summary>
     [HttpGet("{id:guid}")]
+    [Authorize(Policy = "andy-policies:binding:read")]
     [ProducesResponseType(typeof(BindingDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<BindingDto>> Get(Guid id, CancellationToken ct)
@@ -81,6 +83,7 @@ public sealed class BindingsController : ControllerBase
     /// the audit record.
     /// </summary>
     [HttpDelete("{id:guid}")]
+    [Authorize(Policy = "andy-policies:binding:manage")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
@@ -104,6 +107,7 @@ public sealed class BindingsController : ControllerBase
     /// rows.
     /// </summary>
     [HttpGet("")]
+    [Authorize(Policy = "andy-policies:binding:read")]
     [ProducesResponseType(typeof(IReadOnlyList<BindingDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IReadOnlyList<BindingDto>>> Query(
@@ -132,6 +136,7 @@ public sealed class BindingsController : ControllerBase
     /// unknown target returns 200 with <c>count = 0</c>, never 404.
     /// </summary>
     [HttpGet("resolve")]
+    [Authorize(Policy = "andy-policies:binding:read")]
     [ProducesResponseType(typeof(ResolveBindingsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<ResolveBindingsResponse>> Resolve(

--- a/src/Andy.Policies.Api/Controllers/OverridesController.cs
+++ b/src/Andy.Policies.Api/Controllers/OverridesController.cs
@@ -65,6 +65,7 @@ public sealed class OverridesController : ControllerBase
     /// <c>POST /api/overrides/{id}/approve</c>.
     /// </summary>
     [HttpPost]
+    [Authorize(Policy = "andy-policies:override:propose")]
     [OverrideWriteGate]
     [ProducesResponseType(typeof(OverrideDto), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
@@ -89,6 +90,7 @@ public sealed class OverridesController : ControllerBase
     /// <c>Proposed</c>.
     /// </summary>
     [HttpPost("{id:guid}/approve")]
+    [Authorize(Policy = "andy-policies:override:approve")]
     [OverrideWriteGate]
     [ProducesResponseType(typeof(OverrideDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
@@ -109,6 +111,7 @@ public sealed class OverridesController : ControllerBase
     /// <c>Expired</c> path goes through P5.3 instead.
     /// </summary>
     [HttpPost("{id:guid}/revoke")]
+    [Authorize(Policy = "andy-policies:override:revoke")]
     [OverrideWriteGate]
     [ProducesResponseType(typeof(OverrideDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
@@ -134,6 +137,7 @@ public sealed class OverridesController : ControllerBase
     /// scope-narrowed-and-non-expired projection.
     /// </summary>
     [HttpGet]
+    [Authorize(Policy = "andy-policies:override:read")]
     [ProducesResponseType(typeof(IReadOnlyList<OverrideDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
@@ -154,6 +158,7 @@ public sealed class OverridesController : ControllerBase
     /// row is still readable for audit).
     /// </summary>
     [HttpGet("{id:guid}", Name = nameof(Get))]
+    [Authorize(Policy = "andy-policies:override:read")]
     [ProducesResponseType(typeof(OverrideDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
@@ -171,6 +176,7 @@ public sealed class OverridesController : ControllerBase
     /// resolution and by Conductor at admission time.
     /// </summary>
     [HttpGet("active")]
+    [Authorize(Policy = "andy-policies:override:read")]
     [ProducesResponseType(typeof(IReadOnlyList<OverrideDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]

--- a/src/Andy.Policies.Api/Controllers/PoliciesController.cs
+++ b/src/Andy.Policies.Api/Controllers/PoliciesController.cs
@@ -27,6 +27,7 @@ public class PoliciesController : ControllerBase
     }
 
     [HttpGet]
+    [Authorize(Policy = "andy-policies:policy:read")]
     public async Task<ActionResult<IReadOnlyList<PolicyDto>>> List(
         [FromQuery] string? namePrefix,
         [FromQuery] string? scope,
@@ -49,6 +50,7 @@ public class PoliciesController : ControllerBase
     }
 
     [HttpGet("{id:guid}")]
+    [Authorize(Policy = "andy-policies:policy:read")]
     public async Task<ActionResult<PolicyDto>> Get(Guid id, CancellationToken ct)
     {
         var policy = await _policies.GetPolicyAsync(id, ct);
@@ -56,6 +58,7 @@ public class PoliciesController : ControllerBase
     }
 
     [HttpGet("by-name/{name}")]
+    [Authorize(Policy = "andy-policies:policy:read")]
     public async Task<ActionResult<PolicyDto>> GetByName(string name, CancellationToken ct)
     {
         var policy = await _policies.GetPolicyByNameAsync(name, ct);
@@ -63,6 +66,7 @@ public class PoliciesController : ControllerBase
     }
 
     [HttpGet("{id:guid}/versions")]
+    [Authorize(Policy = "andy-policies:policy:read")]
     public async Task<ActionResult<IReadOnlyList<PolicyVersionDto>>> ListVersions(
         Guid id, CancellationToken ct)
     {
@@ -77,6 +81,7 @@ public class PoliciesController : ControllerBase
     /// and the GUID constraint makes the two routes unambiguous regardless.
     /// </summary>
     [HttpGet("{id:guid}/versions/active")]
+    [Authorize(Policy = "andy-policies:policy:read")]
     public async Task<ActionResult<PolicyVersionDto>> GetActiveVersion(
         Guid id, CancellationToken ct)
     {
@@ -85,6 +90,7 @@ public class PoliciesController : ControllerBase
     }
 
     [HttpGet("{id:guid}/versions/{versionId:guid}")]
+    [Authorize(Policy = "andy-policies:policy:read")]
     public async Task<ActionResult<PolicyVersionDto>> GetVersion(
         Guid id, Guid versionId, CancellationToken ct)
     {
@@ -93,6 +99,7 @@ public class PoliciesController : ControllerBase
     }
 
     [HttpPost]
+    [Authorize(Policy = "andy-policies:policy:author")]
     public async Task<ActionResult<PolicyVersionDto>> Create(
         [FromBody] CreatePolicyRequest request, CancellationToken ct)
     {
@@ -105,6 +112,7 @@ public class PoliciesController : ControllerBase
     }
 
     [HttpPut("{id:guid}/versions/{versionId:guid}")]
+    [Authorize(Policy = "andy-policies:policy:author")]
     public async Task<ActionResult<PolicyVersionDto>> UpdateDraft(
         Guid id,
         Guid versionId,
@@ -117,6 +125,7 @@ public class PoliciesController : ControllerBase
     }
 
     [HttpPost("{id:guid}/versions/{sourceVersionId:guid}/bump")]
+    [Authorize(Policy = "andy-policies:policy:author")]
     public async Task<ActionResult<PolicyVersionDto>> Bump(
         Guid id, Guid sourceVersionId, CancellationToken ct)
     {

--- a/src/Andy.Policies.Api/Controllers/PolicyVersionBindingsController.cs
+++ b/src/Andy.Policies.Api/Controllers/PolicyVersionBindingsController.cs
@@ -34,6 +34,7 @@ public sealed class PolicyVersionBindingsController : ControllerBase
     /// tombstoned rows; default <c>false</c> hides them.
     /// </summary>
     [HttpGet("")]
+    [Authorize(Policy = "andy-policies:binding:read")]
     [ProducesResponseType(typeof(IReadOnlyList<BindingDto>), StatusCodes.Status200OK)]
     public async Task<ActionResult<IReadOnlyList<BindingDto>>> List(
         Guid policyId,

--- a/src/Andy.Policies.Api/Controllers/PolicyVersionsLifecycleController.cs
+++ b/src/Andy.Policies.Api/Controllers/PolicyVersionsLifecycleController.cs
@@ -41,6 +41,7 @@ public sealed class PolicyVersionsLifecycleController : ControllerBase
     /// (if any) within the same DB transaction.
     /// </summary>
     [HttpPost("publish")]
+    [Authorize(Policy = "andy-policies:policy:publish")]
     [ProducesResponseType(typeof(PolicyVersionDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
@@ -57,6 +58,7 @@ public sealed class PolicyVersionsLifecycleController : ControllerBase
     /// Active continue to resolve until the version is retired.
     /// </summary>
     [HttpPost("winding-down")]
+    [Authorize(Policy = "andy-policies:policy:transition")]
     [ProducesResponseType(typeof(PolicyVersionDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
@@ -73,6 +75,7 @@ public sealed class PolicyVersionsLifecycleController : ControllerBase
     /// rejected by the matrix.
     /// </summary>
     [HttpPost("retire")]
+    [Authorize(Policy = "andy-policies:policy:transition")]
     [ProducesResponseType(typeof(PolicyVersionDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]

--- a/src/Andy.Policies.Api/Controllers/ScopesController.cs
+++ b/src/Andy.Policies.Api/Controllers/ScopesController.cs
@@ -45,6 +45,7 @@ public sealed class ScopesController : ControllerBase
     /// (Depth, Ref).
     /// </summary>
     [HttpGet]
+    [Authorize(Policy = "andy-policies:scope:read")]
     [ProducesResponseType(typeof(IReadOnlyList<ScopeNodeDto>), StatusCodes.Status200OK)]
     public async Task<ActionResult<IReadOnlyList<ScopeNodeDto>>> List(
         [FromQuery] ScopeType? type,
@@ -61,6 +62,7 @@ public sealed class ScopesController : ControllerBase
     /// snapshotting.
     /// </summary>
     [HttpGet("tree")]
+    [Authorize(Policy = "andy-policies:scope:read")]
     [ProducesResponseType(typeof(IReadOnlyList<ScopeTreeDto>), StatusCodes.Status200OK)]
     public async Task<ActionResult<IReadOnlyList<ScopeTreeDto>>> Tree(CancellationToken ct)
     {
@@ -72,6 +74,7 @@ public sealed class ScopesController : ControllerBase
     /// Get a single scope node by id. Returns 404 if not found.
     /// </summary>
     [HttpGet("{id:guid}")]
+    [Authorize(Policy = "andy-policies:scope:read")]
     [ProducesResponseType(typeof(ScopeNodeDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ScopeNodeDto>> Get(Guid id, CancellationToken ct)
@@ -86,6 +89,7 @@ public sealed class ScopesController : ControllerBase
     /// doesn't exist.
     /// </summary>
     [HttpGet("{id:guid}/effective-policies")]
+    [Authorize(Policy = "andy-policies:scope:read")]
     [ProducesResponseType(typeof(EffectivePolicySetDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<EffectivePolicySetDto>> Effective(Guid id, CancellationToken ct)
@@ -102,6 +106,7 @@ public sealed class ScopesController : ControllerBase
     /// returns 400.
     /// </summary>
     [HttpPost]
+    [Authorize(Policy = "andy-policies:scope:manage")]
     [ProducesResponseType(typeof(ScopeNodeDto), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
@@ -121,6 +126,7 @@ public sealed class ScopesController : ControllerBase
     /// leaves first.
     /// </summary>
     [HttpDelete("{id:guid}")]
+    [Authorize(Policy = "andy-policies:scope:manage")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -51,7 +51,37 @@ builder.Services.AddAuthentication("Bearer")
             };
         }
     });
-builder.Services.AddAuthorization();
+// P7.4 (#57): every permission code in the P7.1 manifest gets a
+// matching ASP.NET authorization policy whose RbacRequirement points
+// at IRbacChecker. Controllers attach via [Authorize(Policy = "code")].
+// Listed verbatim so the round-trip from manifest → policy registration
+// → controller attribute is grep-able. Adding a code requires a manifest
+// update + a new entry here + a [Authorize(Policy = ...)] at the call
+// site; the unit test in ManifestTests already pins the manifest side.
+string[] rbacPermissionCodes =
+{
+    "andy-policies:policy:read",        "andy-policies:policy:author",
+    "andy-policies:policy:publish",     "andy-policies:policy:transition",
+    "andy-policies:binding:read",       "andy-policies:binding:manage",
+    "andy-policies:scope:read",         "andy-policies:scope:manage",
+    "andy-policies:override:read",      "andy-policies:override:propose",
+    "andy-policies:override:approve",   "andy-policies:override:revoke",
+    "andy-policies:bundle:read",        "andy-policies:bundle:create",
+    "andy-policies:bundle:delete",      "andy-policies:audit:read",
+    "andy-policies:audit:export",       "andy-policies:audit:verify",
+};
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddSingleton<
+    Microsoft.AspNetCore.Authorization.IAuthorizationHandler,
+    Andy.Policies.Api.Authorization.RbacAuthorizationHandler>();
+builder.Services.AddAuthorization(options =>
+{
+    foreach (var code in rbacPermissionCodes)
+    {
+        options.AddPolicy(code, p =>
+            p.Requirements.Add(new Andy.Policies.Api.Authorization.RbacRequirement(code)));
+    }
+});
 
 // --- HttpClient defaults ---
 // Dev-only: accept self-signed certs from local andy-* services so

--- a/tests/Andy.Policies.Tests.Integration/Audit/AuditListEndpointTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Audit/AuditListEndpointTests.cs
@@ -65,6 +65,8 @@ public class AuditListEndpointTests : IDisposable
                 if (ctxDescriptor is not null) services.Remove(ctxDescriptor);
                 services.AddDbContext<AppDbContext>(opts => opts.UseSqlite(_connection));
 
+                services.ReplaceWithAllowAll();
+
                 services.AddAuthentication(TestAuthHandler.SchemeName)
                     .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
                         TestAuthHandler.SchemeName, _ => { });

--- a/tests/Andy.Policies.Tests.Integration/Authorization/RbacAuthorizationHandlerTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Authorization/RbacAuthorizationHandlerTests.cs
@@ -1,0 +1,187 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Claims;
+using Andy.Policies.Api.Authorization;
+using Andy.Policies.Application.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Authorization;
+
+/// <summary>
+/// P7.4 (#57) — exercises <see cref="RbacAuthorizationHandler"/> over a
+/// stub <see cref="IRbacChecker"/> and a synthetic
+/// <see cref="HttpContext"/>. No webhost is needed; these are unit-shaped
+/// tests living in the integration project because the handler ships in
+/// <c>Andy.Policies.Api</c>, which only the integration project
+/// references.
+/// </summary>
+public class RbacAuthorizationHandlerTests
+{
+    private const string Permission = "andy-policies:policy:publish";
+
+    private static (RbacAuthorizationHandler handler, RecordingChecker rbac, DefaultHttpContext ctx)
+        Build()
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.RouteValues["id"] = "11111111-1111-1111-1111-111111111111";
+        var accessor = new HttpContextAccessor { HttpContext = ctx };
+        var rbac = new RecordingChecker();
+        var handler = new RbacAuthorizationHandler(
+            rbac, accessor, NullLogger<RbacAuthorizationHandler>.Instance);
+        return (handler, rbac, ctx);
+    }
+
+    private static AuthorizationHandlerContext NewAuthContext(
+        DefaultHttpContext httpCtx, ClaimsPrincipal user, RbacRequirement requirement)
+    {
+        httpCtx.User = user;
+        return new AuthorizationHandlerContext(new[] { requirement }, user, resource: null);
+    }
+
+    [Fact]
+    public async Task Allow_OnRbacApprove_SucceedsRequirement()
+    {
+        var (handler, rbac, ctx) = Build();
+        rbac.Decision = new RbacDecision(true, "role:approver");
+        var user = NewUser(("sub", "user:alice"));
+        var auth = NewAuthContext(ctx, user, new RbacRequirement(Permission));
+
+        await handler.HandleAsync(auth);
+
+        auth.HasSucceeded.Should().BeTrue();
+        rbac.Calls.Should().HaveCount(1);
+        rbac.Calls[0].SubjectId.Should().Be("user:alice");
+        rbac.Calls[0].Permission.Should().Be(Permission);
+        rbac.Calls[0].ResourceInstance.Should().Be("policy:11111111-1111-1111-1111-111111111111");
+    }
+
+    [Fact]
+    public async Task Deny_OnRbacReject_DoesNotSucceedRequirement()
+    {
+        var (handler, rbac, ctx) = Build();
+        rbac.Decision = new RbacDecision(false, "no-permission");
+        var user = NewUser(("sub", "user:bob"));
+        var auth = NewAuthContext(ctx, user, new RbacRequirement(Permission));
+
+        await handler.HandleAsync(auth);
+
+        auth.HasSucceeded.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task FailClosed_TreatedAsDeny()
+    {
+        var (handler, rbac, ctx) = Build();
+        rbac.Decision = new RbacDecision(false, "rbac-unreachable: fail-closed default");
+        var user = NewUser(("sub", "user:alice"));
+        var auth = NewAuthContext(ctx, user, new RbacRequirement(Permission));
+
+        await handler.HandleAsync(auth);
+
+        auth.HasSucceeded.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task MissingSubjectClaim_ReturnsWithoutSucceedingOrCallingRbac()
+    {
+        var (handler, rbac, ctx) = Build();
+        var emptyUser = new ClaimsPrincipal(new ClaimsIdentity());
+        var auth = NewAuthContext(ctx, emptyUser, new RbacRequirement(Permission));
+
+        await handler.HandleAsync(auth);
+
+        auth.HasSucceeded.Should().BeFalse();
+        rbac.Calls.Should().BeEmpty(
+            "no subject means no rbac call — let the framework return 403");
+    }
+
+    [Fact]
+    public async Task SubjectId_PrefersNameIdentifier_ThenSub_ThenIdentityName()
+    {
+        var (handler, rbac, ctx) = Build();
+        rbac.Decision = new RbacDecision(true, "ok");
+
+        // NameIdentifier wins.
+        var user1 = NewUser(
+            (ClaimTypes.NameIdentifier, "from-nameid"),
+            ("sub", "from-sub"),
+            (ClaimTypes.Name, "from-name"));
+        await handler.HandleAsync(NewAuthContext(ctx, user1, new RbacRequirement(Permission)));
+        rbac.Calls[^1].SubjectId.Should().Be("from-nameid");
+
+        // sub wins when NameIdentifier absent.
+        var user2 = NewUser(("sub", "from-sub"), (ClaimTypes.Name, "from-name"));
+        await handler.HandleAsync(NewAuthContext(ctx, user2, new RbacRequirement(Permission)));
+        rbac.Calls[^1].SubjectId.Should().Be("from-sub");
+
+        // Identity.Name fallback when neither claim is present.
+        var user3 = NewUser((ClaimTypes.Name, "from-name"));
+        await handler.HandleAsync(NewAuthContext(ctx, user3, new RbacRequirement(Permission)));
+        rbac.Calls[^1].SubjectId.Should().Be("from-name");
+    }
+
+    [Fact]
+    public async Task Groups_ArePassedThroughToRbac()
+    {
+        var (handler, rbac, ctx) = Build();
+        rbac.Decision = new RbacDecision(true, "ok");
+        var user = NewUser(
+            ("sub", "user:alice"),
+            ("groups", "team:authors"),
+            ("groups", "team:eu"));
+        var auth = NewAuthContext(ctx, user, new RbacRequirement(Permission));
+
+        await handler.HandleAsync(auth);
+
+        auth.HasSucceeded.Should().BeTrue();
+        rbac.Calls[0].Groups.Should().BeEquivalentTo(new[] { "team:authors", "team:eu" });
+    }
+
+    [Fact]
+    public async Task NoRouteId_PassesNullResourceInstance()
+    {
+        var ctx = new DefaultHttpContext();
+        var accessor = new HttpContextAccessor { HttpContext = ctx };
+        var rbac = new RecordingChecker { Decision = new RbacDecision(true, "ok") };
+        var handler = new RbacAuthorizationHandler(
+            rbac, accessor, NullLogger<RbacAuthorizationHandler>.Instance);
+        var user = NewUser(("sub", "user:alice"));
+        var auth = NewAuthContext(ctx, user,
+            new RbacRequirement("andy-policies:policy:read"));
+
+        await handler.HandleAsync(auth);
+
+        rbac.Calls[0].ResourceInstance.Should().BeNull();
+    }
+
+    private static ClaimsPrincipal NewUser(params (string Type, string Value)[] claims)
+    {
+        var identity = new ClaimsIdentity(authenticationType: "Test");
+        foreach (var (type, value) in claims)
+        {
+            identity.AddClaim(new Claim(type, value));
+        }
+        return new ClaimsPrincipal(identity);
+    }
+
+    private sealed class RecordingChecker : IRbacChecker
+    {
+        public RbacDecision Decision { get; set; } = new(true, "default-allow");
+
+        public List<(string SubjectId, string Permission, IReadOnlyList<string> Groups, string? ResourceInstance)>
+            Calls { get; } = new();
+
+        public Task<RbacDecision> CheckAsync(
+            string subjectId, string permissionCode, IReadOnlyList<string> groups,
+            string? resourceInstanceId, CancellationToken ct)
+        {
+            Calls.Add((subjectId, permissionCode, groups, resourceInstanceId));
+            return Task.FromResult(Decision);
+        }
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Authorization/RouteResourceResolverTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Authorization/RouteResourceResolverTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Api.Authorization;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Authorization;
+
+/// <summary>
+/// P7.4 (#57) — pin the route-value → resource-instance mapping that
+/// the <c>RbacAuthorizationHandler</c> attaches to every outgoing
+/// <c>POST /api/check</c>.
+/// </summary>
+public class RouteResourceResolverTests
+{
+    private static HttpContext WithRoute(params (string Key, object Value)[] values)
+    {
+        var ctx = new DefaultHttpContext();
+        foreach (var (key, value) in values)
+        {
+            ctx.Request.RouteValues[key] = value;
+        }
+        return ctx;
+    }
+
+    [Theory]
+    [InlineData("andy-policies:policy:read", "id", "11111111-1111-1111-1111-111111111111", "policy:11111111-1111-1111-1111-111111111111")]
+    [InlineData("andy-policies:policy:publish", "policyId", "abc", "policy:abc")]
+    [InlineData("andy-policies:binding:read", "id", "b-42", "binding:b-42")]
+    [InlineData("andy-policies:binding:manage", "bindingId", "b-7", "binding:b-7")]
+    [InlineData("andy-policies:scope:manage", "id", "s-1", "scope:s-1")]
+    [InlineData("andy-policies:override:approve", "id", "o-9", "override:o-9")]
+    [InlineData("andy-policies:bundle:read", "bundleId", "b-3", "bundle:b-3")]
+    [InlineData("andy-policies:audit:read", "id", "a-1", "audit:a-1")]
+    public void Resolve_RouteWithMatchingKey_ReturnsTypedInstance(
+        string permissionCode, string routeKey, string routeValue, string expected)
+    {
+        var ctx = WithRoute((routeKey, routeValue));
+
+        RouteResourceResolver.Resolve(ctx, permissionCode).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Resolve_RouteWithNoMatchingKey_ReturnsNull()
+    {
+        var ctx = WithRoute(("unrelated", "x"));
+
+        RouteResourceResolver.Resolve(ctx, "andy-policies:policy:publish").Should().BeNull();
+    }
+
+    [Fact]
+    public void Resolve_EmptyRouteValues_ReturnsNull()
+    {
+        var ctx = new DefaultHttpContext();
+
+        RouteResourceResolver.Resolve(ctx, "andy-policies:policy:read").Should().BeNull();
+    }
+
+    [Fact]
+    public void Resolve_UnknownPermissionPrefix_ReturnsNull()
+    {
+        var ctx = WithRoute(("id", "x-1"));
+
+        RouteResourceResolver.Resolve(ctx, "some-other-app:resource:read").Should().BeNull();
+    }
+
+    [Fact]
+    public void Resolve_PrefersFirstCandidateRouteKey()
+    {
+        // Both `id` and `policyId` are candidates for policy codes; `id`
+        // is listed first, so it wins.
+        var ctx = WithRoute(("id", "first"), ("policyId", "second"));
+
+        RouteResourceResolver.Resolve(ctx, "andy-policies:policy:read").Should().Be("policy:first");
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/BackgroundServices/OverrideExpiryReaperIntegrationTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/BackgroundServices/OverrideExpiryReaperIntegrationTests.cs
@@ -90,6 +90,8 @@ public class OverrideExpiryReaperIntegrationTests
                 if (snapshotDescriptor is not null) services.Remove(snapshotDescriptor);
                 services.AddSingleton<ISettingsSnapshot>(Snapshot);
 
+                services.ReplaceWithAllowAll();
+
                 services.AddAuthentication(TestAuthHandler.SchemeName)
                     .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
                         TestAuthHandler.SchemeName, _ => { });

--- a/tests/Andy.Policies.Tests.Integration/Controllers/RationaleEnforcementTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/RationaleEnforcementTests.cs
@@ -88,6 +88,8 @@ public class RationaleEnforcementTests
                 if (snapshotDescriptor is not null) services.Remove(snapshotDescriptor);
                 services.AddSingleton<ISettingsSnapshot>(Snapshot);
 
+                services.ReplaceWithAllowAll();
+
                 services.AddAuthentication(TestAuthHandler.SchemeName)
                     .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
                         TestAuthHandler.SchemeName, _ => { });

--- a/tests/Andy.Policies.Tests.Integration/Controllers/TestRbacOverride.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/TestRbacOverride.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Andy.Policies.Tests.Integration.Controllers;
+
+/// <summary>
+/// Helper for test factories that swap the production
+/// <see cref="IRbacChecker"/> (an <c>HttpRbacChecker</c> pointed at a
+/// placeholder URL) with an inline allow-all stub. Without this swap,
+/// the controller-level <c>[Authorize(Policy = "andy-policies:…")]</c>
+/// attributes added in P7.4 (#57) would fail-closed deny on every
+/// request.
+/// </summary>
+internal static class TestRbacOverride
+{
+    public static IServiceCollection ReplaceWithAllowAll(this IServiceCollection services)
+    {
+        var existing = services
+            .Where(d => d.ServiceType == typeof(IRbacChecker))
+            .ToList();
+        foreach (var d in existing) services.Remove(d);
+        services.AddSingleton<IRbacChecker>(new AllowAllStubRbacChecker());
+        return services;
+    }
+
+    private sealed class AllowAllStubRbacChecker : IRbacChecker
+    {
+        public Task<RbacDecision> CheckAsync(
+            string subjectId,
+            string permissionCode,
+            IReadOnlyList<string> groups,
+            string? resourceInstanceId,
+            CancellationToken ct)
+            => Task.FromResult(new RbacDecision(true, "test-allow"));
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Overrides/OverridesGateToggleTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Overrides/OverridesGateToggleTests.cs
@@ -79,6 +79,8 @@ public class OverridesGateToggleTests : IDisposable
                 if (gateDescriptor is not null) services.Remove(gateDescriptor);
                 services.AddSingleton<IExperimentalOverridesGate>(Gate);
 
+                services.ReplaceWithAllowAll();
+
                 services.AddAuthentication(TestAuthHandler.SchemeName)
                     .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
                         TestAuthHandler.SchemeName, _ => { });


### PR DESCRIPTION
## Summary

Closes #57. Wire `IRbacChecker` (P7.2) into ASP.NET's policy authorization pipeline so every controller action gates through andy-rbac via a standard `[Authorize(Policy = "andy-policies:…")]` attribute. One requirement per permission code keeps the policy name self-documenting and grep-able from manifest → `Program.cs` registration → controller attribute.

> **Spec note**: the issue described an *auth-bypass branch* when `AndyAuth:Authority` is empty. Per `CLAUDE.md` and #103 the API now refuses to start without it, so that branch would be dead code. Skipped — the handler always calls `IRbacChecker`, and tests substitute an allow-all stub via DI.

## Changes

- **`src/Andy.Policies.Api/Authorization/`** *(new)*:
  - `RbacRequirement` — `IAuthorizationRequirement` carrying the permission code.
  - `RbacAuthorizationHandler` — extracts subject id (`NameIdentifier` → `sub` → `Identity.Name`), the JWT `groups` claim, and the route-derived resource instance, then delegates to `IRbacChecker`.
  - `RouteResourceResolver` — maps a permission code's resource-type prefix to a list of route-key candidates (`policy:` → `id`/`policyId`, `binding:` → `id`/`bindingId`, etc.) and returns the canonical `{type}:{routeValue}` string.
- **`Program.cs`** — `AddHttpContextAccessor` + `RbacAuthorizationHandler` as `IAuthorizationHandler`; `AddAuthorization` enumerates the 18 permission codes from P7.1 and registers one `RbacRequirement`-bearing policy per code.
- **All 7 controllers** decorated with `[Authorize(Policy = "...")]` per action:
  - `PoliciesController`: list/get/get-by-name/list-versions/get-active/get-version → `policy:read`; create/update/bump → `policy:author`.
  - `PolicyVersionsLifecycleController`: publish → `policy:publish`; winding-down/retire → `policy:transition`.
  - `BindingsController` + `PolicyVersionBindingsController`: read/list/resolve → `binding:read`; create/delete → `binding:manage`.
  - `ScopesController`: read/list/tree/effective → `scope:read`; create/delete → `scope:manage`.
  - `OverridesController`: read/list/active → `override:read`; propose → `override:propose`; approve → `override:approve`; revoke → `override:revoke`.
  - `AuditController`: list → `audit:read`; verify → `audit:verify`.

## Tests

- **`RouteResourceResolverTests`** (8 tests) — six type prefixes via `[Theory]`, plus edge cases (empty route, unknown prefix, missing key, multi-key precedence).
- **`RbacAuthorizationHandlerTests`** (7 tests) — allow / deny / fail-closed / missing-sub / claim priority / groups pass-through / no-route-id pass-through.
- Tests live in the **Integration** project because the API is only referenced from there; no webhost is required for these.
- **Test scaffolding**: new `TestRbacOverride.ReplaceWithAllowAll()` helper consolidates the inline allow-all stub. Four existing test factories that previously had no `IRbacChecker` override (`AuditListEndpointTests`, `OverridesGateToggleTests`, `RationaleEnforcementTests`, `OverrideExpiryReaperIntegrationTests`) now call `services.ReplaceWithAllowAll()` so the new `[Authorize(Policy=…)]` attributes don't fail-closed deny.

## Acceptance criteria

- [x] `RbacRequirement` + `RbacAuthorizationHandler` exist under `src/Andy.Policies.Api/Authorization/`; handler is registered as `IAuthorizationHandler` in `Program.cs`.
- [x] `Program.cs` calls `AddAuthorization` with all 18 policy names from the P7.1 catalog; each policy holds one `RbacRequirement` whose `PermissionCode` equals the policy name.
- [x] `PoliciesController` actions carry `[Authorize(Policy = "andy-policies:policy:{read|author|publish|transition}")]` (publish/transition live on `PolicyVersionsLifecycleController`).
- [x] When andy-rbac replies `Allowed=true` → request proceeds; `false` → 403; fail-closed → 403.
- [x] Outgoing `ResourceInstanceId` equals `"{resourceType}:{routeId}"` for route-bearing endpoints, `null` otherwise (asserted by `RbacAuthorizationHandlerTests` + `RouteResourceResolverTests`).
- [x] `dotnet build` — 0 warnings, 0 errors with `TreatWarningsAsErrors=true`.

## Test plan

- [x] `dotnet test tests/Andy.Policies.Tests.Unit` — 456 passed.
- [x] `dotnet test tests/Andy.Policies.Tests.Integration --filter "Category!=Perf"` — 471 passed.
- [ ] CI green.

> Per the issue's "fixture shared with P7.5" note, the WireMock-backed full-stack `PolicyAuthorizationTests` is deferred to **P7.5 (#61)** which already owns the WireMock harness setup.