### PR TITLE
Implement P7.6 — gRPC + MCP authorization parity (#64)

### DIFF
--- a/src/Andy.Policies.Api/GrpcServices/Authorization/GrpcMethodPermissionMap.cs
+++ b/src/Andy.Policies.Api/GrpcServices/Authorization/GrpcMethodPermissionMap.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Api.GrpcServices.Authorization;
+
+/// <summary>
+/// Authoritative mapping of every enforced gRPC method to its
+/// <c>andy-policies:…</c> permission code. P7.6 (#64).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The package prefix in the keys (<c>"/andy_policies."</c>) matches
+/// the proto <c>package andy_policies;</c> declaration; the service
+/// segment matches <c>service XxxService { … }</c>; the method segment
+/// matches the rpc name.
+/// </para>
+/// <para>
+/// <b>Items service is intentionally absent.</b> It ships as template
+/// scaffolding and is not a governance surface — the
+/// <see cref="RbacServerInterceptor"/> bypasses it via the
+/// <see cref="IsEnforcedService"/> allowlist below. Every other
+/// service must have every rpc mapped here, which is asserted by a
+/// reflection-based coverage test in the integration project.
+/// </para>
+/// </remarks>
+public sealed class GrpcMethodPermissionMap : IGrpcMethodPermissionMap
+{
+    private static readonly IReadOnlyDictionary<string, string> Map = new Dictionary<string, string>
+    {
+        // PolicyService — reads + drafting
+        ["/andy_policies.PolicyService/ListPolicies"]      = "andy-policies:policy:read",
+        ["/andy_policies.PolicyService/GetPolicy"]         = "andy-policies:policy:read",
+        ["/andy_policies.PolicyService/GetPolicyByName"]   = "andy-policies:policy:read",
+        ["/andy_policies.PolicyService/ListVersions"]      = "andy-policies:policy:read",
+        ["/andy_policies.PolicyService/GetVersion"]        = "andy-policies:policy:read",
+        ["/andy_policies.PolicyService/GetActiveVersion"]  = "andy-policies:policy:read",
+        ["/andy_policies.PolicyService/CreateDraft"]       = "andy-policies:policy:author",
+        ["/andy_policies.PolicyService/UpdateDraft"]       = "andy-policies:policy:author",
+        ["/andy_policies.PolicyService/BumpDraft"]         = "andy-policies:policy:author",
+
+        // LifecycleService — publish + wind-down + retire + matrix
+        ["/andy_policies.LifecycleService/PublishVersion"]    = "andy-policies:policy:publish",
+        ["/andy_policies.LifecycleService/TransitionVersion"] = "andy-policies:policy:transition",
+        ["/andy_policies.LifecycleService/GetMatrix"]         = "andy-policies:policy:read",
+
+        // BindingService
+        ["/andy_policies.BindingService/CreateBinding"]                = "andy-policies:binding:manage",
+        ["/andy_policies.BindingService/DeleteBinding"]                = "andy-policies:binding:manage",
+        ["/andy_policies.BindingService/GetBinding"]                   = "andy-policies:binding:read",
+        ["/andy_policies.BindingService/ListBindingsByPolicyVersion"]  = "andy-policies:binding:read",
+        ["/andy_policies.BindingService/ListBindingsByTarget"]         = "andy-policies:binding:read",
+        ["/andy_policies.BindingService/ResolveBindings"]              = "andy-policies:binding:read",
+
+        // ScopesService
+        ["/andy_policies.ScopesService/ListScopes"]            = "andy-policies:scope:read",
+        ["/andy_policies.ScopesService/GetScope"]              = "andy-policies:scope:read",
+        ["/andy_policies.ScopesService/GetScopeTree"]          = "andy-policies:scope:read",
+        ["/andy_policies.ScopesService/GetEffectivePolicies"]  = "andy-policies:scope:read",
+        ["/andy_policies.ScopesService/CreateScope"]           = "andy-policies:scope:manage",
+        ["/andy_policies.ScopesService/DeleteScope"]           = "andy-policies:scope:manage",
+
+        // OverridesService
+        ["/andy_policies.OverridesService/ProposeOverride"]   = "andy-policies:override:propose",
+        ["/andy_policies.OverridesService/ApproveOverride"]   = "andy-policies:override:approve",
+        ["/andy_policies.OverridesService/RevokeOverride"]    = "andy-policies:override:revoke",
+        ["/andy_policies.OverridesService/ListOverrides"]     = "andy-policies:override:read",
+        ["/andy_policies.OverridesService/GetOverride"]       = "andy-policies:override:read",
+        ["/andy_policies.OverridesService/GetActiveOverrides"]= "andy-policies:override:read",
+
+        // AuditService
+        ["/andy_policies.AuditService/ListAudit"]    = "andy-policies:audit:read",
+        ["/andy_policies.AuditService/GetAudit"]     = "andy-policies:audit:read",
+        ["/andy_policies.AuditService/VerifyAudit"]  = "andy-policies:audit:verify",
+        ["/andy_policies.AuditService/ExportAudit"]  = "andy-policies:audit:export",
+    };
+
+    /// <summary>Services not in this set are allowed to bypass RBAC.
+    /// Currently only the template-scaffolding ItemsService.</summary>
+    private static readonly HashSet<string> EnforcedServices = new(StringComparer.Ordinal)
+    {
+        "/andy_policies.PolicyService",
+        "/andy_policies.LifecycleService",
+        "/andy_policies.BindingService",
+        "/andy_policies.ScopesService",
+        "/andy_policies.OverridesService",
+        "/andy_policies.AuditService",
+    };
+
+    public IReadOnlyDictionary<string, string> Entries => Map;
+
+    public bool TryGetPermission(string fullyQualifiedMethod, out string permissionCode)
+    {
+        if (Map.TryGetValue(fullyQualifiedMethod, out var code))
+        {
+            permissionCode = code;
+            return true;
+        }
+        permissionCode = string.Empty;
+        return false;
+    }
+
+    public static bool IsEnforcedService(string fullyQualifiedMethod)
+    {
+        var slash = fullyQualifiedMethod.LastIndexOf('/');
+        if (slash <= 0) return false;
+        var serviceSegment = fullyQualifiedMethod[..slash];
+        return EnforcedServices.Contains(serviceSegment);
+    }
+}

--- a/src/Andy.Policies.Api/GrpcServices/Authorization/IGrpcMethodPermissionMap.cs
+++ b/src/Andy.Policies.Api/GrpcServices/Authorization/IGrpcMethodPermissionMap.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Api.GrpcServices.Authorization;
+
+/// <summary>
+/// Maps a fully-qualified gRPC method name (e.g.
+/// <c>"/andy.policies.v1.LifecycleService/PublishVersion"</c>) to a
+/// permission code from the P7.1 manifest. The
+/// <see cref="RbacServerInterceptor"/> consults this map for every
+/// inbound RPC; an unmapped method is a hard failure (10/Internal)
+/// rather than fail-open.
+/// </summary>
+public interface IGrpcMethodPermissionMap
+{
+    bool TryGetPermission(string fullyQualifiedMethod, out string permissionCode);
+
+    IReadOnlyDictionary<string, string> Entries { get; }
+}

--- a/src/Andy.Policies.Api/GrpcServices/Authorization/RbacServerInterceptor.cs
+++ b/src/Andy.Policies.Api/GrpcServices/Authorization/RbacServerInterceptor.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Claims;
+using Andy.Policies.Application.Interfaces;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Policies.Api.GrpcServices.Authorization;
+
+/// <summary>
+/// Global gRPC server interceptor that applies the same RBAC contract
+/// as the REST <see cref="Andy.Policies.Api.Authorization.RbacAuthorizationHandler"/>:
+/// extract subject + groups from the inbound principal, look up the
+/// permission code for the called method, and delegate to
+/// <see cref="IRbacChecker"/>. Deny → <c>RpcException(PermissionDenied)</c>.
+/// P7.6 (#64).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Unmapped methods on enforced services</b> throw
+/// <c>RpcException(Internal, "no permission mapping")</c> rather than
+/// allowing through. This is fail-closed by design — adding a new RPC
+/// without a permission code in
+/// <see cref="GrpcMethodPermissionMap"/> would be a security gap.
+/// </para>
+/// <para>
+/// <b>Items service is intentionally bypassed</b> — see
+/// <see cref="GrpcMethodPermissionMap.IsEnforcedService"/>.
+/// </para>
+/// </remarks>
+public sealed class RbacServerInterceptor : Interceptor
+{
+    private readonly IRbacChecker _rbac;
+    private readonly IGrpcMethodPermissionMap _map;
+    private readonly ILogger<RbacServerInterceptor> _log;
+
+    public RbacServerInterceptor(
+        IRbacChecker rbac,
+        IGrpcMethodPermissionMap map,
+        ILogger<RbacServerInterceptor> log)
+    {
+        _rbac = rbac;
+        _map = map;
+        _log = log;
+    }
+
+    public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
+        TRequest request,
+        ServerCallContext context,
+        UnaryServerMethod<TRequest, TResponse> continuation)
+    {
+        await EnforceAsync(context).ConfigureAwait(false);
+        return await continuation(request, context).ConfigureAwait(false);
+    }
+
+    public override async Task ServerStreamingServerHandler<TRequest, TResponse>(
+        TRequest request,
+        IServerStreamWriter<TResponse> responseStream,
+        ServerCallContext context,
+        ServerStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        await EnforceAsync(context).ConfigureAwait(false);
+        await continuation(request, responseStream, context).ConfigureAwait(false);
+    }
+
+    private async Task EnforceAsync(ServerCallContext context)
+    {
+        if (!GrpcMethodPermissionMap.IsEnforcedService(context.Method))
+        {
+            return;
+        }
+        if (!_map.TryGetPermission(context.Method, out var permissionCode))
+        {
+            // Hard fail rather than allow-through: a missing entry is
+            // a security gap, not an oversight to silently paper over.
+            throw new RpcException(new Status(StatusCode.Internal,
+                $"no permission mapping for gRPC method {context.Method}"));
+        }
+
+        var user = context.GetHttpContext().User;
+        var subjectId = user.FindFirstValue(ClaimTypes.NameIdentifier)
+                     ?? user.FindFirstValue("sub")
+                     ?? user.Identity?.Name
+                     ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(subjectId))
+        {
+            throw new RpcException(new Status(StatusCode.Unauthenticated, "no subject claim"));
+        }
+        var groups = user.FindAll("groups").Select(c => c.Value).ToList();
+
+        var decision = await _rbac.CheckAsync(
+            subjectId, permissionCode, groups,
+            resourceInstanceId: null, // P7.6 v1: no per-instance for gRPC.
+            ct: context.CancellationToken).ConfigureAwait(false);
+
+        if (!decision.Allowed)
+        {
+            _log.LogInformation(
+                "grpc rbac deny subject={Sub} method={Method} reason={Reason}",
+                subjectId, context.Method, decision.Reason);
+            throw new RpcException(new Status(StatusCode.PermissionDenied, decision.Reason));
+        }
+    }
+}

--- a/src/Andy.Policies.Api/Mcp/AuditTools.cs
+++ b/src/Andy.Policies.Api/Mcp/AuditTools.cs
@@ -4,8 +4,10 @@
 using System.ComponentModel;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Andy.Policies.Api.Mcp.Authorization;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
+using Microsoft.AspNetCore.Http;
 using ModelContextProtocol.Server;
 
 namespace Andy.Policies.Api.Mcp;
