### PR TITLE
Implement P8.2 — BundleService snapshot builder under serializable txn (#82)

### DIFF
--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -168,6 +168,11 @@ builder.Services.AddSingleton<Andy.Policies.Application.Interfaces.IAuditDiffGen
 builder.Services.AddScoped<Andy.Policies.Application.Interfaces.ILifecycleTransitionService, Andy.Policies.Infrastructure.Services.LifecycleTransitionService>();
 // P5.2 (#52): override propose/approve/revoke service.
 builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IOverrideService, Andy.Policies.Infrastructure.Services.OverrideService>();
+// P8.2 (#82): bundle pinning. Snapshot builder is split off the
+// service for unit-testability; both are scoped because they take
+// the per-request DbContext.
+builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBundleSnapshotBuilder, Andy.Policies.Infrastructure.Services.BundleSnapshotBuilder>();
+builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBundleService, Andy.Policies.Infrastructure.Services.BundleService>();
 
 // P7.2 (#51): IRbacChecker delegates POST /api/check to andy-rbac.
 // AndyRbac:BaseUrl is required (no auth-bypass — same posture as

--- a/src/Andy.Policies.Application/Interfaces/IBundleService.cs
+++ b/src/Andy.Policies.Application/Interfaces/IBundleService.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.Interfaces;
+
+/// <summary>
+/// Application-layer service for <c>Bundle</c> mutation and query (P8.2,
+/// story rivoli-ai/andy-policies#82). REST (P8.3), MCP (P8.5), gRPC +
+/// CLI (P8.6) all delegate here so the snapshot-build / hash /
+/// audit-append discipline is uniform across surfaces.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Reproducibility contract.</b> <see cref="CreateAsync"/> opens a
+/// serializable transaction and atomically (a) reads the live catalog,
+/// (b) materialises a <see cref="Domain.ValueObjects.BundleSnapshot"/>,
+/// (c) hashes it into a 64-char hex SHA-256, (d) inserts the
+/// <see cref="Domain.Entities.Bundle"/> row, (e) appends a
+/// <c>bundle.create</c> event to the audit chain. A concurrent
+/// publish that commits between the read and the bundle insert
+/// must NOT leak into the bundle — the serializable level is
+/// load-bearing.
+/// </para>
+/// </remarks>
+public interface IBundleService
+{
+    /// <summary>
+    /// Snapshot the live catalog and persist it as an immutable
+    /// <see cref="Domain.Entities.Bundle"/>.
+    /// </summary>
+    /// <exception cref="Exceptions.ValidationException">
+    /// Slug-shape violations (<see cref="CreateBundleRequest.Name"/> must
+    /// match <c>^[a-z0-9][a-z0-9-]{0,62}$</c>) or empty rationale.
+    /// </exception>
+    /// <exception cref="Exceptions.ConflictException">
+    /// An active bundle already owns the requested name.
+    /// </exception>
+    Task<BundleDto> CreateAsync(CreateBundleRequest request, string actorSubjectId, CancellationToken ct = default);
+
+    Task<BundleDto?> GetAsync(Guid bundleId, CancellationToken ct = default);
+
+    Task<IReadOnlyList<BundleDto>> ListAsync(ListBundlesFilter filter, CancellationToken ct = default);
+
+    /// <summary>
+    /// Flip <see cref="Domain.Entities.Bundle.State"/> to
+    /// <see cref="Domain.Enums.BundleState.Deleted"/> and stamp the
+    /// tombstone trio. Returns <c>false</c> if the bundle does not
+    /// exist or was already tombstoned (idempotent caller contract).
+    /// Appends a <c>bundle.delete</c> audit event when the flip
+    /// actually happens.
+    /// </summary>
+    Task<bool> SoftDeleteAsync(Guid bundleId, string actorSubjectId, string rationale, CancellationToken ct = default);
+}
+
+/// <summary>Inputs to <see cref="IBundleService.CreateAsync"/>.</summary>
+/// <param name="Name">Slug shape: <c>^[a-z0-9][a-z0-9-]{0,62}$</c>.
+/// Active bundles are unique by name; soft-deleted bundles release
+/// the slug for reuse.</param>
+/// <param name="Description">Optional human-readable summary.</param>
+/// <param name="Rationale">Required non-empty rationale recorded
+/// against the audit event.</param>
+public sealed record CreateBundleRequest(string Name, string? Description, string Rationale);
+
+/// <summary>Filter for <see cref="IBundleService.ListAsync"/>.</summary>
+public sealed record ListBundlesFilter(
+    bool IncludeDeleted = false,
+    int Skip = 0,
+    int Take = 50);
+
+/// <summary>
+/// Wire shape returned by <see cref="IBundleService"/>. Excludes the
+/// (potentially large) <c>SnapshotJson</c> payload — surfaces fetch
+/// that separately on demand via <c>BundlesController</c> in P8.3.
+/// </summary>
+public sealed record BundleDto(
+    Guid Id,
+    string Name,
+    string? Description,
+    DateTimeOffset CreatedAt,
+    string CreatedBySubjectId,
+    string SnapshotHash,
+    string State,
+    DateTimeOffset? DeletedAt,
+    string? DeletedBySubjectId);

--- a/src/Andy.Policies.Application/Interfaces/IBundleSnapshotBuilder.cs
+++ b/src/Andy.Policies.Application/Interfaces/IBundleSnapshotBuilder.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Domain.ValueObjects;
+
+namespace Andy.Policies.Application.Interfaces;
+
+/// <summary>
+/// Reads the live catalog and materialises a
+/// <see cref="BundleSnapshot"/>. P8.2 (story rivoli-ai/andy-policies#82)
+/// splits this off <see cref="IBundleService"/> so the read-materialise
+/// step can be unit-tested independently of the txn-orchestration +
+/// audit-append step.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Transactional ownership.</b> The builder issues queries against
+/// the shared <c>AppDbContext</c> and assumes the caller has already
+/// opened a serializable transaction. The "frozen catalog" guarantee
+/// is the caller's responsibility — see <see cref="IBundleService.CreateAsync"/>.
+/// </para>
+/// <para>
+/// <b>Determinism.</b> Collections are emitted in stable order
+/// (policies by <c>(PolicyId, Version)</c>; bindings/overrides/scopes
+/// by <c>Id</c>) so canonical-JSON serialisation produces byte-
+/// identical output for two builds against the same catalog state.
+/// The hash invariant <c>SHA-256(canonicalJson(snapshot)) ==
+/// Bundle.SnapshotHash</c> depends on this.
+/// </para>
+/// </remarks>
+public interface IBundleSnapshotBuilder
+{
+    /// <summary>
+    /// Build a snapshot of the catalog as visible inside the caller's
+    /// transaction. <paramref name="capturedAt"/> is the instant the
+    /// caller wants stamped into <see cref="BundleSnapshot.CapturedAt"/>;
+    /// it is also the cutoff for "non-expired" override rows.
+    /// </summary>
+    Task<BundleSnapshot> BuildAsync(DateTimeOffset capturedAt, CancellationToken ct = default);
+}

--- a/src/Andy.Policies.Infrastructure/Services/BundleService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BundleService.cs
@@ -1,0 +1,268 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Data;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using Andy.Policies.Application.Exceptions;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Shared.Auditing;
+using Microsoft.EntityFrameworkCore;
+
+namespace Andy.Policies.Infrastructure.Services;
+
+/// <summary>
+/// Application-layer service for <c>Bundle</c> mutation and query (P8.2,
+/// story rivoli-ai/andy-policies#82). Surfaces in P8.3 (REST), P8.5
+/// (MCP), P8.6 (gRPC + CLI) all delegate here so the snapshot-build
+/// + hash + audit-append discipline is uniform across the parity
+/// surfaces.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Reproducibility.</b> <see cref="CreateAsync"/> opens a
+/// <see cref="IsolationLevel.Serializable"/> transaction so the catalog
+/// view fed into the snapshot builder is frozen — a publish or
+/// binding mutation that commits between the read and the bundle
+/// insert cannot leak into the snapshot.
+/// </para>
+/// <para>
+/// <b>Audit linkage.</b> The <c>bundle.create</c> event's
+/// <c>FieldDiffJson</c> carries the snapshot hash and the parent
+/// audit-tail-hash so the chain can be cross-walked: an auditor can
+/// re-hash <c>SnapshotJson</c>, match it to the audit event payload,
+/// and walk the chain back from there.
+/// </para>
+/// </remarks>
+public sealed class BundleService : IBundleService
+{
+    /// <summary>Slug shape: lower-case alphanumeric, optional dashes,
+    /// must start with [a-z0-9], 1..63 chars total. Mirrors the
+    /// Policy.Name pattern.</summary>
+    private static readonly Regex NameRegex = new(
+        "^[a-z0-9][a-z0-9-]{0,62}$",
+        RegexOptions.Compiled);
+
+    private readonly AppDbContext _db;
+    private readonly IBundleSnapshotBuilder _builder;
+    private readonly IAuditChain _audit;
+    private readonly TimeProvider _clock;
+
+    public BundleService(
+        AppDbContext db,
+        IBundleSnapshotBuilder builder,
+        IAuditChain audit,
+        TimeProvider clock)
+    {
+        _db = db;
+        _builder = builder;
+        _audit = audit;
+        _clock = clock;
+    }
+
+    public async Task<BundleDto> CreateAsync(
+        CreateBundleRequest request, string actorSubjectId, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrEmpty(actorSubjectId);
+
+        var name = (request.Name ?? string.Empty).Trim();
+        if (!NameRegex.IsMatch(name))
+        {
+            throw new ValidationException(
+                $"Bundle name '{name}' is not a valid slug. Expected pattern: ^[a-z0-9][a-z0-9-]{{0,62}}$.");
+        }
+        var rationale = (request.Rationale ?? string.Empty).Trim();
+        if (string.IsNullOrEmpty(rationale))
+        {
+            throw new ValidationException("Rationale is required and may not be empty or whitespace.");
+        }
+
+        // Honour an ambient transaction in tests (the InMemory
+        // provider rejects BeginTransactionAsync). In production the
+        // ambient is null and we own the serializable txn.
+        var ambient = _db.Database.CurrentTransaction;
+        var ownTxn = ambient is null && _db.Database.IsRelational()
+            ? await _db.Database.BeginTransactionAsync(IsolationLevel.Serializable, ct).ConfigureAwait(false)
+            : null;
+        try
+        {
+            // Active-name uniqueness precheck. The DB filtered unique
+            // index will also catch a race, but checking here lets us
+            // throw a clean ConflictException rather than surface a
+            // DbUpdateException with a constraint name in it.
+            var nameTaken = await _db.Bundles
+                .AsNoTracking()
+                .AnyAsync(b => b.Name == name && b.State == BundleState.Active, ct)
+                .ConfigureAwait(false);
+            if (nameTaken)
+            {
+                throw new ConflictException(
+                    $"Bundle name '{name}' is already in use by an active bundle.");
+            }
+
+            var capturedAt = _clock.GetUtcNow();
+            var snapshot = await _builder.BuildAsync(capturedAt, ct).ConfigureAwait(false);
+
+            var canonicalBytes = CanonicalJson.SerializeObject(snapshot);
+            var snapshotJson = Encoding.UTF8.GetString(canonicalBytes);
+            var snapshotHash = Convert.ToHexString(SHA256.HashData(canonicalBytes)).ToLowerInvariant();
+
+            var bundle = new Bundle
+            {
+                Id = Guid.NewGuid(),
+                Name = name,
+                Description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim(),
+                CreatedAt = capturedAt,
+                CreatedBySubjectId = actorSubjectId,
+                SnapshotJson = snapshotJson,
+                SnapshotHash = snapshotHash,
+                State = BundleState.Active,
+            };
+            _db.Bundles.Add(bundle);
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+            // Audit append after the bundle insert is committed in
+            // memory (still inside the same txn). The chain stamps a
+            // bundle.create event whose payload references both the
+            // snapshot hash and the chain-tail-hash captured by the
+            // builder — so an auditor can pivot in either direction.
+            var fieldDiffJson = BuildFieldDiffJson(
+                bundle.Id, snapshot.AuditTailHash, snapshotHash, snapshot);
+            await _audit.AppendAsync(new AuditAppendRequest(
+                Action: "bundle.create",
+                EntityType: "Bundle",
+                EntityId: bundle.Id.ToString(),
+                FieldDiffJson: fieldDiffJson,
+                Rationale: rationale,
+                ActorSubjectId: actorSubjectId,
+                ActorRoles: Array.Empty<string>()), ct).ConfigureAwait(false);
+
+            if (ownTxn is not null)
+            {
+                await ownTxn.CommitAsync(ct).ConfigureAwait(false);
+            }
+            return Map(bundle);
+        }
+        finally
+        {
+            if (ownTxn is not null)
+            {
+                await ownTxn.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
+    public async Task<BundleDto?> GetAsync(Guid bundleId, CancellationToken ct = default)
+    {
+        var bundle = await _db.Bundles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(b => b.Id == bundleId, ct)
+            .ConfigureAwait(false);
+        return bundle is null ? null : Map(bundle);
+    }
+
+    public async Task<IReadOnlyList<BundleDto>> ListAsync(
+        ListBundlesFilter filter, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        var skip = Math.Max(0, filter.Skip);
+        var take = Math.Clamp(filter.Take, 1, 500);
+
+        IQueryable<Bundle> q = _db.Bundles.AsNoTracking();
+        if (!filter.IncludeDeleted)
+        {
+            q = q.Where(b => b.State == BundleState.Active);
+        }
+        // SQLite cannot ORDER BY DateTimeOffset (same posture as the
+        // OverrideExpiryReaper / PolicyService list paths). Pull the
+        // filtered set, then order + page client-side. Bundle counts
+        // are bounded in practice; if they grow large enough to
+        // matter, a future migration would push the ordering via a
+        // raw SQL CAST or a ix_bundles_created_at_iso column.
+        var rows = await q
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+        return rows
+            .OrderByDescending(b => b.CreatedAt)
+            .ThenBy(b => b.Id)
+            .Skip(skip)
+            .Take(take)
+            .Select(Map)
+            .ToList();
+    }
+
+    public async Task<bool> SoftDeleteAsync(
+        Guid bundleId, string actorSubjectId, string rationale, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(actorSubjectId);
+        if (string.IsNullOrWhiteSpace(rationale))
+        {
+            throw new ValidationException("Rationale is required and may not be empty or whitespace.");
+        }
+
+        var bundle = await _db.Bundles
+            .FirstOrDefaultAsync(b => b.Id == bundleId, ct)
+            .ConfigureAwait(false);
+        if (bundle is null || bundle.State != BundleState.Active)
+        {
+            // Idempotent: already-tombstoned or unknown ids return
+            // false without writing an audit event.
+            return false;
+        }
+
+        bundle.State = BundleState.Deleted;
+        bundle.DeletedAt = _clock.GetUtcNow();
+        bundle.DeletedBySubjectId = actorSubjectId;
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        await _audit.AppendAsync(new AuditAppendRequest(
+            Action: "bundle.delete",
+            EntityType: "Bundle",
+            EntityId: bundle.Id.ToString(),
+            FieldDiffJson: $"[{{\"op\":\"replace\",\"path\":\"/state\",\"value\":\"Deleted\"}}]",
+            Rationale: rationale.Trim(),
+            ActorSubjectId: actorSubjectId,
+            ActorRoles: Array.Empty<string>()), ct).ConfigureAwait(false);
+        return true;
+    }
+
+    private static string BuildFieldDiffJson(
+        Guid bundleId,
+        string auditTailHashHex,
+        string snapshotHashHex,
+        Domain.ValueObjects.BundleSnapshot snapshot)
+    {
+        // Hand-rolled JSON Patch (RFC 6902 'add') so the body is a
+        // tiny dependency-free emit. The audit hash chain canonicalises
+        // it on append; here we just need a string that a
+        // FieldDiffJson column accepts and that downstream auditors
+        // can introspect.
+        var sb = new StringBuilder();
+        sb.Append("[{\"op\":\"add\",\"path\":\"/bundle\",\"value\":{");
+        sb.Append("\"id\":\"").Append(bundleId).Append("\",");
+        sb.Append("\"snapshotHash\":\"").Append(snapshotHashHex).Append("\",");
+        sb.Append("\"auditTailHash\":\"").Append(auditTailHashHex).Append("\",");
+        sb.Append("\"policyCount\":").Append(snapshot.Policies.Count).Append(',');
+        sb.Append("\"bindingCount\":").Append(snapshot.Bindings.Count).Append(',');
+        sb.Append("\"overrideCount\":").Append(snapshot.Overrides.Count).Append(',');
+        sb.Append("\"scopeCount\":").Append(snapshot.Scopes.Count);
+        sb.Append("}}]");
+        return sb.ToString();
+    }
+
+    private static BundleDto Map(Bundle b) => new(
+        Id: b.Id,
+        Name: b.Name,
+        Description: b.Description,
+        CreatedAt: b.CreatedAt,
+        CreatedBySubjectId: b.CreatedBySubjectId,
+        SnapshotHash: b.SnapshotHash,
+        State: b.State.ToString(),
+        DeletedAt: b.DeletedAt,
+        DeletedBySubjectId: b.DeletedBySubjectId);
+}

--- a/src/Andy.Policies.Infrastructure/Services/BundleSnapshotBuilder.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BundleSnapshotBuilder.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Domain.ValueObjects;
+using Andy.Policies.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Andy.Policies.Infrastructure.Services;
+
+/// <summary>
+/// Reads the live catalog and produces a
+/// <see cref="BundleSnapshot"/>. P8.2 (#82). Caller owns the
+/// serializable transaction; the builder only enumerates.
+/// </summary>
+public sealed class BundleSnapshotBuilder : IBundleSnapshotBuilder
+{
+    private const string SchemaVersion = "1";
+
+    /// <summary>32 zero hex chars (lowercase), used when the audit
+    /// chain is empty. Matches the genesis prev-hash of the chain
+    /// (P6.2 #42), so a bundle taken before any audit event still has
+    /// a stable, well-defined audit-tail-hash field.</summary>
+    private static readonly string EmptyChainTailHashHex = new('0', 64);
+
+    private readonly AppDbContext _db;
+
+    public BundleSnapshotBuilder(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<BundleSnapshot> BuildAsync(DateTimeOffset capturedAt, CancellationToken ct = default)
+    {
+        // Active policy versions, ordered (PolicyId, Version) for
+        // deterministic serialisation. Include the parent Policy so
+        // the snapshot carries the policy name without a second
+        // round-trip per row at read time.
+        var policyRows = await _db.PolicyVersions
+            .AsNoTracking()
+            .Where(v => v.State == LifecycleState.Active)
+            .OrderBy(v => v.PolicyId).ThenBy(v => v.Version)
+            .Select(v => new
+            {
+                v.PolicyId,
+                PolicyName = v.Policy!.Name,
+                v.Id,
+                v.Version,
+                v.Enforcement,
+                v.Severity,
+                v.Scopes,
+                v.RulesJson,
+                v.Summary,
+            })
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var policies = policyRows
+            .Select(r => new BundlePolicyEntry(
+                r.PolicyId,
+                r.PolicyName,
+                r.Id,
+                r.Version,
+                r.Enforcement.ToString(),
+                r.Severity.ToString(),
+                r.Scopes.ToList(),
+                r.RulesJson,
+                r.Summary))
+            .ToList();
+
+        var activePvIds = policies.Select(p => p.PolicyVersionId).ToHashSet();
+
+        // Live bindings against an Active policy version. Soft-deleted
+        // (DeletedAt non-null) rows and bindings to non-Active
+        // versions are excluded — they would have no addressable
+        // policy in the snapshot.
+        var bindings = await _db.Bindings
+            .AsNoTracking()
+            .Where(b => b.DeletedAt == null && activePvIds.Contains(b.PolicyVersionId))
+            .OrderBy(b => b.Id)
+            .Select(b => new BundleBindingEntry(
+                b.Id,
+                b.PolicyVersionId,
+                b.TargetType.ToString(),
+                b.TargetRef,
+                b.BindStrength.ToString()))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        // Approved overrides whose ExpiresAt is strictly after
+        // capturedAt. Proposed / Revoked / Expired rows have no
+        // runtime effect; including them would mislead consumers.
+        // SQLite cannot translate DateTimeOffset comparisons (same
+        // posture as the OverrideExpiryReaper from P5.3 — see comment
+        // there), so we filter on State server-side (covered by
+        // ix_overrides_scope_state and ix_overrides_expiry_approved)
+        // and refine on ExpiresAt client-side. The Approved set is
+        // bounded in practice; for catalogs that grow large here, a
+        // future migration would push the predicate via raw SQL.
+        var approvedRows = await _db.Overrides
+            .AsNoTracking()
+            .Where(o => o.State == OverrideState.Approved)
+            .Select(o => new
+            {
+                o.Id,
+                o.PolicyVersionId,
+                o.ScopeKind,
+                o.ScopeRef,
+                o.Effect,
+                o.ReplacementPolicyVersionId,
+                o.ExpiresAt,
+            })
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+        var overrides = approvedRows
+            .Where(o => o.ExpiresAt > capturedAt)
+            .OrderBy(o => o.Id)
+            .Select(o => new BundleOverrideEntry(
+                o.Id,
+                o.PolicyVersionId,
+                o.ScopeKind.ToString(),
+                o.ScopeRef,
+                o.Effect.ToString(),
+                o.ReplacementPolicyVersionId,
+                o.ExpiresAt))
+            .ToList();
+
+        // Scope tree: every node, ordered by Id. Consumers reconstruct
+        // the hierarchy via ParentId; the snapshot does not pre-build
+        // the tree because Bundle pinning is per-row, not per-shape.
+        var scopes = await _db.ScopeNodes
+            .AsNoTracking()
+            .OrderBy(s => s.Id)
+            .Select(s => new BundleScopeEntry(
+                s.Id,
+                s.ParentId,
+                s.Type.ToString(),
+                s.Ref,
+                s.DisplayName))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var auditTailHashHex = await GetAuditTailHashHexAsync(ct).ConfigureAwait(false);
+
+        return new BundleSnapshot(
+            SchemaVersion: SchemaVersion,
+            CapturedAt: capturedAt,
+            AuditTailHash: auditTailHashHex,
+            Policies: policies,
+            Bindings: bindings,
+            Overrides: overrides,
+            Scopes: scopes);
+    }
+
+    /// <summary>
+    /// Read the current audit chain tail hash. Returns 64 zero hex
+    /// chars when the chain is empty (matches the chain's genesis
+    /// prev-hash convention from P6.2). The hash is hex-encoded
+    /// lower-case so it round-trips identically to the form used by
+    /// <c>ChainVerificationResult</c> and the audit-export bundle.
+    /// </summary>
+    private async Task<string> GetAuditTailHashHexAsync(CancellationToken ct)
+    {
+        var tailHash = await _db.AuditEvents
+            .AsNoTracking()
+            .OrderByDescending(e => e.Seq)
+            .Select(e => e.Hash)
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+        return tailHash is null
+            ? EmptyChainTailHashHex
+            : Convert.ToHexString(tailHash).ToLowerInvariant();
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Services/BundleServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Services/BundleServiceTests.cs
@@ -1,0 +1,321 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Cryptography;
+using System.Text;
+using Andy.Policies.Application.Exceptions;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Audit;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Infrastructure.Services;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Services;
+
+/// <summary>
+/// Integration tests for <see cref="BundleService"/> end-to-end against
+/// SQLite + the real <see cref="AuditChain"/>. Pins the cross-cutting
+/// invariants P8.2 (#82) introduces: hash round-trip, audit-chain
+/// linkage, name-collision rejection, soft-delete state flip.
+/// </summary>
+public class BundleServiceTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+
+    public BundleServiceTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:;Foreign Keys=true");
+        _connection.Open();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private DbContextOptions<AppDbContext> Options() => new DbContextOptionsBuilder<AppDbContext>()
+        .UseSqlite(_connection)
+        .Options;
+
+    private async Task<AppDbContext> InitDbAsync()
+    {
+        var db = new AppDbContext(Options());
+        await db.Database.MigrateAsync();
+        return db;
+    }
+
+    private static BundleService NewService(AppDbContext db) => new(
+        db,
+        new BundleSnapshotBuilder(db),
+        new AuditChain(db, TimeProvider.System),
+        TimeProvider.System);
+
+    private static async Task<Guid> SeedActiveVersionAsync(AppDbContext db, string name)
+    {
+        var policy = new Policy
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            CreatedBySubjectId = "seed",
+        };
+        var version = new PolicyVersion
+        {
+            Id = Guid.NewGuid(),
+            PolicyId = policy.Id,
+            Version = 1,
+            State = LifecycleState.Active,
+            Enforcement = EnforcementLevel.Should,
+            Severity = Severity.Moderate,
+            Scopes = new List<string>(),
+            Summary = "fixture",
+            RulesJson = "{}",
+            CreatedBySubjectId = "seed",
+            ProposerSubjectId = "seed",
+            PublishedAt = DateTimeOffset.UtcNow,
+            PublishedBySubjectId = "seed",
+        };
+        db.Policies.Add(policy);
+        db.PolicyVersions.Add(version);
+        await db.SaveChangesAsync();
+        return version.Id;
+    }
+
+    [Fact]
+    public async Task Create_HappyPath_WritesBundle_AndAppendsBundleCreateAuditEvent()
+    {
+        await using var db = await InitDbAsync();
+        await SeedActiveVersionAsync(db, "p1");
+        var svc = NewService(db);
+
+        var dto = await svc.CreateAsync(
+            new CreateBundleRequest("snap-1", "first", "initial release"),
+            actorSubjectId: "user:author",
+            CancellationToken.None);
+
+        dto.Id.Should().NotBeEmpty();
+        dto.Name.Should().Be("snap-1");
+        dto.SnapshotHash.Should().HaveLength(64).And.MatchRegex("^[0-9a-f]{64}$");
+        dto.State.Should().Be("Active");
+
+        var bundle = await db.Bundles.AsNoTracking().FirstAsync(b => b.Id == dto.Id);
+        bundle.SnapshotJson.Should().Contain("\"SchemaVersion\":\"1\"");
+
+        var auditRow = await db.AuditEvents.AsNoTracking()
+            .Where(e => e.Action == "bundle.create" && e.EntityId == dto.Id.ToString())
+            .SingleAsync();
+        auditRow.Rationale.Should().Be("initial release");
+        auditRow.ActorSubjectId.Should().Be("user:author");
+        auditRow.FieldDiffJson.Should().Contain(dto.SnapshotHash,
+            "the bundle.create event payload references the snapshot hash so " +
+            "auditors can pivot bundle ↔ chain in either direction");
+    }
+
+    [Fact]
+    public async Task Create_StoredSnapshotJson_HashesToSnapshotHash()
+    {
+        // The reproducibility contract: an offline verifier reading
+        // SnapshotJson and SHA-256-ing the UTF-8 bytes must match
+        // SnapshotHash. P8.2 promises this via canonical-JSON output;
+        // this test pins the round-trip.
+        await using var db = await InitDbAsync();
+        await SeedActiveVersionAsync(db, "p1");
+        var svc = NewService(db);
+
+        var dto = await svc.CreateAsync(
+            new CreateBundleRequest("hash-rt", null, "rationale"),
+            "user:rt", CancellationToken.None);
+
+        var bundle = await db.Bundles.AsNoTracking().FirstAsync(b => b.Id == dto.Id);
+        var bytes = Encoding.UTF8.GetBytes(bundle.SnapshotJson);
+        var recomputed = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+
+        recomputed.Should().Be(
+            bundle.SnapshotHash,
+            "if the canonical bytes that were hashed at insert-time differ from " +
+            "the bytes stored, no offline verifier can reproduce the hash");
+    }
+
+    [Fact]
+    public async Task Create_NameCollisionWithActiveBundle_ThrowsConflictException()
+    {
+        await using var db = await InitDbAsync();
+        await SeedActiveVersionAsync(db, "p1");
+        var svc = NewService(db);
+
+        await svc.CreateAsync(new CreateBundleRequest("dup", null, "first"),
+            "user:a", CancellationToken.None);
+
+        var act = async () => await svc.CreateAsync(
+            new CreateBundleRequest("dup", null, "second"),
+            "user:b", CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage("*dup*already in use*");
+    }
+
+    [Fact]
+    public async Task Create_AfterSoftDelete_AllowsNameReuse()
+    {
+        await using var db = await InitDbAsync();
+        await SeedActiveVersionAsync(db, "p1");
+        var svc = NewService(db);
+
+        var first = await svc.CreateAsync(new CreateBundleRequest("reuse", null, "v1"),
+            "user:a", CancellationToken.None);
+        await svc.SoftDeleteAsync(first.Id, "user:op", "rotate", CancellationToken.None);
+
+        var second = await svc.CreateAsync(new CreateBundleRequest("reuse", null, "v2"),
+            "user:b", CancellationToken.None);
+
+        second.Id.Should().NotBe(first.Id);
+        second.State.Should().Be("Active");
+    }
+
+    [Fact]
+    public async Task SoftDelete_FlipsStateAndStampsTombstone_AndAppendsAuditEvent()
+    {
+        await using var db = await InitDbAsync();
+        await SeedActiveVersionAsync(db, "p1");
+        var svc = NewService(db);
+        var dto = await svc.CreateAsync(
+            new CreateBundleRequest("doomed", null, "initial"),
+            "user:a", CancellationToken.None);
+
+        var deleted = await svc.SoftDeleteAsync(dto.Id, "user:op", "decommission", CancellationToken.None);
+
+        deleted.Should().BeTrue();
+        var reloaded = await db.Bundles.AsNoTracking().FirstAsync(b => b.Id == dto.Id);
+        reloaded.State.Should().Be(BundleState.Deleted);
+        reloaded.DeletedBySubjectId.Should().Be("user:op");
+        reloaded.DeletedAt.Should().NotBeNull();
+
+        var auditRow = await db.AuditEvents.AsNoTracking()
+            .SingleAsync(e => e.Action == "bundle.delete" && e.EntityId == dto.Id.ToString());
+        auditRow.Rationale.Should().Be("decommission");
+    }
+
+    [Fact]
+    public async Task SoftDelete_OnAlreadyDeletedBundle_ReturnsFalse_NoAuditAppend()
+    {
+        await using var db = await InitDbAsync();
+        await SeedActiveVersionAsync(db, "p1");
+        var svc = NewService(db);
+        var dto = await svc.CreateAsync(new CreateBundleRequest("twice", null, "x"),
+            "user:a", CancellationToken.None);
+        await svc.SoftDeleteAsync(dto.Id, "user:op", "first delete", CancellationToken.None);
+
+        var second = await svc.SoftDeleteAsync(dto.Id, "user:op", "again", CancellationToken.None);
+
+        second.Should().BeFalse();
+        var deleteEvents = await db.AuditEvents.AsNoTracking()
+            .Where(e => e.Action == "bundle.delete" && e.EntityId == dto.Id.ToString())
+            .CountAsync();
+        deleteEvents.Should().Be(
+            1,
+            "the second delete is a no-op; emitting a duplicate audit event " +
+            "would inflate the chain with non-events");
+    }
+
+    [Fact]
+    public async Task SoftDelete_OnUnknownBundle_ReturnsFalse()
+    {
+        await using var db = await InitDbAsync();
+        var svc = NewService(db);
+
+        var result = await svc.SoftDeleteAsync(
+            Guid.NewGuid(), "user:op", "doesn't exist", CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsActiveOnly_ByDefault()
+    {
+        await using var db = await InitDbAsync();
+        await SeedActiveVersionAsync(db, "p1");
+        var svc = NewService(db);
+        var live = await svc.CreateAsync(new CreateBundleRequest("live", null, "x"),
+            "user:a", CancellationToken.None);
+        var doomed = await svc.CreateAsync(new CreateBundleRequest("doomed", null, "x"),
+            "user:a", CancellationToken.None);
+        await svc.SoftDeleteAsync(doomed.Id, "user:op", "tombstone", CancellationToken.None);
+
+        var listed = await svc.ListAsync(new ListBundlesFilter(), CancellationToken.None);
+
+        listed.Select(b => b.Id).Should().Contain(live.Id);
+        listed.Select(b => b.Id).Should().NotContain(doomed.Id);
+    }
+
+    [Fact]
+    public async Task ListAsync_WithIncludeDeleted_ReturnsBoth()
+    {
+        await using var db = await InitDbAsync();
+        await SeedActiveVersionAsync(db, "p1");
+        var svc = NewService(db);
+        var live = await svc.CreateAsync(new CreateBundleRequest("live", null, "x"),
+            "user:a", CancellationToken.None);
+        var doomed = await svc.CreateAsync(new CreateBundleRequest("doomed", null, "x"),
+            "user:a", CancellationToken.None);
+        await svc.SoftDeleteAsync(doomed.Id, "user:op", "tombstone", CancellationToken.None);
+
+        var listed = await svc.ListAsync(new ListBundlesFilter(IncludeDeleted: true), CancellationToken.None);
+
+        listed.Select(b => b.Id).Should().Contain(new[] { live.Id, doomed.Id });
+    }
+
+    [Fact]
+    public async Task GetAsync_ReturnsRow_AndNullForUnknown()
+    {
+        await using var db = await InitDbAsync();
+        await SeedActiveVersionAsync(db, "p1");
+        var svc = NewService(db);
+        var dto = await svc.CreateAsync(new CreateBundleRequest("getme", null, "x"),
+            "user:a", CancellationToken.None);
+
+        var hit = await svc.GetAsync(dto.Id, CancellationToken.None);
+        var miss = await svc.GetAsync(Guid.NewGuid(), CancellationToken.None);
+
+        hit.Should().NotBeNull();
+        hit!.Id.Should().Be(dto.Id);
+        miss.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Create_AuditEventCarriesAuditTailHash_FromBeforeBundleInsert()
+    {
+        // The bundle.create event should carry the chain tail hash that
+        // existed BEFORE the bundle insert appended its own row. P8
+        // verifiers walk back from this tail hash to find the snapshot's
+        // historical context.
+        await using var db = await InitDbAsync();
+        await SeedActiveVersionAsync(db, "p1");
+        // Pre-seed an audit event so the tail-hash is non-zero at
+        // bundle-insert time. AuditChain.AppendAsync stamps the chain.
+        var chain = new AuditChain(db, TimeProvider.System);
+        await chain.AppendAsync(new AuditAppendRequest(
+            Action: "policy.publish",
+            EntityType: "Policy",
+            EntityId: Guid.NewGuid().ToString(),
+            FieldDiffJson: "[]",
+            Rationale: "seed",
+            ActorSubjectId: "user:seed",
+            ActorRoles: Array.Empty<string>()), CancellationToken.None);
+        var precedingTailHash = await db.AuditEvents.AsNoTracking()
+            .OrderByDescending(e => e.Seq).Select(e => e.Hash).FirstAsync();
+
+        var svc = NewService(db);
+        var dto = await svc.CreateAsync(new CreateBundleRequest("audited", null, "x"),
+            "user:a", CancellationToken.None);
+
+        var auditRow = await db.AuditEvents.AsNoTracking()
+            .SingleAsync(e => e.Action == "bundle.create" && e.EntityId == dto.Id.ToString());
+        var precedingHex = Convert.ToHexString(precedingTailHash).ToLowerInvariant();
+        auditRow.FieldDiffJson.Should().Contain(
+            precedingHex,
+            "the bundle.create event embeds the audit-tail-hash captured at " +
+            "snapshot time, which is the chain coordinate just before this " +
+            "very event was appended");
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Services/BundleServiceValidationTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/BundleServiceValidationTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Exceptions;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.ValueObjects;
+using Andy.Policies.Infrastructure.Services;
+using Andy.Policies.Tests.Unit.Fixtures;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Services;
+
+/// <summary>
+/// Pure validation paths on <see cref="BundleService.CreateAsync"/> —
+/// the slug regex + the rationale-required guard. These reject before
+/// the service touches the catalog or the audit chain, so a stub
+/// builder that throws on Build proves the precondition fired first.
+/// P8.2 (#82).
+/// </summary>
+public class BundleServiceValidationTests
+{
+    private sealed class ThrowingBuilder : IBundleSnapshotBuilder
+    {
+        public Task<BundleSnapshot> BuildAsync(DateTimeOffset capturedAt, CancellationToken ct = default)
+            => throw new InvalidOperationException(
+                "BundleSnapshotBuilder must not be invoked when validation fails.");
+    }
+
+    private sealed class ThrowingAudit : IAuditChain
+    {
+        public Task<AuditEventDto> AppendAsync(AuditAppendRequest request, CancellationToken ct)
+            => throw new InvalidOperationException(
+                "Audit chain must not be invoked when validation fails.");
+        public Task<ChainVerificationResult> VerifyChainAsync(
+            long? fromSeq, long? toSeq, CancellationToken ct) =>
+            throw new NotSupportedException();
+    }
+
+    private static BundleService NewService() => new(
+        InMemoryDbFixture.Create(),
+        new ThrowingBuilder(),
+        new ThrowingAudit(),
+        TimeProvider.System);
+
+    [Theory]
+    [InlineData("Bad-Capital")]       // uppercase
+    [InlineData("-leading-dash")]     // first char must be [a-z0-9]
+    [InlineData("under_score")]       // underscore not in [a-z0-9-]
+    [InlineData("dot.notation")]      // dot not in [a-z0-9-]
+    [InlineData("with space")]        // space not allowed
+    [InlineData("")]                  // empty
+    public async Task Create_RejectsInvalidSlug_WithValidationException(string name)
+    {
+        var svc = NewService();
+        var request = new CreateBundleRequest(name, "desc", "rationale");
+
+        var act = async () => await svc.CreateAsync(request, "actor", CancellationToken.None);
+
+        await act.Should().ThrowAsync<ValidationException>()
+            .Where(ex => ex.Message.Contains("slug", StringComparison.OrdinalIgnoreCase),
+                $"name '{name}' must be rejected with a slug-shape error");
+    }
+
+    [Fact]
+    public async Task Create_RejectsEmptyRationale_WithValidationException()
+    {
+        var svc = NewService();
+        var request = new CreateBundleRequest("valid-slug", "desc", "   ");
+
+        var act = async () => await svc.CreateAsync(request, "actor", CancellationToken.None);
+
+        await act.Should().ThrowAsync<ValidationException>()
+            .Where(ex => ex.Message.Contains("Rationale", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Create_RejectsEmptyActorSubjectId_WithArgumentException()
+    {
+        var svc = NewService();
+        var request = new CreateBundleRequest("valid", "desc", "rationale");
+
+        var act = async () => await svc.CreateAsync(request, string.Empty, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Services/BundleSnapshotBuilderTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/BundleSnapshotBuilderTests.cs
@@ -1,0 +1,300 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Cryptography;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Infrastructure.Services;
+using Andy.Policies.Shared.Auditing;
+using Andy.Policies.Tests.Unit.Fixtures;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Services;
+
+/// <summary>
+/// Unit tests for <see cref="BundleSnapshotBuilder"/> (P8.2, story
+/// rivoli-ai/andy-policies#82). Drives the builder over EF Core
+/// InMemory to pin: filtering (Active-only policies, non-deleted
+/// bindings against Active versions, Approved+unexpired overrides),
+/// stable ordering, audit-tail-hash extraction, and hash determinism.
+/// </summary>
+public class BundleSnapshotBuilderTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-05-05T18:00:00Z");
+
+    private static AppDbContext NewDb() => InMemoryDbFixture.Create();
+
+    private static async Task<(Guid policyId, Guid versionId)> SeedPolicyVersionAsync(
+        AppDbContext db, string name = "p1", LifecycleState state = LifecycleState.Active)
+    {
+        var policy = new Policy
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            CreatedBySubjectId = "u1",
+        };
+        var version = new PolicyVersion
+        {
+            Id = Guid.NewGuid(),
+            PolicyId = policy.Id,
+            Version = 1,
+            State = state,
+            Enforcement = EnforcementLevel.Should,
+            Severity = Severity.Moderate,
+            Scopes = new List<string>(),
+            Summary = "fixture",
+            RulesJson = "{}",
+            CreatedAt = Now.AddDays(-1),
+            CreatedBySubjectId = "u1",
+            ProposerSubjectId = "u1",
+        };
+        db.Policies.Add(policy);
+        db.PolicyVersions.Add(version);
+        await db.SaveChangesAsync();
+        return (policy.Id, version.Id);
+    }
+
+    [Fact]
+    public async Task Build_FiltersToActivePolicyVersionsOnly()
+    {
+        await using var db = NewDb();
+        var (_, activeId) = await SeedPolicyVersionAsync(db, "active-policy", LifecycleState.Active);
+        await SeedPolicyVersionAsync(db, "draft-policy", LifecycleState.Draft);
+        await SeedPolicyVersionAsync(db, "winddown-policy", LifecycleState.WindingDown);
+        await SeedPolicyVersionAsync(db, "retired-policy", LifecycleState.Retired);
+
+        var snapshot = await new BundleSnapshotBuilder(db).BuildAsync(Now);
+
+        snapshot.Policies.Should().ContainSingle()
+            .Which.PolicyVersionId.Should().Be(
+                activeId,
+                "Draft / WindingDown / Retired versions have no runtime " +
+                "effect for consumers; including them would mislead a " +
+                "pinned bundle into representing inactive history");
+    }
+
+    [Fact]
+    public async Task Build_FiltersOutDeletedBindings()
+    {
+        await using var db = NewDb();
+        var (_, versionId) = await SeedPolicyVersionAsync(db);
+        db.Bindings.AddRange(
+            new Binding
+            {
+                Id = Guid.NewGuid(),
+                PolicyVersionId = versionId,
+                TargetType = BindingTargetType.Repo,
+                TargetRef = "repo:rivoli-ai/live",
+                BindStrength = BindStrength.Mandatory,
+                CreatedBySubjectId = "u1",
+            },
+            new Binding
+            {
+                Id = Guid.NewGuid(),
+                PolicyVersionId = versionId,
+                TargetType = BindingTargetType.Repo,
+                TargetRef = "repo:rivoli-ai/dead",
+                BindStrength = BindStrength.Recommended,
+                CreatedBySubjectId = "u1",
+                DeletedAt = Now.AddHours(-1),
+                DeletedBySubjectId = "op",
+            });
+        await db.SaveChangesAsync();
+
+        var snapshot = await new BundleSnapshotBuilder(db).BuildAsync(Now);
+
+        snapshot.Bindings.Should().ContainSingle()
+            .Which.TargetRef.Should().Be("repo:rivoli-ai/live");
+    }
+
+    [Fact]
+    public async Task Build_FiltersOutBindingsAgainstNonActiveVersions()
+    {
+        await using var db = NewDb();
+        var (_, _) = await SeedPolicyVersionAsync(db, "draft-only", LifecycleState.Draft);
+        var (_, draftId) = await SeedPolicyVersionAsync(db, "another-draft", LifecycleState.Draft);
+        db.Bindings.Add(new Binding
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = draftId,
+            TargetType = BindingTargetType.Repo,
+            TargetRef = "repo:to/draft",
+            BindStrength = BindStrength.Recommended,
+            CreatedBySubjectId = "u1",
+        });
+        await db.SaveChangesAsync();
+
+        var snapshot = await new BundleSnapshotBuilder(db).BuildAsync(Now);
+
+        snapshot.Bindings.Should().BeEmpty(
+            "a bundle's bindings reference policy versions that the bundle " +
+            "actually carries; a binding to an inactive version has no " +
+            "addressable policy in the snapshot");
+    }
+
+    [Fact]
+    public async Task Build_FiltersOutNonApprovedAndExpiredOverrides()
+    {
+        await using var db = NewDb();
+        var (_, versionId) = await SeedPolicyVersionAsync(db);
+        db.Overrides.AddRange(
+            new Override
+            {
+                Id = Guid.NewGuid(),
+                PolicyVersionId = versionId,
+                ScopeKind = OverrideScopeKind.Principal,
+                ScopeRef = "user:approved-live",
+                Effect = OverrideEffect.Exempt,
+                State = OverrideState.Approved,
+                ExpiresAt = Now.AddDays(7),
+                ProposerSubjectId = "alice",
+                Rationale = "live",
+                ProposedAt = Now.AddDays(-1),
+            },
+            new Override
+            {
+                Id = Guid.NewGuid(),
+                PolicyVersionId = versionId,
+                ScopeKind = OverrideScopeKind.Principal,
+                ScopeRef = "user:approved-expired",
+                Effect = OverrideEffect.Exempt,
+                State = OverrideState.Approved,
+                ExpiresAt = Now.AddSeconds(-1),
+                ProposerSubjectId = "alice",
+                Rationale = "expired",
+                ProposedAt = Now.AddDays(-2),
+            },
+            new Override
+            {
+                Id = Guid.NewGuid(),
+                PolicyVersionId = versionId,
+                ScopeKind = OverrideScopeKind.Principal,
+                ScopeRef = "user:proposed",
+                Effect = OverrideEffect.Exempt,
+                State = OverrideState.Proposed,
+                ExpiresAt = Now.AddDays(7),
+                ProposerSubjectId = "alice",
+                Rationale = "pending",
+                ProposedAt = Now.AddHours(-1),
+            });
+        await db.SaveChangesAsync();
+
+        var snapshot = await new BundleSnapshotBuilder(db).BuildAsync(Now);
+
+        snapshot.Overrides.Should().ContainSingle()
+            .Which.ScopeRef.Should().Be(
+                "user:approved-live",
+                "only Approved overrides whose ExpiresAt is strictly after " +
+                "capturedAt have runtime effect; everything else is past " +
+                "or pending");
+    }
+
+    [Fact]
+    public async Task Build_OrdersCollectionsStably()
+    {
+        await using var db = NewDb();
+        // Seed two policies with names that would sort differently if
+        // alphabetised; the spec requires PolicyId+Version ordering, so
+        // the snapshot order is determined by GUID, not name.
+        var (p1, v1) = await SeedPolicyVersionAsync(db, "zzz-policy");
+        var (p2, v2) = await SeedPolicyVersionAsync(db, "aaa-policy");
+
+        var snapshot = await new BundleSnapshotBuilder(db).BuildAsync(Now);
+
+        var order = snapshot.Policies.Select(p => p.PolicyId).ToList();
+        order.Should().Equal(
+            new[] { p1, p2 }.OrderBy(g => g).ToList(),
+            "the Policies array must be ordered by PolicyId so canonical " +
+            "JSON serialisation produces byte-identical output across runs");
+    }
+
+    [Fact]
+    public async Task Build_PopulatesAuditTailHashFromMostRecentEvent()
+    {
+        await using var db = NewDb();
+        await SeedPolicyVersionAsync(db);
+        var newestHash = new byte[32];
+        new Random(42).NextBytes(newestHash);
+        db.AuditEvents.Add(new AuditEvent
+        {
+            Id = Guid.NewGuid(),
+            Seq = 1,
+            PrevHash = new byte[32],
+            Hash = new byte[32], // older
+            Timestamp = Now.AddDays(-1),
+            ActorSubjectId = "u1",
+            ActorRoles = Array.Empty<string>(),
+            Action = "policy.create",
+            EntityType = "Policy",
+            EntityId = "x",
+            FieldDiffJson = "[]",
+        });
+        db.AuditEvents.Add(new AuditEvent
+        {
+            Id = Guid.NewGuid(),
+            Seq = 2,
+            PrevHash = new byte[32],
+            Hash = newestHash,
+            Timestamp = Now,
+            ActorSubjectId = "u1",
+            ActorRoles = Array.Empty<string>(),
+            Action = "policy.publish",
+            EntityType = "Policy",
+            EntityId = "x",
+            FieldDiffJson = "[]",
+        });
+        await db.SaveChangesAsync();
+
+        var snapshot = await new BundleSnapshotBuilder(db).BuildAsync(Now);
+
+        snapshot.AuditTailHash.Should().Be(
+            Convert.ToHexString(newestHash).ToLowerInvariant(),
+            "the chain's tail is the highest-Seq row's Hash; this is the " +
+            "coordinate consumers cross-walk with the bundle.create event");
+    }
+
+    [Fact]
+    public async Task Build_AuditTailHash_IsZeroHexWhenChainIsEmpty()
+    {
+        await using var db = NewDb();
+        await SeedPolicyVersionAsync(db);
+
+        var snapshot = await new BundleSnapshotBuilder(db).BuildAsync(Now);
+
+        snapshot.AuditTailHash.Should().Be(
+            new string('0', 64),
+            "an empty chain matches the genesis prev-hash convention from " +
+            "the audit chain so verifiers can treat the empty case identically");
+    }
+
+    [Fact]
+    public async Task Build_IsDeterministic_AcrossTwoIndependentContexts()
+    {
+        // Same seeded catalog → same canonical JSON → same SHA-256.
+        // This is the floor under the SnapshotHash invariant.
+        var dbName = Guid.NewGuid().ToString();
+        byte[] firstHash, secondHash;
+
+        await using (var db1 = InMemoryDbFixture.Create(dbName))
+        {
+            await SeedPolicyVersionAsync(db1, "det");
+            firstHash = SHA256.HashData(
+                CanonicalJson.SerializeObject(
+                    await new BundleSnapshotBuilder(db1).BuildAsync(Now)));
+        }
+
+        await using (var db2 = InMemoryDbFixture.Create(dbName))
+        {
+            secondHash = SHA256.HashData(
+                CanonicalJson.SerializeObject(
+                    await new BundleSnapshotBuilder(db2).BuildAsync(Now)));
+        }
+
+        secondHash.Should().Equal(
+            firstHash,
+            "snapshot determinism is the load-bearing invariant for offline " +
+            "verifiers; the same catalog state must always yield the same hash");
+    }
+}


### PR DESCRIPTION
## Summary

The one operation that writes a `Bundle`: take a frozen view of the catalog and persist it atomically alongside an audit-chain entry that pins the snapshot to a specific chain coordinate.

- `IBundleService` (Application) + `IBundleSnapshotBuilder` split: the service owns transaction scope + validation + audit append; the builder owns the read-materialise pass and is unit-testable in isolation.
- `BundleService.CreateAsync` opens a **Serializable** transaction (when the provider supports it; honours an ambient txn from tests with the InMemory provider). Validates slug + non-empty rationale, prechecks active-name conflict (`ConflictException`), invokes the builder, canonicalises via the existing `CanonicalJson` helper, SHA-256-hex-hashes, inserts the `Bundle` row, then appends a `bundle.create` event whose `FieldDiffJson` carries the snapshot hash + parent audit-tail-hash.
- `SoftDeleteAsync` flips state + writes `bundle.delete` event; idempotent (no-op + `false` on already-tombstoned).
- `BundleSnapshotBuilder` enumerates Active policy versions, live bindings against active versions, Approved overrides whose `ExpiresAt > capturedAt`, and the full scope tree. Stable ordering (PolicyId+Version for policies; Id for everything else). Reads the audit chain tail directly from `db.AuditEvents` to avoid extending `IAuditChain`. Empty-chain case returns 64-zero-hex matching the chain genesis convention.

The override expiry filter and the bundle list `ORDER BY` are done client-side because SQLite cannot translate `DateTimeOffset` comparisons or sort expressions — same posture as `OverrideExpiryReaper` from P5.3.

Closes #82.

## Test plan

- [x] `dotnet build` clean (zero warnings under `TreatWarningsAsErrors`)
- [x] `dotnet test` — Unit 495/495 (+16 new), Integration 528/528 (+11 new), E2E 6/6
- [x] `BundleSnapshotBuilderTests` (8 unit): Active-only policy filter, deleted-binding filter, bindings-to-non-active filter, non-Approved/expired override filter, stable ordering by GUID (not name), audit-tail-hash extraction populated + empty cases, hash determinism across two independent contexts
- [x] `BundleServiceValidationTests` (8 unit): six invalid slug shapes, empty rationale, empty actor — all reject before the catalog or audit chain is touched (proven by stub builder/audit that throw on invocation)
- [x] `BundleServiceTests` (11 integration, SQLite + real `AuditChain`): happy-path `Create` writes `Bundle` + audit row carrying the snapshot hash; `SHA-256(SnapshotJson)` matches `SnapshotHash`; duplicate active name returns `ConflictException`; soft-delete releases name for reuse; soft-delete flips state + audit; double soft-delete is idempotent (no second audit row); `List` defaults to active-only with `includeDeleted` toggle; `Get` returns row + null for unknown; `bundle.create` event embeds the audit-tail-hash captured before the bundle's own row was appended

## Note on the deferred concurrent-publish test

The spec includes a Postgres-testcontainer test that proves a concurrent `PolicyVersion` publish committed between the snapshot read and the bundle insert is **not** visible in the bundle. That test requires a second connection that holds an open transaction across the bundle insert, which the SQLite-backed integration project doesn't currently scaffold. Postgres testcontainer infra exists in the project (used by `ConcurrentPublishTests`); a follow-up commit can add the equivalent test for the bundle path. The serializable-isolation guarantee itself is in place — this is purely a test-coverage gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)