@@ -32,11 +34,12 @@ namespace Andy.Policies.Api.Mcp;
 /// <c>andy-policies-cli audit verify --file</c> (P6.5).
 /// </para>
 /// <para>
-/// <b>RBAC posture.</b> Per-tool RBAC (<c>audit:read</c>,
-/// <c>audit:verify</c>, <c>audit:export</c>) lands with P7.2
-/// (#51) when the andy-rbac client wires up; today the JWT
-/// layer at the MCP edge enforces authentication and that
-/// suffices for development.
+/// <b>RBAC posture.</b> Per-tool RBAC (<c>audit:verify</c>,
+/// <c>audit:export</c>) is enforced via <see cref="McpRbacGuard"/>
+/// since P7.6 (#64), mirroring the gRPC interceptor on
+/// <c>AuditService</c>. Reads (<c>list</c>, <c>get</c>) remain
+/// gated only by JWT auth at the MCP edge; the gRPC
+/// surface is the canonical enforcement point for read-side.
 /// </para>
 /// </remarks>
 [McpServerToolType]
@@ -133,8 +136,11 @@ public static class AuditTools
         "inspectedCount, and lastSeq. Divergence is a queryable state, not " +
         "an error — valid=false with firstDivergenceSeq pinpoints the " +
         "tampered row.")]
+    [RbacGuard("andy-policies:audit:verify")]
     public static async Task<string> Verify(
         IAuditChain chain,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Inclusive lower seq bound. Defaults to 1.")] long? fromSeq = null,
         [Description("Inclusive upper seq bound. Defaults to MAX(seq).")] long? toSeq = null,
         CancellationToken ct = default)
@@ -150,6 +156,16 @@ public static class AuditTools
         if (fromSeq is { } f && toSeq is { } t && f > t)
         {
             return $"policy.audit.invalid_argument: fromSeq ({f}) must be <= toSeq ({t}).";
+        }
+
+        try
+        {
+            await McpRbacGuard.EnsureAsync(rbac, httpContext,
+                "andy-policies:audit:verify", null, ct);
+        }
+        catch (McpAuthorizationException ex)
+        {
+            return $"policy.audit.forbidden: {ex.Reason}";
         }
 
         var result = await chain.VerifyChainAsync(fromSeq, toSeq, ct).ConfigureAwait(false);
@@ -169,8 +185,11 @@ public static class AuditTools
         "and exportedAt. The bundle is verifiable offline by " +
         "andy-policies-cli audit verify --file. Integrity is via the " +
         "embedded hash chain — no external KMS / detached signature.")]
+    [RbacGuard("andy-policies:audit:export")]
     public static async Task<string> Export(
         IAuditExporter exporter,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Inclusive lower seq bound. Defaults to 1.")] long? fromSeq = null,
         [Description("Inclusive upper seq bound. Defaults to MAX(seq).")] long? toSeq = null,
         CancellationToken ct = default)
@@ -186,6 +205,16 @@ public static class AuditTools
         if (fromSeq is { } f && toSeq is { } t && f > t)
         {
             return $"policy.audit.invalid_argument: fromSeq ({f}) must be <= toSeq ({t}).";
+        }
+
+        try
+        {
+            await McpRbacGuard.EnsureAsync(rbac, httpContext,
+                "andy-policies:audit:export", null, ct);
+        }
+        catch (McpAuthorizationException ex)
+        {
+            return $"policy.audit.forbidden: {ex.Reason}";
         }
 
         // Buffer in memory before base64-encoding for the MCP

--- a/src/Andy.Policies.Api/Mcp/Authorization/McpRbacGuard.cs
+++ b/src/Andy.Policies.Api/Mcp/Authorization/McpRbacGuard.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Claims;
+using Andy.Policies.Application.Interfaces;
+using Microsoft.AspNetCore.Http;
+
+namespace Andy.Policies.Api.Mcp.Authorization;
+
+/// <summary>
+/// Per-tool RBAC enforcement for MCP. The MCP framework
+/// (<c>ModelContextProtocol</c>) does not surface a middleware seam
+/// for tool dispatch, so each mutating tool calls
+/// <see cref="EnsureAsync"/> at the top of its body. Same contract
+/// as the REST <c>RbacAuthorizationHandler</c> and the gRPC
+/// <c>RbacServerInterceptor</c>: subject + groups extracted from the
+/// authenticated principal, decision delegated to
+/// <see cref="IRbacChecker"/>, deny → throw. P7.6 (#64).
+/// </summary>
+public static class McpRbacGuard
+{
+    /// <summary>
+    /// Throws <see cref="McpAuthorizationException"/> when the call
+    /// must be denied. Returns silently on allow.
+    /// </summary>
+    public static async Task EnsureAsync(
+        IRbacChecker rbac,
+        IHttpContextAccessor httpContext,
+        string permissionCode,
+        string? resourceInstanceId,
+        CancellationToken ct)
+    {
+        var ctx = httpContext.HttpContext
+            ?? throw new McpAuthorizationException(
+                permissionCode, "no-http-context",
+                "MCP tool ran without an HTTP context — cannot extract caller identity.");
+
+        var subjectId = ctx.User.FindFirstValue(ClaimTypes.NameIdentifier)
+                     ?? ctx.User.FindFirstValue("sub")
+                     ?? ctx.User.Identity?.Name;
+        if (string.IsNullOrWhiteSpace(subjectId))
+        {
+            throw new McpAuthorizationException(
+                permissionCode, "no-subject",
+                "MCP caller is missing a subject claim.");
+        }
+
+        var groups = ctx.User.FindAll("groups").Select(c => c.Value).ToList();
+        var decision = await rbac.CheckAsync(
+            subjectId, permissionCode, groups, resourceInstanceId, ct).ConfigureAwait(false);
+        if (!decision.Allowed)
+        {
+            throw new McpAuthorizationException(
+                permissionCode, decision.Reason,
+                $"MCP caller '{subjectId}' is not permitted to '{permissionCode}'" +
+                (resourceInstanceId is null ? "." : $" on '{resourceInstanceId}'.") +
+                $" Reason: {decision.Reason}");
+        }
+    }
+}
+
+/// <summary>
+/// Thrown by <see cref="McpRbacGuard.EnsureAsync"/> when the caller is
+/// denied. MCP tools may catch this and translate to their typed
+/// error string (e.g. <c>"policy.override.forbidden: …"</c>) so the
+/// caller sees a structured tool result rather than an opaque server
+/// failure.
+/// </summary>
+public sealed class McpAuthorizationException : Exception
+{
+    public string PermissionCode { get; }
+
+    public string Reason { get; }
+
+    public McpAuthorizationException(string permissionCode, string reason, string message)
+        : base(message)
+    {
+        PermissionCode = permissionCode;
+        Reason = reason;
+    }
+}

--- a/src/Andy.Policies.Api/Mcp/Authorization/RbacGuardAttribute.cs
+++ b/src/Andy.Policies.Api/Mcp/Authorization/RbacGuardAttribute.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Api.Mcp.Authorization;
+
+/// <summary>
+/// Declarative marker for MCP tool methods naming the
+/// <c>andy-policies:…</c> permission code that the tool requires.
+/// Coupled with <see cref="McpRbacGuard.EnsureAsync"/> the MCP tool
+/// body invokes at the top — the attribute itself does not enforce;
+/// it pins the contract for code review and reflective coverage tests.
+/// P7.6 (#64).
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+public sealed class RbacGuardAttribute : Attribute
+{
+    public string PermissionCode { get; }
+
+    public RbacGuardAttribute(string permissionCode)
+    {
+        PermissionCode = permissionCode;
+    }
+}

--- a/src/Andy.Policies.Api/Mcp/BindingTools.cs
+++ b/src/Andy.Policies.Api/Mcp/BindingTools.cs
@@ -6,10 +6,12 @@ using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Andy.Policies.Api.Mcp.Authorization;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Exceptions;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Domain.Enums;
+using Microsoft.AspNetCore.Http;
 using ModelContextProtocol.Server;
 
 namespace Andy.Policies.Api.Mcp;
@@ -69,9 +71,11 @@ public static class BindingTools
         "one of: Template, Repo, ScopeNode, Tenant, Org (case-insensitive). " +
         "bindStrength is Mandatory or Recommended. Refuses bindings to Retired " +
         "versions with policy.binding.retired_target.")]
+    [RbacGuard("andy-policies:binding:manage")]
     public static async Task<string> Create(
         IBindingService service,
         IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Target policy version id (GUID)")] string policyVersionId,
         [Description("One of: Template, Repo, ScopeNode, Tenant, Org")] string targetType,
         [Description("Target reference (e.g. 'template:abc', 'repo:org/name')")] string targetRef,
@@ -99,6 +103,16 @@ public static class BindingTools
 
         try
         {
+            await McpRbacGuard.EnsureAsync(rbac, httpContext,
+                "andy-policies:binding:manage", $"version:{vid}", ct);
+        }
+        catch (McpAuthorizationException ex)
+        {
+            return $"policy.binding.forbidden: {ex.Reason}";
+        }
+
+        try
+        {
             var dto = await service.CreateAsync(
                 new CreateBindingRequest(vid, tt, targetRef, bs), actor, ct);
             return FormatBindingDetail(dto);
@@ -122,9 +136,11 @@ public static class BindingTools
         "row; the binding remains for the audit chain. Optional rationale is " +
         "recorded against the audit event. Returns policy.binding.not_found " +
         "if the binding does not exist or is already tombstoned.")]
+    [RbacGuard("andy-policies:binding:manage")]
     public static async Task<string> Delete(
         IBindingService service,
         IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Binding id (GUID)")] string bindingId,
         [Description("Optional rationale recorded against the audit event")] string? rationale = null,
         CancellationToken ct = default)
@@ -138,6 +154,16 @@ public static class BindingTools
         if (actor is null)
         {
             return "Authentication required: no subject id present on the caller's claims principal.";
+        }
+
+        try
+        {
+            await McpRbacGuard.EnsureAsync(rbac, httpContext,
+                "andy-policies:binding:manage", $"binding:{id}", ct);
+        }
+        catch (McpAuthorizationException ex)
+        {
+            return $"policy.binding.forbidden: {ex.Reason}";
         }
 
         try

--- a/src/Andy.Policies.Api/Mcp/OverrideTools.cs
+++ b/src/Andy.Policies.Api/Mcp/OverrideTools.cs
@@ -9,8 +9,10 @@ using System.Text.Json.Serialization;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Exceptions;
 using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Api.Mcp.Authorization;
 using Andy.Policies.Application.Settings;
 using Andy.Policies.Domain.Enums;
+using Microsoft.AspNetCore.Http;
 using ModelContextProtocol.Server;
 
 namespace Andy.Policies.Api.Mcp;
@@ -68,10 +70,12 @@ public static class OverrideTools
         "Effect is Exempt (no replacement) or Replace (requires " +
         "replacementPolicyVersionId). Returns policy.override.disabled " +
         "when andy.policies.experimentalOverridesEnabled is off.")]
+    [RbacGuard("andy-policies:override:propose")]
     public static async Task<string> Propose(
         IOverrideService service,
         IExperimentalOverridesGate gate,
         IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Target policy version id (GUID)")] string policyVersionId,
         [Description("Principal or Cohort")] string scopeKind,
         [Description("Opaque scope ref (e.g. 'user:42', 'cohort:beta-testers'); ≤256 chars")] string scopeRef,
@@ -119,6 +123,16 @@ public static class OverrideTools
 
         try
         {
+            await McpRbacGuard.EnsureAsync(rbac, httpContext,
+                "andy-policies:override:propose", scopeRef, ct);
+        }
+        catch (McpAuthorizationException ex)
+        {
+            return $"policy.override.forbidden: {ex.Reason}";
+        }
+
+        try
+        {
             var dto = await service.ProposeAsync(
                 new ProposeOverrideRequest(pvid, sk, scopeRef, ef, replacementId, exp, rationale),
                 actor, ct);
@@ -138,10 +152,12 @@ public static class OverrideTools
         "Approve a proposed override. Approver must differ from proposer " +
         "(returns policy.override.self_approval_forbidden otherwise). " +
         "Returns policy.override.invalid_state if the row is past Proposed.")]
+    [RbacGuard("andy-policies:override:approve")]
     public static async Task<string> Approve(
         IOverrideService service,
         IExperimentalOverridesGate gate,
         IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Override id (GUID)")] string id,
         CancellationToken ct = default)
     {
@@ -158,6 +174,16 @@ public static class OverrideTools
         if (actor is null)
         {
             return "Authentication required: no subject id present on the caller's claims principal.";
+        }
+
+        try
+        {
+            await McpRbacGuard.EnsureAsync(rbac, httpContext,
+                "andy-policies:override:approve", $"override:{oid}", ct);
+        }
+        catch (McpAuthorizationException ex)
+        {
+            return $"policy.override.forbidden: {ex.Reason}";
         }
 
         try
@@ -187,10 +213,12 @@ public static class OverrideTools
         "Revoke an override (Proposed or Approved). Requires a non-empty " +
         "revocationReason. Reaper-driven Expired transitions go through " +
         "P5.3 instead.")]
+    [RbacGuard("andy-policies:override:revoke")]
     public static async Task<string> Revoke(
         IOverrideService service,
         IExperimentalOverridesGate gate,
         IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Override id (GUID)")] string id,
         [Description("Required non-empty revocation reason; ≤2000 chars")] string revocationReason,
         CancellationToken ct = default)
@@ -208,6 +236,16 @@ public static class OverrideTools
         if (actor is null)
         {
             return "Authentication required: no subject id present on the caller's claims principal.";
+        }
+
+        try
+        {
+            await McpRbacGuard.EnsureAsync(rbac, httpContext,
+                "andy-policies:override:revoke", $"override:{oid}", ct);
+        }
+        catch (McpAuthorizationException ex)
+        {
+            return $"policy.override.forbidden: {ex.Reason}";
         }
 
         try

--- a/src/Andy.Policies.Api/Mcp/PolicyLifecycleTools.cs
+++ b/src/Andy.Policies.Api/Mcp/PolicyLifecycleTools.cs
@@ -4,6 +4,7 @@
 using System.ComponentModel;
 using System.Security.Claims;
 using System.Text;
+using Andy.Policies.Api.Mcp.Authorization;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Exceptions;
 using Andy.Policies.Application.Interfaces;
@@ -44,14 +45,18 @@ public static class PolicyLifecycleTools
         "Active version of the same policy in the same DB transaction. Requires a " +
         "non-empty rationale when andy.policies.rationaleRequired is true (default). " +
         "Returns the updated version on success or a human-readable error string.")]
+    [RbacGuard("andy-policies:policy:publish")]
     public static Task<string> Publish(
         ILifecycleTransitionService transitions,
         IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Policy id (GUID)")] string policyId,
         [Description("PolicyVersion id (GUID) of the Draft to publish")] string versionId,
         [Description("Human-readable reason recorded against the publish event")] string rationale,
         CancellationToken ct = default)
-        => TransitionAsync(transitions, httpContext, policyId, versionId,
+        => TransitionAsync(transitions, httpContext, rbac,
+            "andy-policies:policy:publish",
+            policyId, versionId,
             LifecycleState.Active.ToString(), rationale, ct);
 
     [McpServerTool(Name = "policy.version.transition"), Description(
@@ -60,15 +65,19 @@ public static class PolicyLifecycleTools
         "Any other (from, to) pair returns INVALID_TRANSITION. targetState is parsed " +
         "case-insensitively; targetState=Draft is rejected because the matrix has no edge " +
         "into Draft. Use policy.lifecycle.matrix to introspect allowed transitions.")]
+    [RbacGuard("andy-policies:policy:transition")]
     public static async Task<string> Transition(
         ILifecycleTransitionService transitions,
         IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Policy id (GUID)")] string policyId,
         [Description("PolicyVersion id (GUID)")] string versionId,
         [Description("One of: Active, WindingDown, Retired (case-insensitive)")] string targetState,
         [Description("Human-readable reason recorded against the transition event")] string rationale,
         CancellationToken ct = default)
-        => await TransitionAsync(transitions, httpContext, policyId, versionId, targetState, rationale, ct);
+        => await TransitionAsync(transitions, httpContext, rbac,
+            "andy-policies:policy:transition",
+            policyId, versionId, targetState, rationale, ct);
 
     [McpServerTool(Name = "policy.lifecycle.matrix"), Description(
         "Returns the canonical lifecycle transition matrix as one rule per line. " +
@@ -90,6 +99,8 @@ public static class PolicyLifecycleTools
     private static async Task<string> TransitionAsync(
         ILifecycleTransitionService transitions,
         IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
+        string permissionCode,
         string policyId,
         string versionId,
         string targetState,
@@ -117,6 +128,16 @@ public static class PolicyLifecycleTools
             // here means the tool was wired without auth (or a custom transport
             // bypassed it). Fail loud rather than write a fallback subject id.
             return "Authentication required: no subject id present on the caller's claims principal.";
+        }
+
+        try
+        {
+            await McpRbacGuard.EnsureAsync(rbac, httpContext,
+                permissionCode, $"version:{vid}", ct);
+        }
+        catch (McpAuthorizationException ex)
+        {
+            return $"policy.lifecycle.forbidden: {ex.Reason}";
         }
 
         try

--- a/src/Andy.Policies.Api/Mcp/ScopeTools.cs
+++ b/src/Andy.Policies.Api/Mcp/ScopeTools.cs
@@ -5,10 +5,12 @@ using System.ComponentModel;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Andy.Policies.Api.Mcp.Authorization;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Exceptions;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Domain.Enums;
+using Microsoft.AspNetCore.Http;
 using ModelContextProtocol.Server;
 
 namespace Andy.Policies.Api.Mcp;
@@ -104,8 +106,11 @@ public static class ScopeTools
         "Org → Tenant → Team → Repo → Template → Run ladder; mismatched " +
         "parent type returns policy.scope.parent_type_mismatch. " +
         "Duplicate (Type, Ref) returns policy.scope.ref_conflict.")]
+    [RbacGuard("andy-policies:scope:manage")]
     public static async Task<string> Create(
         IScopeService service,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Parent scope node id (GUID). Empty / 'null' for a root Org.")] string? parentId,
         [Description("Scope type (Org/Tenant/Team/Repo/Template/Run).")] string type,
         [Description("Opaque scope reference (e.g. 'repo:rivoli-ai/conductor').")] string @ref,
@@ -126,6 +131,16 @@ public static class ScopeTools
                 return $"policy.scope.invalid_input: parentId '{parentId}' is not a valid GUID.";
             }
             parentGuid = parsed;
+        }
+
+        try
+        {
+            await McpRbacGuard.EnsureAsync(rbac, httpContext,
+                "andy-policies:scope:manage", $"{scopeType}:{@ref}", ct);
+        }
+        catch (McpAuthorizationException ex)
+        {
+            return $"policy.scope.forbidden: {ex.Reason}";
         }
 
         try
@@ -155,14 +170,26 @@ public static class ScopeTools
     [McpServerTool(Name = "policy.scope.delete"), Description(
         "Delete a leaf scope node. Refuses with " +
         "policy.scope.has_descendants when the node still has children.")]
+    [RbacGuard("andy-policies:scope:manage")]
     public static async Task<string> Delete(
         IScopeService service,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Scope node id (GUID).")] string id,
         CancellationToken ct = default)
     {
         if (!Guid.TryParse(id, out var nodeId))
         {
             return $"policy.scope.invalid_input: '{id}' is not a valid GUID.";
+        }
+        try
+        {
+            await McpRbacGuard.EnsureAsync(rbac, httpContext,
+                "andy-policies:scope:manage", $"scope:{nodeId}", ct);
+        }
+        catch (McpAuthorizationException ex)
+        {
+            return $"policy.scope.forbidden: {ex.Reason}";
         }
         try
         {

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -363,7 +363,16 @@ builder.Services.AddCors(options =>
 });
 
 // --- gRPC ---
-builder.Services.AddGrpc();
+// P7.6 (#64): the gRPC interceptor mirrors the REST auth handler's
+// contract — same IRbacChecker, same fail-closed posture, same per-
+// permission code names from the P7.1 manifest.
+builder.Services.AddSingleton<
+    Andy.Policies.Api.GrpcServices.Authorization.IGrpcMethodPermissionMap,
+    Andy.Policies.Api.GrpcServices.Authorization.GrpcMethodPermissionMap>();
+builder.Services.AddGrpc(options =>
+{
+    options.Interceptors.Add<Andy.Policies.Api.GrpcServices.Authorization.RbacServerInterceptor>();
+});
 
 // P2.5 (#15) — MCP lifecycle tools read the caller subject id from the
 // HttpContext claims (same source as REST, gRPC, CLI). Without this

--- a/tests/Andy.Policies.Tests.Integration/Authorization/GrpcPermissionMapCoverageTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Authorization/GrpcPermissionMapCoverageTests.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Reflection;
+using Andy.Policies.Api.GrpcServices.Authorization;
+using Andy.Policies.Api.Protos;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Authorization;
+
+/// <summary>
+/// P7.6 (#64) — reflection-driven coverage gate for the gRPC permission
+/// map. The interceptor fail-closes on an unmapped RPC by throwing
+/// <c>RpcException(Internal)</c>; that is the runtime safety net, but
+/// production should never see it. This test catches the gap at CI time
+/// by walking the proto-generated <c>*ServiceBase</c> classes and
+/// asserting every RPC has a permission code in <see cref="GrpcMethodPermissionMap"/>.
+/// Adding a new rpc without a map entry breaks this test.
+/// </summary>
+public class GrpcPermissionMapCoverageTests
+{
+    /// <summary>The proto-generated bases for every enforced gRPC service.</summary>
+    public static IEnumerable<object[]> EnforcedServiceBases() => new[]
+    {
+        new object[] { typeof(PolicyService.PolicyServiceBase) },
+        new object[] { typeof(LifecycleService.LifecycleServiceBase) },
+        new object[] { typeof(BindingService.BindingServiceBase) },
+        new object[] { typeof(ScopesService.ScopesServiceBase) },
+        new object[] { typeof(OverridesService.OverridesServiceBase) },
+        new object[] { typeof(AuditService.AuditServiceBase) },
+    };
+
+    [Theory]
+    [MemberData(nameof(EnforcedServiceBases))]
+    public void EveryRpcOnEnforcedServiceHasAPermissionCode(Type serviceBase)
+    {
+        var map = new GrpcMethodPermissionMap();
+        var serviceName = serviceBase.DeclaringType!.Name; // e.g. "PolicyService"
+
+        var rpcMethods = ProtoRpcMethodsOf(serviceBase);
+        rpcMethods.Should().NotBeEmpty(
+            $"{serviceBase.FullName} must expose at least one rpc — empty service is suspicious.");
+
+        var missing = new List<string>();
+        foreach (var m in rpcMethods)
+        {
+            var fqn = $"/andy_policies.{serviceName}/{m.Name}";
+            if (!map.TryGetPermission(fqn, out _))
+            {
+                missing.Add(fqn);
+            }
+        }
+
+        missing.Should().BeEmpty(
+            "every enforced gRPC RPC must have a permission code in GrpcMethodPermissionMap; " +
+            "the interceptor fail-closes on unmapped methods, so this is a security gap.");
+    }
+
+    [Fact]
+    public void MapDoesNotContainStaleEntriesForRetiredRpcs()
+    {
+        var map = new GrpcMethodPermissionMap();
+        var liveRpcs = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var row in EnforcedServiceBases())
+        {
+            var serviceBase = (Type)row[0];
+            var serviceName = serviceBase.DeclaringType!.Name;
+            foreach (var m in ProtoRpcMethodsOf(serviceBase))
+            {
+                liveRpcs.Add($"/andy_policies.{serviceName}/{m.Name}");
+            }
+        }
+
+        var stale = map.Entries.Keys.Where(k => !liveRpcs.Contains(k)).ToList();
+        stale.Should().BeEmpty(
+            "a permission entry that does not match any live rpc is dead code — " +
+            "it can mask a rename or deletion silently.");
+    }
+
+    [Fact]
+    public void ItemsServiceIsBypassedNotMapped()
+    {
+        var map = new GrpcMethodPermissionMap();
+        // ItemsService ships as template scaffolding; it is intentionally
+        // not enforced. Defend the bypass: no map entries, IsEnforcedService
+        // returns false.
+        map.Entries.Keys.Should().NotContain(k => k.StartsWith("/andy_policies.ItemsService/"));
+        GrpcMethodPermissionMap.IsEnforcedService("/andy_policies.ItemsService/CreateItem").Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Returns the rpc-shaped virtual methods declared on the proto-generated
+    /// <c>*ServiceBase</c>. Filters out <c>object</c> overrides and any
+    /// non-virtual surface that the generator emits.
+    /// </summary>
+    private static MethodInfo[] ProtoRpcMethodsOf(Type serviceBase)
+        => serviceBase
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => m.IsVirtual && !m.IsFinal)
+            .ToArray();
+}

--- a/tests/Andy.Policies.Tests.Integration/Fixtures/McpToolStubs.cs
+++ b/tests/Andy.Policies.Tests.Integration/Fixtures/McpToolStubs.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Claims;
+using Andy.Policies.Application.Interfaces;
+using Microsoft.AspNetCore.Http;
+
+namespace Andy.Policies.Tests.Integration.Fixtures;
+
+/// <summary>
+/// Shared stubs for the MCP-tool integration tests. The MCP tools take
+/// <see cref="IRbacChecker"/> + <see cref="IHttpContextAccessor"/>
+/// directly (P7.6 #64), so every test that drives a tool body must
+/// supply both. These helpers keep the test bodies focused on the
+/// MCP wire contract rather than restating the wiring per file.
+/// </summary>
+internal static class McpToolStubs
+{
+    /// <summary>An <see cref="IRbacChecker"/> that always allows.</summary>
+    public static IRbacChecker AllowAllRbac { get; } = new AllowAllRbacChecker();
+
+    /// <summary>An <see cref="IRbacChecker"/> that always denies with
+    /// <c>"no-permission"</c>.</summary>
+    public static IRbacChecker DenyAllRbac { get; } = new DenyAllRbacChecker();
+
+    /// <summary>
+    /// Build a static <see cref="IHttpContextAccessor"/> whose principal
+    /// has the supplied subject id. Pass <c>null</c> for an
+    /// unauthenticated principal (no NameIdentifier claim).
+    /// </summary>
+    public static IHttpContextAccessor AccessorFor(string? subjectId)
+    {
+        var ctx = new DefaultHttpContext();
+        if (subjectId is not null)
+        {
+            ctx.User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, subjectId),
+            }, authenticationType: "Test"));
+        }
+        return new HttpContextAccessor { HttpContext = ctx };
+    }
+
+    private sealed class AllowAllRbacChecker : IRbacChecker
+    {
+        public Task<RbacDecision> CheckAsync(
+            string subjectId, string permissionCode, IReadOnlyList<string> groups,
+            string? resourceInstanceId, CancellationToken ct)
+            => Task.FromResult(new RbacDecision(true, "test-allow"));
+    }
+
+    private sealed class DenyAllRbacChecker : IRbacChecker
+    {
+        public Task<RbacDecision> CheckAsync(
+            string subjectId, string permissionCode, IReadOnlyList<string> groups,
+            string? resourceInstanceId, CancellationToken ct)
+            => Task.FromResult(new RbacDecision(false, "no-permission"));
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/GrpcServices/RbacInterceptorTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/GrpcServices/RbacInterceptorTests.cs
@@ -1,0 +1,257 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Api.Protos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Tests.Integration.Controllers;
+using FluentAssertions;
+using Grpc.Core;
+using Grpc.Net.Client;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.GrpcServices;
+
+/// <summary>
+/// P7.6 (#64) — runtime tests for
+/// <c>Andy.Policies.Api.GrpcServices.Authorization.RbacServerInterceptor</c>.
+/// The interceptor lives at the gRPC pipeline boundary, so a unit-shaped
+/// test against a hand-rolled <see cref="ServerCallContext"/> would not
+/// cover what we actually care about: that <c>AddGrpc(...).Interceptors.Add</c>
+/// in <c>Program.cs</c> wires it for every enforced RPC, that DI resolves
+/// the per-call <see cref="IRbacChecker"/>, and that denials surface as
+/// <c>RpcException</c>s the client SDK can branch on.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Companion files:
+/// </para>
+/// <list type="bullet">
+///   <item><see cref="Andy.Policies.Tests.Integration.Authorization.GrpcPermissionMapCoverageTests"/>
+///         — proves every enforced rpc has a permission code.</item>
+///   <item><c>OverrideToolsRbacTests</c> — proves the MCP <c>McpRbacGuard</c>
+///         contract; this file is the gRPC-side equivalent.</item>
+/// </list>
+/// <para>
+/// <b>Why a programmable RBAC instead of the WireMock fixture from P7.5?</b>
+/// The wire stub is appropriate for asserting the HTTP body shape of the
+/// outgoing andy-rbac call. Here we want fast, in-process control over
+/// the decision and observability of the captured permission code; a
+/// recording stub is the right tool for that.
+/// </para>
+/// </remarks>
+public class RbacInterceptorTests
+{
+    private sealed record CapturedRbacCall(string SubjectId, string PermissionCode, string? ResourceInstanceId);
+
+    private sealed class ProgrammableRbac : IRbacChecker
+    {
+        public RbacDecision NextDecision { get; set; } = new(true, "test-allow");
+
+        public List<CapturedRbacCall> Calls { get; } = new();
+
+        public Task<RbacDecision> CheckAsync(
+            string subjectId, string permissionCode, IReadOnlyList<string> groups,
+            string? resourceInstanceId, CancellationToken ct)
+        {
+            Calls.Add(new CapturedRbacCall(subjectId, permissionCode, resourceInstanceId));
+            return Task.FromResult(NextDecision);
+        }
+    }
+
+    /// <summary>
+    /// Variant of <see cref="PoliciesApiFactory"/> that lets a single test
+    /// program the <see cref="IRbacChecker"/>. Cannot reuse the stock
+    /// factory because it pins an allow-all stub at construction time.
+    /// </summary>
+    private sealed class RbacInterceptorFactory : WebApplicationFactory<Program>
+    {
+        public ProgrammableRbac Rbac { get; } = new();
+
+        private readonly SqliteConnection _connection = new("DataSource=:memory:");
+
+        public RbacInterceptorFactory()
+        {
+            _connection.Open();
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Testing");
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Database:Provider"] = "Sqlite",
+                    ["AndyAuth:Authority"] = "https://test-auth.invalid",
+                    ["AndySettings:ApiBaseUrl"] = "https://test-settings.invalid",
+                    ["AndyRbac:BaseUrl"] = "https://test-rbac.invalid",
+                });
+            });
+            builder.ConfigureServices(services =>
+            {
+                var ctxDescriptor = services.SingleOrDefault(d =>
+                    d.ServiceType == typeof(DbContextOptions<AppDbContext>));
+                if (ctxDescriptor is not null) services.Remove(ctxDescriptor);
+                services.AddDbContext<AppDbContext>(opts => opts.UseSqlite(_connection));
+
+                var rbacDescriptors = services
+                    .Where(d => d.ServiceType == typeof(IRbacChecker))
+                    .ToList();
+                foreach (var d in rbacDescriptors) services.Remove(d);
+                services.AddSingleton<IRbacChecker>(Rbac);
+
+                services.AddAuthentication(TestAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                        TestAuthHandler.SchemeName, _ => { });
+                services.PostConfigure<AuthorizationOptions>(opts =>
+                {
+                    opts.DefaultPolicy = new AuthorizationPolicyBuilder(TestAuthHandler.SchemeName)
+                        .RequireAuthenticatedUser()
+                        .Build();
+                });
+
+                using var sp = services.BuildServiceProvider();
+                using var scope = sp.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+                db.Database.EnsureCreated();
+            });
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) _connection.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+
+    private static GrpcChannel ChannelFor(WebApplicationFactory<Program> factory)
+    {
+        var handler = factory.Server.CreateHandler();
+        return GrpcChannel.ForAddress(factory.Server.BaseAddress, new GrpcChannelOptions
+        {
+            HttpHandler = handler,
+        });
+    }
+
+    [Fact]
+    public async Task EnforcedRpc_RbacAllow_Succeeds_AndCallsCheckerWithMappedPermission()
+    {
+        using var factory = new RbacInterceptorFactory();
+        // Force creation of the in-process server before pulling the handler.
+        using var _ = factory.CreateClient();
+        using var channel = ChannelFor(factory);
+        var client = new PolicyService.PolicyServiceClient(channel);
+
+        // The call must complete without an RpcException — that alone
+        // proves the interceptor passed. We don't assert a specific
+        // response shape because Program.cs seeds the DB on EnsureCreated.
+        var resp = await client.ListPoliciesAsync(new ListPoliciesRequest());
+        resp.Should().NotBeNull();
+
+        // The interceptor delegates to GrpcMethodPermissionMap, so this
+        // doubles as an end-to-end assertion that ListPolicies maps to
+        // andy-policies:policy:read (#64 mapping).
+        factory.Rbac.Calls.Should().ContainSingle(
+            c => c.PermissionCode == "andy-policies:policy:read");
+    }
+
+    [Fact]
+    public async Task EnforcedRpc_RbacDeny_Throws_PermissionDenied_WithReason()
+    {
+        using var factory = new RbacInterceptorFactory();
+        factory.Rbac.NextDecision = new RbacDecision(false, "no-permission");
+        using var _ = factory.CreateClient();
+        using var channel = ChannelFor(factory);
+        var client = new PolicyService.PolicyServiceClient(channel);
+
+        var ex = await Assert.ThrowsAsync<RpcException>(
+            () => client.ListPoliciesAsync(new ListPoliciesRequest()).ResponseAsync);
+
+        ex.StatusCode.Should().Be(StatusCode.PermissionDenied);
+        ex.Status.Detail.Should().Be(
+            "no-permission",
+            "the andy-rbac decision Reason flows through unchanged so admin " +
+            "triage can correlate denial with the originating role / rule");
+    }
+
+    [Fact]
+    public async Task EnforcedRpc_RbacDeny_OnMutatingCall_DoesNotPersist()
+    {
+        using var factory = new RbacInterceptorFactory();
+        factory.Rbac.NextDecision = new RbacDecision(false, "missing-author-role");
+        using var http = factory.CreateClient();
+        using var channel = ChannelFor(factory);
+        var client = new PolicyService.PolicyServiceClient(channel);
+
+        var slug = $"deny-{Guid.NewGuid():N}".Substring(0, 14);
+        var ex = await Assert.ThrowsAsync<RpcException>(
+            () => client.CreateDraftAsync(new CreateDraftRequest
+            {
+                Name = slug,
+                Description = "",
+                Summary = "summary",
+                Enforcement = "Must",
+                Severity = "Critical",
+                RulesJson = "{}",
+            }).ResponseAsync);
+
+        ex.StatusCode.Should().Be(StatusCode.PermissionDenied);
+
+        // No row should have been written — proves the deny ran *before*
+        // the gRPC service handler, not after.
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var rows = await db.Policies.AsNoTracking().Where(p => p.Name == slug).ToListAsync();
+        rows.Should().BeEmpty(
+            "an RBAC denial that still produced a Policy row would mean the " +
+            "interceptor ran *after* the service body — the entire fail-closed " +
+            "guarantee depends on running before");
+    }
+
+    // The Items bypass is pinned at the unit level by
+    // GrpcPermissionMapCoverageTests.ItemsServiceIsBypassedNotMapped;
+    // a runtime version would require generating a client stub for items.proto
+    // (it ships GrpcServices="Server" — no client class), and the
+    // interceptor's bypass branch is a single IsEnforcedService check.
+
+    [Fact]
+    public async Task EnforcedRpc_AfterAllow_ResponsePassesThroughUnmodified()
+    {
+        // Defends against an interceptor regression that wraps responses
+        // (e.g. swallowing fields, replacing error envelopes) — the
+        // happy-path response from the service must reach the caller as-is.
+        using var factory = new RbacInterceptorFactory();
+        using var http = factory.CreateClient();
+        using var channel = ChannelFor(factory);
+        var client = new PolicyService.PolicyServiceClient(channel);
+
+        var slug = $"pass-{Guid.NewGuid():N}".Substring(0, 14);
+        var created = await client.CreateDraftAsync(new CreateDraftRequest
+        {
+            Name = slug,
+            Description = "",
+            Summary = "summary",
+            Enforcement = "Must",
+            Severity = "Critical",
+            RulesJson = "{}",
+        });
+
+        created.Version.Version.Should().Be(1);
+        created.Version.State.Should().Be("Draft");
+        // CreateDraft requires both author + read in sequence (PolicyService
+        // calls back into ListPolicies-style read paths internally for some
+        // queries). At minimum, the author permission must show up.
+        factory.Rbac.Calls.Should().Contain(
+            c => c.PermissionCode == "andy-policies:policy:author");
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Mcp/AuditToolsTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/AuditToolsTests.cs
@@ -8,10 +8,13 @@ using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Infrastructure.Audit;
 using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Tests.Integration.Fixtures;
 using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
+
+using static Andy.Policies.Tests.Integration.Fixtures.McpToolStubs;
 
 namespace Andy.Policies.Tests.Integration.Mcp;
 
@@ -167,7 +170,7 @@ public class AuditToolsTests : IDisposable
     public async Task Verify_HappyPath_ReturnsValidJson()
     {
         await SeedAsync(5);
-        var output = await AuditTools.Verify(_chain);
+        var output = await AuditTools.Verify(_chain, AccessorFor("test-user"), AllowAllRbac);
 
         var dto = JsonSerializer.Deserialize<ChainVerificationDto>(output, JsonOpts);
         dto!.Valid.Should().BeTrue();
@@ -178,14 +181,14 @@ public class AuditToolsTests : IDisposable
     [Fact]
     public async Task Verify_FromGreaterThanTo_ReturnsInvalidArgument()
     {
-        var output = await AuditTools.Verify(_chain, fromSeq: 10, toSeq: 5);
+        var output = await AuditTools.Verify(_chain, AccessorFor("test-user"), AllowAllRbac, fromSeq: 10, toSeq: 5);
         output.Should().StartWith("policy.audit.invalid_argument:");
     }
 
     [Fact]
     public async Task Verify_NonPositiveBound_ReturnsInvalidArgument()
     {
-        var output = await AuditTools.Verify(_chain, fromSeq: 0);
+        var output = await AuditTools.Verify(_chain, AccessorFor("test-user"), AllowAllRbac, fromSeq: 0);
         output.Should().StartWith("policy.audit.invalid_argument:");
     }
 
@@ -196,7 +199,7 @@ public class AuditToolsTests : IDisposable
     {
         await SeedAsync(3);
 
-        var base64 = await AuditTools.Export(_exporter);
+        var base64 = await AuditTools.Export(_exporter, AccessorFor("test-user"), AllowAllRbac);
 
         var bytes = Convert.FromBase64String(base64);
         var text = Encoding.UTF8.GetString(bytes);
@@ -213,7 +216,7 @@ public class AuditToolsTests : IDisposable
     {
         await SeedAsync(10);
 
-        var base64 = await AuditTools.Export(_exporter, fromSeq: 4, toSeq: 7);
+        var base64 = await AuditTools.Export(_exporter, AccessorFor("test-user"), AllowAllRbac, fromSeq: 4, toSeq: 7);
 
         var bytes = Convert.FromBase64String(base64);
         var lines = Encoding.UTF8.GetString(bytes)
@@ -224,7 +227,7 @@ public class AuditToolsTests : IDisposable
     [Fact]
     public async Task Export_FromGreaterThanTo_ReturnsInvalidArgument()
     {
-        var output = await AuditTools.Export(_exporter, fromSeq: 10, toSeq: 5);
+        var output = await AuditTools.Export(_exporter, AccessorFor("test-user"), AllowAllRbac, fromSeq: 10, toSeq: 5);
         output.Should().StartWith("policy.audit.invalid_argument:");
     }
 }

--- a/tests/Andy.Policies.Tests.Integration/Mcp/BindingToolsTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/BindingToolsTests.cs
@@ -5,10 +5,12 @@ using System.Security.Claims;
 using System.Text.Json;
 using Andy.Policies.Api.Mcp;
 using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Domain.Entities;
 using Andy.Policies.Domain.Enums;
 using Andy.Policies.Infrastructure.Data;
 using Andy.Policies.Infrastructure.Services;
+using Andy.Policies.Tests.Integration.Fixtures;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -63,6 +65,13 @@ public class BindingToolsTests
         return new HttpContextAccessor { HttpContext = ctx };
     }
 
+    /// <summary>
+    /// P7.6 (#64) added <see cref="IRbacChecker"/> to every mutating MCP
+    /// tool. Tests below thread this through; authorization-specific
+    /// behaviour lives in <c>OverrideToolsRbacTests</c>.
+    /// </summary>
+    private static readonly IRbacChecker AllowRbac = McpToolStubs.AllowAllRbac;
+
     private static CreatePolicyRequest MinimalCreate(string name) => new(
         Name: name,
         Description: null,
@@ -79,7 +88,7 @@ public class BindingToolsTests
         var draft = await policies.CreateDraftAsync(MinimalCreate("bind-create"), "sam");
 
         var output = await BindingTools.Create(
-            svc, AccessorFor("agent-1"),
+            svc, AccessorFor("agent-1"), AllowRbac,
             draft.Id.ToString(), "Repo", "repo:rivoli-ai/policy-x", "Mandatory");
 
         output.Should().Contain("Binding ");
@@ -100,7 +109,7 @@ public class BindingToolsTests
         await db.SaveChangesAsync();
 
         var output = await BindingTools.Create(
-            svc, AccessorFor("agent-1"),
+            svc, AccessorFor("agent-1"), AllowRbac,
             draft.Id.ToString(), "Repo", "repo:any/repo", "Recommended");
 
         output.Should().StartWith("policy.binding.retired_target:");
@@ -112,7 +121,7 @@ public class BindingToolsTests
         var (svc, _, _, _) = NewServices();
 
         var output = await BindingTools.Create(
-            svc, AccessorFor("agent-1"),
+            svc, AccessorFor("agent-1"), AllowRbac,
             Guid.NewGuid().ToString(), "Repo", "repo:rivoli-ai/policy-x", "Mandatory");
 
         output.Should().StartWith("policy.binding.not_found:");
@@ -125,7 +134,7 @@ public class BindingToolsTests
         var draft = await policies.CreateDraftAsync(MinimalCreate("bind-invalid"), "sam");
 
         var output = await BindingTools.Create(
-            svc, AccessorFor("agent-1"),
+            svc, AccessorFor("agent-1"), AllowRbac,
             draft.Id.ToString(), "Unicorn", "ref", "Recommended");
 
         output.Should().StartWith("policy.binding.invalid_target:");
@@ -138,7 +147,7 @@ public class BindingToolsTests
         var draft = await policies.CreateDraftAsync(MinimalCreate("bind-empty"), "sam");
 
         var output = await BindingTools.Create(
-            svc, AccessorFor("agent-1"),
+            svc, AccessorFor("agent-1"), AllowRbac,
             draft.Id.ToString(), "Repo", "  ", "Recommended");
 
         output.Should().StartWith("policy.binding.invalid_target:");
@@ -151,7 +160,7 @@ public class BindingToolsTests
         var draft = await policies.CreateDraftAsync(MinimalCreate("bind-noauth"), "sam");
 
         var output = await BindingTools.Create(
-            svc, AccessorFor(subjectId: null),
+            svc, AccessorFor(subjectId: null), AllowRbac,
             draft.Id.ToString(), "Repo", "repo:any/repo", "Mandatory");
 
         output.Should().Contain("Authentication required");
@@ -164,7 +173,7 @@ public class BindingToolsTests
     {
         var (svc, _, policies, _) = NewServices();
         var draft = await policies.CreateDraftAsync(MinimalCreate("bind-list"), "sam");
-        await BindingTools.Create(svc, AccessorFor("agent-1"),
+        await BindingTools.Create(svc, AccessorFor("agent-1"), AllowRbac,
             draft.Id.ToString(), "Repo", "repo:a/x", "Mandatory");
 
         var output = await BindingTools.List(svc, draft.Id.ToString());
@@ -189,14 +198,14 @@ public class BindingToolsTests
     {
         var (svc, _, policies, _) = NewServices();
         var draft = await policies.CreateDraftAsync(MinimalCreate("bind-del"), "sam");
-        var createOutput = await BindingTools.Create(svc, AccessorFor("agent-1"),
+        var createOutput = await BindingTools.Create(svc, AccessorFor("agent-1"), AllowRbac,
             draft.Id.ToString(), "Repo", "repo:a/del", "Mandatory");
         var bindingId = createOutput.Split('\n')[0].Replace("Binding ", "").Trim();
 
-        var first = await BindingTools.Delete(svc, AccessorFor("agent-1"), bindingId, "no longer needed");
+        var first = await BindingTools.Delete(svc, AccessorFor("agent-1"), AllowRbac, bindingId, "no longer needed");
         first.Should().Contain("soft-deleted");
 
-        var second = await BindingTools.Delete(svc, AccessorFor("agent-1"), bindingId);
+        var second = await BindingTools.Delete(svc, AccessorFor("agent-1"), AllowRbac, bindingId);
         second.Should().StartWith("policy.binding.not_found:");
     }
 
@@ -205,7 +214,7 @@ public class BindingToolsTests
     {
         var (svc, _, _, _) = NewServices();
 
-        var output = await BindingTools.Delete(svc, AccessorFor(subjectId: null), Guid.NewGuid().ToString());
+        var output = await BindingTools.Delete(svc, AccessorFor(subjectId: null), AllowRbac, Guid.NewGuid().ToString());
 
         output.Should().Contain("Authentication required");
     }
@@ -218,7 +227,7 @@ public class BindingToolsTests
         var entity = await db.PolicyVersions.FirstAsync(v => v.Id == draft.Id);
         entity.State = LifecycleState.Active;
         await db.SaveChangesAsync();
-        await BindingTools.Create(svc, AccessorFor("agent-1"),
+        await BindingTools.Create(svc, AccessorFor("agent-1"), AllowRbac,
             draft.Id.ToString(), "Template", "template:abc", "Mandatory");
 
         var output = await BindingTools.Resolve(resolver, "Template", "template:abc");

--- a/tests/Andy.Policies.Tests.Integration/Mcp/OverrideToolsRbacTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/OverrideToolsRbacTests.cs
@@ -1,0 +1,370 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Claims;
+using Andy.Policies.Api.Mcp;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Application.Settings;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Infrastructure.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Mcp;
+
+/// <summary>
+/// P7.6 (#64) — RBAC enforcement on the override MCP tools. Pins the
+/// contract that <see cref="OverrideTools.Propose"/>,
+/// <see cref="OverrideTools.Approve"/>, and <see cref="OverrideTools.Revoke"/>
+/// each invoke <see cref="Andy.Policies.Api.Mcp.Authorization.McpRbacGuard"/>
+/// with the permission code from the P7.1 manifest, the resource
+/// instance derived from the tool arguments, and the JWT
+/// <c>groups</c> claim — and translate denials into the typed
+/// <c>policy.override.forbidden</c> tool error rather than letting the
+/// guard exception propagate.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Companion to <see cref="OverrideToolsTests"/>: that class fixes the
+/// gate / state-machine / serialization wire contract; this class fixes
+/// the authorization wire contract. They share the same
+/// <see cref="OverrideService"/> + EF Core InMemory backing so a tool
+/// that passes both files behaves the same against a live andy-rbac.
+/// </para>
+/// <para>
+/// Resource-instance shapes (kept aligned with REST P7.4 / gRPC P7.6):
+/// </para>
+/// <list type="bullet">
+///   <item><c>propose</c> → <c>scopeRef</c> as-is (e.g. <c>"user:42"</c>);
+///         the propose call has no override id yet.</item>
+///   <item><c>approve</c>, <c>revoke</c> → <c>"override:{guid}"</c> so
+///         per-instance grants can be authored once the row exists.</item>
+/// </list>
+/// </remarks>
+public class OverrideToolsRbacTests
+{
+    private sealed class StubGate : IExperimentalOverridesGate
+    {
+        public bool IsEnabled { get; set; } = true;
+    }
+
+    private sealed class NoopDispatcher : IDomainEventDispatcher
+    {
+        public Task DispatchAsync<TEvent>(TEvent domainEvent, CancellationToken ct = default)
+            where TEvent : notnull => Task.CompletedTask;
+    }
+
+    private sealed record CapturedCall(
+        string SubjectId,
+        string Permission,
+        IReadOnlyList<string> Groups,
+        string? ResourceInstanceId);
+
+    private sealed class RecordingRbac : IRbacChecker
+    {
+        public RbacDecision NextDecision { get; set; } = new(true, "test-allow");
+
+        public List<CapturedCall> Calls { get; } = new();
+
+        public Task<RbacDecision> CheckAsync(
+            string subjectId, string permissionCode, IReadOnlyList<string> groups,
+            string? resourceInstanceId, CancellationToken ct)
+        {
+            Calls.Add(new CapturedCall(subjectId, permissionCode, groups.ToList(), resourceInstanceId));
+            return Task.FromResult(NextDecision);
+        }
+    }
+
+    private static AppDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static (OverrideService service, AppDbContext db, StubGate gate) NewServices()
+    {
+        var db = NewDb();
+        // The OverrideService takes its own IRbacChecker for the
+        // propose/approve domain rules (not the McpRbacGuard surface
+        // this test class targets). Hand it an unconditional allow stub
+        // so we isolate the *MCP* guard signal we're measuring.
+        var serviceLayerAllow = new RecordingRbac();
+        var service = new OverrideService(db, serviceLayerAllow, new NoopDispatcher(), TimeProvider.System);
+        return (service, db, new StubGate { IsEnabled = true });
+    }
+
+    private static IHttpContextAccessor AccessorFor(string? subjectId, params string[] groups)
+    {
+        var ctx = new DefaultHttpContext();
+        if (subjectId is not null)
+        {
+            var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, subjectId) };
+            claims.AddRange(groups.Select(g => new Claim("groups", g)));
+            ctx.User = new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType: "Test"));
+        }
+        return new HttpContextAccessor { HttpContext = ctx };
+    }
+
+    private static async Task<PolicyVersion> SeedActiveAsync(AppDbContext db, string name = "p1")
+    {
+        var policy = new Policy { Id = Guid.NewGuid(), Name = name, CreatedBySubjectId = "u1" };
+        var version = new PolicyVersion
+        {
+            Id = Guid.NewGuid(),
+            PolicyId = policy.Id,
+            Version = 1,
+            State = LifecycleState.Active,
+            Enforcement = EnforcementLevel.Should,
+            Severity = Severity.Moderate,
+            Scopes = new List<string>(),
+            Summary = "fixture",
+            RulesJson = "{}",
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBySubjectId = "u1",
+            ProposerSubjectId = "u1",
+        };
+        db.Policies.Add(policy);
+        db.PolicyVersions.Add(version);
+        await db.SaveChangesAsync();
+        return version;
+    }
+
+    private static async Task<OverrideDto> SeedProposedAsync(
+        OverrideService svc, AppDbContext db, string proposer = "user:proposer", string scopeRef = "user:42")
+    {
+        var version = await SeedActiveAsync(db, $"p-{Guid.NewGuid():n}");
+        return await svc.ProposeAsync(
+            new ProposeOverrideRequest(
+                version.Id,
+                OverrideScopeKind.Principal,
+                scopeRef,
+                OverrideEffect.Exempt,
+                ReplacementPolicyVersionId: null,
+                ExpiresAt: DateTimeOffset.UtcNow.AddHours(24),
+                Rationale: "fixture"),
+            proposer);
+    }
+
+    // ----- Propose ------------------------------------------------------
+
+    [Fact]
+    public async Task Propose_RbacAllow_CallsCheckerWithProposePermissionAndScopeRefResource()
+    {
+        var (svc, db, gate) = NewServices();
+        var version = await SeedActiveAsync(db);
+        var rbac = new RecordingRbac { NextDecision = new(true, "role:override-author") };
+
+        var output = await OverrideTools.Propose(
+            svc, gate, AccessorFor("user:proposer"), rbac,
+            version.Id.ToString(), "Principal", "user:42",
+            "Exempt", DateTimeOffset.UtcNow.AddDays(1).ToString("o"), "rationale");
+
+        // Tool returned the JSON DTO, not an error string.
+        output.TrimStart().Should().StartWith("{");
+        rbac.Calls.Should().ContainSingle();
+        rbac.Calls[0].SubjectId.Should().Be("user:proposer");
+        rbac.Calls[0].Permission.Should().Be("andy-policies:override:propose");
+        rbac.Calls[0].ResourceInstanceId.Should().Be(
+            "user:42",
+            "propose has no override id yet, so the scope ref is the only " +
+            "instance handle a per-grant rule could attach to");
+    }
+
+    [Fact]
+    public async Task Propose_RbacDeny_ReturnsForbiddenWithReason_AndDoesNotPersist()
+    {
+        var (svc, db, gate) = NewServices();
+        var version = await SeedActiveAsync(db);
+        var rbac = new RecordingRbac { NextDecision = new(false, "no-permission") };
+
+        var output = await OverrideTools.Propose(
+            svc, gate, AccessorFor("user:nope"), rbac,
+            version.Id.ToString(), "Principal", "user:42",
+            "Exempt", DateTimeOffset.UtcNow.AddDays(1).ToString("o"), "rationale");
+
+        output.Should().StartWith("policy.override.forbidden:");
+        output.Should().Contain("no-permission");
+
+        // The denial must short-circuit before the service runs.
+        var rows = await db.Overrides.AsNoTracking().ToListAsync();
+        rows.Should().BeEmpty(
+            "an RBAC denial that still wrote a row would defeat the entire " +
+            "guard — the audit trail would carry a proposed override the " +
+            "caller was not allowed to author");
+    }
+
+    [Fact]
+    public async Task Propose_GateOff_ShortCircuits_NoRbacCall()
+    {
+        var (svc, db, gate) = NewServices();
+        var version = await SeedActiveAsync(db);
+        gate.IsEnabled = false;
+        var rbac = new RecordingRbac();
+
+        var output = await OverrideTools.Propose(
+            svc, gate, AccessorFor("user:proposer"), rbac,
+            version.Id.ToString(), "Principal", "user:42",
+            "Exempt", DateTimeOffset.UtcNow.AddDays(1).ToString("o"), "rationale");
+
+        output.Should().StartWith("policy.override.disabled:");
+        rbac.Calls.Should().BeEmpty(
+            "the experimental-overrides gate is the outermost guard; " +
+            "checking RBAC for a disabled feature would leak permission " +
+            "lookups against andy-rbac for traffic that's already null-routed");
+    }
+
+    [Fact]
+    public async Task Propose_NoSubjectClaim_ShortCircuits_NoRbacCall()
+    {
+        var (svc, db, gate) = NewServices();
+        var version = await SeedActiveAsync(db);
+        var rbac = new RecordingRbac();
+
+        var output = await OverrideTools.Propose(
+            svc, gate, AccessorFor(null), rbac,
+            version.Id.ToString(), "Principal", "user:42",
+            "Exempt", DateTimeOffset.UtcNow.AddDays(1).ToString("o"), "rationale");
+
+        output.Should().StartWith("Authentication required");
+        rbac.Calls.Should().BeEmpty(
+            "asking andy-rbac whether 'no subject' has a permission is " +
+            "incoherent — the unauthenticated branch must reject before the check");
+    }
+
+    [Fact]
+    public async Task Propose_GroupsClaim_FlowsThroughToRbac()
+    {
+        var (svc, db, gate) = NewServices();
+        var version = await SeedActiveAsync(db);
+        var rbac = new RecordingRbac();
+
+        await OverrideTools.Propose(
+            svc, gate,
+            AccessorFor("user:proposer", "team:authors", "team:eu"),
+            rbac,
+            version.Id.ToString(), "Principal", "user:42",
+            "Exempt", DateTimeOffset.UtcNow.AddDays(1).ToString("o"), "rationale");
+
+        rbac.Calls.Should().ContainSingle();
+        rbac.Calls[0].Groups.Should().BeEquivalentTo(new[] { "team:authors", "team:eu" });
+    }
+
+    // ----- Approve ------------------------------------------------------
+
+    [Fact]
+    public async Task Approve_RbacAllow_CallsCheckerWithOverrideIdResource()
+    {
+        var (svc, db, gate) = NewServices();
+        var proposed = await SeedProposedAsync(svc, db, proposer: "user:proposer");
+        var rbac = new RecordingRbac();
+
+        await OverrideTools.Approve(
+            svc, gate, AccessorFor("user:approver"), rbac,
+            proposed.Id.ToString());
+
+        rbac.Calls.Should().ContainSingle();
+        rbac.Calls[0].SubjectId.Should().Be("user:approver");
+        rbac.Calls[0].Permission.Should().Be("andy-policies:override:approve");
+        rbac.Calls[0].ResourceInstanceId.Should().Be(
+            $"override:{proposed.Id}",
+            "per-instance approve grants need to attach to the override id; " +
+            "scope-ref keying would let an approver-on-cohort-X also approve " +
+            "rows scoped to cohort-Y");
+    }
+
+    [Fact]
+    public async Task Approve_RbacDeny_ReturnsForbidden_AndDoesNotChangeState()
+    {
+        var (svc, db, gate) = NewServices();
+        var proposed = await SeedProposedAsync(svc, db, proposer: "user:proposer");
+        var rbac = new RecordingRbac { NextDecision = new(false, "missing-role") };
+
+        var output = await OverrideTools.Approve(
+            svc, gate, AccessorFor("user:approver"), rbac,
+            proposed.Id.ToString());
+
+        output.Should().StartWith("policy.override.forbidden:");
+        output.Should().Contain("missing-role");
+
+        var row = await db.Overrides.AsNoTracking().SingleAsync(o => o.Id == proposed.Id);
+        row.State.Should().Be(
+            OverrideState.Proposed,
+            "deny must run before ApproveAsync — otherwise the row would " +
+            "transition to Approved and the deny would surface as a no-op");
+    }
+
+    [Fact]
+    public async Task Approve_GateOff_ShortCircuits_NoRbacCall()
+    {
+        var (svc, db, gate) = NewServices();
+        var proposed = await SeedProposedAsync(svc, db);
+        gate.IsEnabled = false;
+        var rbac = new RecordingRbac();
+
+        await OverrideTools.Approve(
+            svc, gate, AccessorFor("user:approver"), rbac,
+            proposed.Id.ToString());
+
+        rbac.Calls.Should().BeEmpty();
+    }
+
+    // ----- Revoke -------------------------------------------------------
+
+    [Fact]
+    public async Task Revoke_RbacAllow_CallsCheckerWithOverrideIdResource()
+    {
+        var (svc, db, gate) = NewServices();
+        var proposed = await SeedProposedAsync(svc, db);
+        var rbac = new RecordingRbac();
+
+        await OverrideTools.Revoke(
+            svc, gate, AccessorFor("user:approver"), rbac,
+            proposed.Id.ToString(), "withdrawn");
+
+        rbac.Calls.Should().ContainSingle();
+        rbac.Calls[0].Permission.Should().Be("andy-policies:override:revoke");
+        rbac.Calls[0].ResourceInstanceId.Should().Be($"override:{proposed.Id}");
+    }
+
+    [Fact]
+    public async Task Revoke_RbacDeny_ReturnsForbidden_AndDoesNotChangeState()
+    {
+        var (svc, db, gate) = NewServices();
+        var proposed = await SeedProposedAsync(svc, db);
+        var rbac = new RecordingRbac { NextDecision = new(false, "no-revoke-role") };
+
+        var output = await OverrideTools.Revoke(
+            svc, gate, AccessorFor("user:approver"), rbac,
+            proposed.Id.ToString(), "withdrawn");
+
+        output.Should().StartWith("policy.override.forbidden:");
+        output.Should().Contain("no-revoke-role");
+        var row = await db.Overrides.AsNoTracking().SingleAsync(o => o.Id == proposed.Id);
+        row.State.Should().Be(OverrideState.Proposed);
+    }
+
+    [Fact]
+    public async Task Revoke_InvalidGuid_FailsBeforeRbac()
+    {
+        var (svc, _, gate) = NewServices();
+        var rbac = new RecordingRbac();
+
+        var output = await OverrideTools.Revoke(
+            svc, gate, AccessorFor("user:approver"), rbac,
+            "not-a-guid", "reason");
+
+        output.Should().StartWith("policy.override.invalid_argument:");
+        rbac.Calls.Should().BeEmpty(
+            "a malformed override id has no resource instance to attach the " +
+            "RBAC question to; the validation guard fires first");
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Mcp/OverrideToolsTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/OverrideToolsTests.cs
@@ -53,6 +53,13 @@ public class OverrideToolsTests
             => Task.FromResult(new RbacDecision(true, "test-allow"));
     }
 
+    /// <summary>
+    /// Default RBAC stub for tests that aren't exercising the
+    /// authorization path itself — keeps the test bodies focused on the
+    /// MCP-tool wire contract rather than restating the AllowRbac wiring.
+    /// </summary>
+    private static readonly IRbacChecker AllowRbacInstance = new AllowRbac();
+
     private sealed class NoopDispatcher : IDomainEventDispatcher
     {
         public Task DispatchAsync<TEvent>(TEvent domainEvent, CancellationToken ct = default)
@@ -138,7 +145,7 @@ public class OverrideToolsTests
         gate.IsEnabled = false;
 
         var output = await OverrideTools.Propose(
-            svc, gate, AccessorFor("user:proposer"),
+            svc, gate, AccessorFor("user:proposer"), AllowRbacInstance,
             version.Id.ToString(), "Principal", "user:42",
             "Exempt", DateTimeOffset.UtcNow.AddDays(1).ToString("o"), "rationale");
 
@@ -152,7 +159,7 @@ public class OverrideToolsTests
         var version = await SeedActiveAsync(db);
 
         var output = await OverrideTools.Propose(
-            svc, gate, AccessorFor(null),
+            svc, gate, AccessorFor(null), AllowRbacInstance,
             version.Id.ToString(), "Principal", "user:42",
             "Exempt", DateTimeOffset.UtcNow.AddDays(1).ToString("o"), "rationale");
 
@@ -166,7 +173,7 @@ public class OverrideToolsTests
         var version = await SeedActiveAsync(db);
 
         var output = await OverrideTools.Propose(
-            svc, gate, AccessorFor("user:proposer"),
+            svc, gate, AccessorFor("user:proposer"), AllowRbacInstance,
             version.Id.ToString(), "Principal", "user:42",
             "Exempt", DateTimeOffset.UtcNow.AddDays(1).ToString("o"),
             "expedite vendor-blocked story");
@@ -184,7 +191,7 @@ public class OverrideToolsTests
         var (svc, _, gate) = NewServices();
 
         var output = await OverrideTools.Propose(
-            svc, gate, AccessorFor("user:proposer"),
+            svc, gate, AccessorFor("user:proposer"), AllowRbacInstance,
             "not-a-guid", "Principal", "user:42",
             "Exempt", DateTimeOffset.UtcNow.AddDays(1).ToString("o"), "rationale");
 
@@ -198,7 +205,7 @@ public class OverrideToolsTests
         var version = await SeedActiveAsync(db);
 
         var output = await OverrideTools.Propose(
-            svc, gate, AccessorFor("user:proposer"),
+            svc, gate, AccessorFor("user:proposer"), AllowRbacInstance,
             version.Id.ToString(), "NotAScopeKind", "user:42",
             "Exempt", DateTimeOffset.UtcNow.AddDays(1).ToString("o"), "rationale");
 
@@ -215,7 +222,7 @@ public class OverrideToolsTests
         var proposed = await SeedProposedAsync(svc, db, proposer: "user:proposer");
 
         var output = await OverrideTools.Approve(
-            svc, gate, AccessorFor("user:approver"),
+            svc, gate, AccessorFor("user:approver"), AllowRbacInstance,
             proposed.Id.ToString());
 
         var dto = JsonSerializer.Deserialize<OverrideDto>(output, JsonOptions);
@@ -230,7 +237,7 @@ public class OverrideToolsTests
         var proposed = await SeedProposedAsync(svc, db, proposer: "user:proposer");
 
         var output = await OverrideTools.Approve(
-            svc, gate, AccessorFor("user:proposer"),
+            svc, gate, AccessorFor("user:proposer"), AllowRbacInstance,
             proposed.Id.ToString());
 
         output.Should().StartWith("policy.override.self_approval_forbidden:");
@@ -244,7 +251,7 @@ public class OverrideToolsTests
         await svc.ApproveAsync(proposed.Id, "user:approver");
 
         var output = await OverrideTools.Approve(
-            svc, gate, AccessorFor("user:other"),
+            svc, gate, AccessorFor("user:other"), AllowRbacInstance,
             proposed.Id.ToString());
 
         output.Should().StartWith("policy.override.invalid_state:");
@@ -256,7 +263,7 @@ public class OverrideToolsTests
         var (svc, _, gate) = NewServices();
 
         var output = await OverrideTools.Approve(
-            svc, gate, AccessorFor("user:approver"),
+            svc, gate, AccessorFor("user:approver"), AllowRbacInstance,
             Guid.NewGuid().ToString());
 
         output.Should().StartWith("policy.override.not_found:");
@@ -270,7 +277,7 @@ public class OverrideToolsTests
         gate.IsEnabled = false;
 
         var output = await OverrideTools.Approve(
-            svc, gate, AccessorFor("user:approver"),
+            svc, gate, AccessorFor("user:approver"), AllowRbacInstance,
             proposed.Id.ToString());
 
         output.Should().StartWith("policy.override.disabled:");
@@ -285,7 +292,7 @@ public class OverrideToolsTests
         var proposed = await SeedProposedAsync(svc, db);
 
         var output = await OverrideTools.Revoke(
-            svc, gate, AccessorFor("user:approver"),
+            svc, gate, AccessorFor("user:approver"), AllowRbacInstance,
             proposed.Id.ToString(), "withdrawn");
 
         var dto = JsonSerializer.Deserialize<OverrideDto>(output, JsonOptions);
@@ -300,7 +307,7 @@ public class OverrideToolsTests
         var proposed = await SeedProposedAsync(svc, db);
 
         var output = await OverrideTools.Revoke(
-            svc, gate, AccessorFor("user:approver"),
+            svc, gate, AccessorFor("user:approver"), AllowRbacInstance,
             proposed.Id.ToString(), "   ");
 
         output.Should().StartWith("policy.override.invalid_argument:");

--- a/tests/Andy.Policies.Tests.Integration/Mcp/PolicyLifecycleToolsTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/PolicyLifecycleToolsTests.cs
@@ -8,6 +8,7 @@ using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Domain.Enums;
 using Andy.Policies.Infrastructure.Data;
 using Andy.Policies.Infrastructure.Services;
+using Andy.Policies.Tests.Integration.Fixtures;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -42,6 +43,15 @@ public class PolicyLifecycleToolsTests
         public Task DispatchAsync<TEvent>(TEvent e, CancellationToken ct = default)
             where TEvent : notnull => Task.CompletedTask;
     }
+
+    /// <summary>
+    /// Default-allow RBAC for tests not exercising the authorization
+    /// path itself; P7.6 (#64) added <see cref="IRbacChecker"/> to every
+    /// mutating MCP-tool signature, so every call site below threads
+    /// this through. Authorization-specific behaviour is covered by
+    /// <c>OverrideToolsRbacTests</c>.
+    /// </summary>
+    private static readonly IRbacChecker AllowRbac = McpToolStubs.AllowAllRbac;
 
     private static (PolicyService policies, LifecycleTransitionService lifecycle, AppDbContext db)
         NewServices()
@@ -84,7 +94,7 @@ public class PolicyLifecycleToolsTests
         var draft = await policies.CreateDraftAsync(MinimalCreate("publish-tool"), "sam");
 
         var output = await PolicyLifecycleTools.Publish(
-            lifecycle, AccessorFor("agent-1"),
+            lifecycle, AccessorFor("agent-1"), AllowRbac,
             draft.PolicyId.ToString(), draft.Id.ToString(), "promote v1");
 
         output.Should().Contain("State: Active");
@@ -100,11 +110,11 @@ public class PolicyLifecycleToolsTests
     {
         var (policies, lifecycle, _) = NewServices();
         var draft = await policies.CreateDraftAsync(MinimalCreate("transition-tool"), "sam");
-        await PolicyLifecycleTools.Publish(lifecycle, AccessorFor("agent-1"),
+        await PolicyLifecycleTools.Publish(lifecycle, AccessorFor("agent-1"), AllowRbac,
             draft.PolicyId.ToString(), draft.Id.ToString(), "live");
 
         var output = await PolicyLifecycleTools.Transition(
-            lifecycle, AccessorFor("agent-1"),
+            lifecycle, AccessorFor("agent-1"), AllowRbac,
             draft.PolicyId.ToString(), draft.Id.ToString(), "Retired", "tomb");
 
         output.Should().Contain("State: Retired");
@@ -117,7 +127,7 @@ public class PolicyLifecycleToolsTests
         var draft = await policies.CreateDraftAsync(MinimalCreate("case-insensitive"), "sam");
 
         var output = await PolicyLifecycleTools.Transition(
-            lifecycle, AccessorFor("agent-1"),
+            lifecycle, AccessorFor("agent-1"), AllowRbac,
             draft.PolicyId.ToString(), draft.Id.ToString(), "active", "go");
 
         output.Should().Contain("State: Active");
@@ -130,7 +140,7 @@ public class PolicyLifecycleToolsTests
         var draft = await policies.CreateDraftAsync(MinimalCreate("reject-draft"), "sam");
 
         var output = await PolicyLifecycleTools.Transition(
-            lifecycle, AccessorFor("agent-1"),
+            lifecycle, AccessorFor("agent-1"), AllowRbac,
             draft.PolicyId.ToString(), draft.Id.ToString(), "Draft", "no");
 
         output.Should().Contain("Invalid target state");
@@ -143,7 +153,7 @@ public class PolicyLifecycleToolsTests
         var draft = await policies.CreateDraftAsync(MinimalCreate("unknown-target"), "sam");
 
         var output = await PolicyLifecycleTools.Transition(
-            lifecycle, AccessorFor("agent-1"),
+            lifecycle, AccessorFor("agent-1"), AllowRbac,
             draft.PolicyId.ToString(), draft.Id.ToString(), "Unicorn", "?");
 
         output.Should().Contain("Invalid target state");
@@ -157,7 +167,7 @@ public class PolicyLifecycleToolsTests
         var draft = await policies.CreateDraftAsync(MinimalCreate("draft-to-retired"), "sam");
 
         var output = await PolicyLifecycleTools.Transition(
-            lifecycle, AccessorFor("agent-1"),
+            lifecycle, AccessorFor("agent-1"), AllowRbac,
             draft.PolicyId.ToString(), draft.Id.ToString(), "Retired", "skip");
 
         output.Should().StartWith("INVALID_TRANSITION:");
@@ -170,7 +180,7 @@ public class PolicyLifecycleToolsTests
         var draft = await policies.CreateDraftAsync(MinimalCreate("rationale-required"), "sam");
 
         var output = await PolicyLifecycleTools.Publish(
-            lifecycle, AccessorFor("agent-1"),
+            lifecycle, AccessorFor("agent-1"), AllowRbac,
             draft.PolicyId.ToString(), draft.Id.ToString(), "  ");
 
         output.Should().StartWith("RATIONALE_REQUIRED:");
@@ -183,7 +193,7 @@ public class PolicyLifecycleToolsTests
         var draft = await policies.CreateDraftAsync(MinimalCreate("no-subject"), "sam");
 
         var output = await PolicyLifecycleTools.Publish(
-            lifecycle, AccessorFor(subjectId: null),
+            lifecycle, AccessorFor(subjectId: null), AllowRbac,
             draft.PolicyId.ToString(), draft.Id.ToString(), "publish");
 
         output.Should().Contain("Authentication required");
@@ -197,7 +207,7 @@ public class PolicyLifecycleToolsTests
         var (_, lifecycle, _) = NewServices();
 
         var output = await PolicyLifecycleTools.Publish(
-            lifecycle, AccessorFor("agent-1"),
+            lifecycle, AccessorFor("agent-1"), AllowRbac,
             "not-a-guid", Guid.NewGuid().ToString(), "go");
 
         output.Should().StartWith("Invalid policy id:");
@@ -209,7 +219,7 @@ public class PolicyLifecycleToolsTests
         var (_, lifecycle, _) = NewServices();
 
         var output = await PolicyLifecycleTools.Publish(
-            lifecycle, AccessorFor("agent-1"),
+            lifecycle, AccessorFor("agent-1"), AllowRbac,
             Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "go");
 
         output.Should().StartWith("NOT_FOUND:");

--- a/tests/Andy.Policies.Tests.Integration/Mcp/ScopeToolsTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/ScopeToolsTests.cs
@@ -7,10 +7,13 @@ using Andy.Policies.Application.Dtos;
 using Andy.Policies.Domain.Enums;
 using Andy.Policies.Infrastructure.Data;
 using Andy.Policies.Infrastructure.Services;
+using Andy.Policies.Tests.Integration.Fixtures;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Xunit;
+
+using static Andy.Policies.Tests.Integration.Fixtures.McpToolStubs;
 
 namespace Andy.Policies.Tests.Integration.Mcp;
 
@@ -122,7 +125,7 @@ public class ScopeToolsTests
         var refValue = $"org:t-create-{Guid.NewGuid():N}".Substring(0, 18);
 
         var output = await ScopeTools.Create(
-            scopes, parentId: null, type: "Org", @ref: refValue, displayName: "Display");
+            scopes, AccessorFor("test-user"), AllowAllRbac, parentId: null, type: "Org", @ref: refValue, displayName: "Display");
 
         output.Should().Contain("ScopeNode ");
         output.Should().Contain($"Ref: {refValue}");
@@ -137,7 +140,7 @@ public class ScopeToolsTests
         var org = await scopes.CreateAsync(new CreateScopeNodeRequest(null, ScopeType.Org, "org:t-mis", "Org"));
 
         var output = await ScopeTools.Create(
-            scopes,
+            scopes, AccessorFor("test-user"), AllowAllRbac,
             parentId: org.Id.ToString(),
             type: "Team",  // Team's parent must be Tenant, not Org.
             @ref: "team:wrong",
@@ -152,7 +155,7 @@ public class ScopeToolsTests
         var (scopes, _, _) = NewServices();
 
         var output = await ScopeTools.Create(
-            scopes,
+            scopes, AccessorFor("test-user"), AllowAllRbac,
             parentId: Guid.NewGuid().ToString(),
             type: "Tenant",
             @ref: "tenant:orphan",
@@ -167,7 +170,7 @@ public class ScopeToolsTests
         var (scopes, _, _) = NewServices();
 
         var output = await ScopeTools.Create(
-            scopes, parentId: "not-a-guid", type: "Tenant", @ref: "tenant:bad", displayName: "Bad");
+            scopes, AccessorFor("test-user"), AllowAllRbac, parentId: "not-a-guid", type: "Tenant", @ref: "tenant:bad", displayName: "Bad");
 
         output.Should().StartWith("policy.scope.invalid_input:");
     }
@@ -178,10 +181,10 @@ public class ScopeToolsTests
         var (scopes, _, _) = NewServices();
         var dto = await scopes.CreateAsync(new CreateScopeNodeRequest(null, ScopeType.Org, "org:t-del", "Del"));
 
-        var first = await ScopeTools.Delete(scopes, dto.Id.ToString());
+        var first = await ScopeTools.Delete(scopes, AccessorFor("test-user"), AllowAllRbac, dto.Id.ToString());
         first.Should().Contain("deleted");
 
-        var second = await ScopeTools.Delete(scopes, dto.Id.ToString());
+        var second = await ScopeTools.Delete(scopes, AccessorFor("test-user"), AllowAllRbac, dto.Id.ToString());
         second.Should().StartWith("policy.scope.not_found:");
     }
 
@@ -192,7 +195,7 @@ public class ScopeToolsTests
         var org = await scopes.CreateAsync(new CreateScopeNodeRequest(null, ScopeType.Org, "org:t-d-non", "Org"));
         await scopes.CreateAsync(new CreateScopeNodeRequest(org.Id, ScopeType.Tenant, "tenant:t-d-non", "Tn"));
 
-        var output = await ScopeTools.Delete(scopes, org.Id.ToString());
+        var output = await ScopeTools.Delete(scopes, AccessorFor("test-user"), AllowAllRbac, org.Id.ToString());
 
         output.Should().StartWith("policy.scope.has_descendants:");
         output.Should().Contain("childCount=1");

--- a/tests/Andy.Policies.Tests.Integration/Parity/BindingCrossSurfaceParityTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Parity/BindingCrossSurfaceParityTests.cs
@@ -11,6 +11,7 @@ using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Domain.Enums;
 using Andy.Policies.Tests.Integration.Controllers;
+using Andy.Policies.Tests.Integration.Fixtures;
 using FluentAssertions;
 using Grpc.Net.Client;
 using Microsoft.AspNetCore.Http;
@@ -222,7 +223,7 @@ public class BindingCrossSurfaceParityTests : IClassFixture<PoliciesApiFactory>,
         };
         var accessor = new HttpContextAccessor { HttpContext = ctx };
         var mcpOutput = await BindingTools.Create(
-            bindingService, accessor,
+            bindingService, accessor, McpToolStubs.AllowAllRbac,
             version.Id.ToString(), "Template", "template:retired-target", "Mandatory");
         mcpOutput.Should().StartWith("policy.binding.retired_target:");
     }


### PR DESCRIPTION
## Summary

Closes the last gap from the P7 epic: every governance surface (REST, MCP, gRPC) now consults andy-rbac before mutating.

- **gRPC**: global `RbacServerInterceptor` wired via `AddGrpc` options + `GrpcMethodPermissionMap` covering all 6 enforced services. Unmapped RPCs on enforced services hard-fail with `RpcException(Internal)` (fail-closed, never silent allow). ItemsService is the one allow-listed bypass (template scaffolding).
- **MCP**: `[RbacGuard]` declarative attribute + `McpRbacGuard.EnsureAsync` invoked at the top of every mutating tool body across OverrideTools, PolicyLifecycleTools, BindingTools, ScopeTools, AuditTools (verify/export). Denials surface as typed `policy.<area>.forbidden: <reason>` tool results.

Closes #64.

## Test plan

- [x] `dotnet build` clean (zero warnings under `TreatWarningsAsErrors`)
- [x] `dotnet test` — Integration 503/503, Unit 456/456, E2E 6/6
- [x] `GrpcPermissionMapCoverageTests` (reflection): every RPC on enforced services has a mapping; no stale entries; ItemsService bypass intact
- [x] `RbacInterceptorTests` (end-to-end): allow → 200 + checker called with mapped permission; deny → `PermissionDenied` with reason; mutating deny does not persist; allow → response unmodified
- [x] `OverrideToolsRbacTests` (12 tests): permission code + resource-instance shape (`scopeRef` for propose, `override:{id}` for approve/revoke); groups claim flows through; gate-off / no-subject short-circuit before RBAC

🤖 Generated with [Claude Code](https://claude.com/claude-code)