### PR TITLE
Implement P8.3 — bundle resolution endpoints with ETag/304 (#83)

### DIFF
--- a/src/Andy.Policies.Api/Controllers/BundlesController.cs
+++ b/src/Andy.Policies.Api/Controllers/BundlesController.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Enums;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
+
+namespace Andy.Policies.Api.Controllers;
+
+/// <summary>
+/// REST surface for resolving and reading from a frozen
+/// <see cref="Andy.Policies.Domain.Entities.Bundle"/> snapshot
+/// (P8.3, story rivoli-ai/andy-policies#83). Two endpoints today:
+/// <list type="bullet">
+///   <item><c>GET /api/bundles/{id}/resolve?targetType=&amp;targetRef=</c>
+///     — bindings against the snapshot for a target.</item>
+///   <item><c>GET /api/bundles/{id}/policies/{policyId}</c> — pinned
+///     policy lookup.</item>
+/// </list>
+/// Mutation surfaces (POST / DELETE) land in P8.4–P8.5 alongside the
+/// MCP and gRPC parity.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>HTTP caching.</b> Bundles are immutable so responses carry
+/// <c>ETag: "&lt;snapshotHash&gt;"</c> and
+/// <c>Cache-Control: public, max-age=31536000, immutable</c>. A
+/// matching <c>If-None-Match</c> short-circuits to 304. This is
+/// transport-layer caching of an immutable artifact and does not
+/// conflict with the epic's "no consumer caching" non-goal — that
+/// rule governs application-level stale-data caches, not the HTTP
+/// strong-validator path.
+/// </para>
+/// </remarks>
+[ApiController]
+[Authorize]
+[Route("api/bundles")]
+[Produces("application/json")]
+public sealed class BundlesController : ControllerBase
+{
+    private readonly IBundleResolver _resolver;
+
+    public BundlesController(IBundleResolver resolver)
+    {
+        _resolver = resolver;
+    }
+
+    /// <summary>
+    /// Resolve bindings for a <c>(targetType, targetRef)</c> pair
+    /// against a frozen bundle. Exact-match only (mirrors the live
+    /// <c>GET /api/bindings/resolve</c>); no hierarchy walk.
+    /// Returns 200 with a <see cref="BundleResolveResult"/>; 404
+    /// when the bundle does not exist or is soft-deleted; 400 when
+    /// <paramref name="targetRef"/> is empty.
+    /// </summary>
+    [HttpGet("{id:guid}/resolve")]
+    [Authorize(Policy = "andy-policies:bundle:read")]
+    [ProducesResponseType(typeof(BundleResolveResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status304NotModified)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Resolve(
+        Guid id,
+        [FromQuery] BindingTargetType targetType,
+        [FromQuery] string targetRef,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(targetRef))
+        {
+            return ValidationProblem("targetRef query parameter is required.");
+        }
+
+        var result = await _resolver.ResolveAsync(id, targetType, targetRef, ct);
+        if (result is null) return NotFound();
+
+        if (TryReturnNotModified(result.SnapshotHash, out var notModified))
+        {
+            return notModified;
+        }
+
+        SetSnapshotCacheHeaders(result.SnapshotHash);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Look up a single pinned policy by id. Returns 200 with a
+    /// <see cref="BundlePinnedPolicyDto"/>, or 404 when the bundle
+    /// does not exist / is soft-deleted, or the policy id is not in
+    /// the snapshot.
+    /// </summary>
+    [HttpGet("{id:guid}/policies/{policyId:guid}")]
+    [Authorize(Policy = "andy-policies:bundle:read")]
+    [ProducesResponseType(typeof(BundlePinnedPolicyDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status304NotModified)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetPinnedPolicy(
+        Guid id,
+        Guid policyId,
+        CancellationToken ct)
+    {
+        var dto = await _resolver.GetPinnedPolicyAsync(id, policyId, ct);
+        if (dto is null) return NotFound();
+
+        if (TryReturnNotModified(dto.SnapshotHash, out var notModified))
+        {
+            return notModified;
+        }
+
+        SetSnapshotCacheHeaders(dto.SnapshotHash);
+        return Ok(dto);
+    }
+
+    private bool TryReturnNotModified(string snapshotHash, out IActionResult result)
+    {
+        var ifNoneMatch = Request.Headers[HeaderNames.IfNoneMatch].ToString();
+        if (!string.IsNullOrEmpty(ifNoneMatch))
+        {
+            // Strong validator: the ETag we emit is `"<hash>"`. Match
+            // either form (with quotes from a compliant client, or
+            // without from a permissive proxy).
+            var bare = ifNoneMatch.Trim().Trim('"');
+            if (string.Equals(bare, snapshotHash, StringComparison.Ordinal))
+            {
+                SetSnapshotCacheHeaders(snapshotHash);
+                result = StatusCode(StatusCodes.Status304NotModified);
+                return true;
+            }
+        }
+        result = null!;
+        return false;
+    }
+
+    private void SetSnapshotCacheHeaders(string snapshotHash)
+    {
+        Response.Headers[HeaderNames.ETag] = $"\"{snapshotHash}\"";
+        // Bundles are immutable post-insert (P8.1's SaveChanges sweep),
+        // so an aggressive max-age + immutable directive is honest:
+        // the response body for a given (bundleId, snapshotHash) will
+        // never change.
+        Response.Headers[HeaderNames.CacheControl] = "public, max-age=31536000, immutable";
+    }
+}

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -173,6 +173,10 @@ builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IOverrideService
 // the per-request DbContext.
 builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBundleSnapshotBuilder, Andy.Policies.Infrastructure.Services.BundleSnapshotBuilder>();
 builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBundleService, Andy.Policies.Infrastructure.Services.BundleService>();
+// P8.3 (#83): in-memory resolver over the bundle snapshot. Scoped
+// because it depends on the per-request DbContext; the cached
+// parsed-snapshot lives in the singleton IMemoryCache below.
+builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBundleResolver, Andy.Policies.Infrastructure.Services.BundleResolver>();
 
 // P7.2 (#51): IRbacChecker delegates POST /api/check to andy-rbac.
 // AndyRbac:BaseUrl is required (no auth-bypass — same posture as

--- a/src/Andy.Policies.Application/Interfaces/IBundleResolver.cs
+++ b/src/Andy.Policies.Application/Interfaces/IBundleResolver.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Domain.Enums;
+
+namespace Andy.Policies.Application.Interfaces;
+
+/// <summary>
+/// Resolution-shaped read against a frozen <c>Bundle</c> snapshot
+/// (P8.3, story rivoli-ai/andy-policies#83). Mirrors
+/// <see cref="IBindingResolver"/>'s exact-match contract — same
+/// dedup rule, same ordering — but reads from the bundle's
+/// pre-materialised <c>SnapshotJson</c> instead of live tables, so
+/// answers are reproducible across catalog mutations.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Override application is intentionally out of scope</b> for
+/// P8.3. The live <see cref="IBindingResolver"/> doesn't apply
+/// override effects either — that lives in P5's flow. Bundle-time
+/// override semantics will be pinned by ADR 0008 (P8.8) and wired
+/// in a follow-up.
+/// </para>
+/// </remarks>
+public interface IBundleResolver
+{
+    /// <summary>
+    /// Resolve bindings for an exact <c>(targetType, targetRef)</c>
+    /// pair against the bundle's snapshot. Returns <c>null</c> when
+    /// the bundle does not exist or is soft-deleted; returns an
+    /// empty <see cref="BundleResolveResult.Bindings"/> when the
+    /// bundle exists but has no bindings for the target.
+    /// </summary>
+    Task<BundleResolveResult?> ResolveAsync(
+        Guid bundleId,
+        BindingTargetType targetType,
+        string targetRef,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Look up a single pinned policy in a bundle by its
+    /// <c>PolicyId</c>. Returns <c>null</c> when the bundle is
+    /// missing/deleted or the policy is not in the snapshot.
+    /// </summary>
+    Task<BundlePinnedPolicyDto?> GetPinnedPolicyAsync(
+        Guid bundleId,
+        Guid policyId,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Envelope for <see cref="IBundleResolver.ResolveAsync"/>. Carries
+/// the bundle identity + snapshot coordinate (<see cref="SnapshotHash"/>,
+/// <see cref="CapturedAt"/>) so callers caching the response have
+/// everything they need to validate it against a re-fetched bundle.
+/// </summary>
+public sealed record BundleResolveResult(
+    Guid BundleId,
+    string BundleName,
+    string SnapshotHash,
+    DateTimeOffset CapturedAt,
+    BindingTargetType TargetType,
+    string TargetRef,
+    IReadOnlyList<BundleResolvedBindingDto> Bindings,
+    int Count);
+
+/// <summary>
+/// Per-binding row in <see cref="BundleResolveResult.Bindings"/>.
+/// Mirrors <see cref="Andy.Policies.Application.Dtos.ResolvedBindingDto"/>
+/// from P3.4: same wire-format casing, same fields. The only
+/// difference is the data source (frozen snapshot vs. live tables).
+/// </summary>
+public sealed record BundleResolvedBindingDto(
+    Guid BindingId,
+    Guid PolicyId,
+    string PolicyName,
+    Guid PolicyVersionId,
+    int VersionNumber,
+    string Enforcement,
+    string Severity,
+    IReadOnlyList<string> Scopes,
+    BindStrength BindStrength);
+
+/// <summary>
+/// Single-policy projection from a bundle snapshot. Returned by
+/// <see cref="IBundleResolver.GetPinnedPolicyAsync"/>; carries the
+/// snapshot coordinates so callers can stamp ETags / cache keys.
+/// </summary>
+public sealed record BundlePinnedPolicyDto(
+    Guid BundleId,
+    string BundleName,
+    string SnapshotHash,
+    DateTimeOffset CapturedAt,
+    Guid PolicyId,
+    string PolicyName,
+    Guid PolicyVersionId,
+    int VersionNumber,
+    string Enforcement,
+    string Severity,
+    IReadOnlyList<string> Scopes,
+    string RulesJson,
+    string Summary);

--- a/src/Andy.Policies.Infrastructure/Services/BundleResolver.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BundleResolver.cs
@@ -1,0 +1,210 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Domain.ValueObjects;
+using Andy.Policies.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Andy.Policies.Infrastructure.Services;
+
+/// <summary>
+/// In-memory resolver over <c>Bundle.SnapshotJson</c> (P8.3, story
+/// rivoli-ai/andy-policies#83). Reads the bundle row, deserialises the
+/// snapshot once per <c>(bundleId, snapshotHash)</c> into an
+/// <see cref="IMemoryCache"/> entry, and serves resolution + pinned-
+/// policy lookups out of the cached <see cref="BundleSnapshot"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Cache identity.</b> The cache key is
+/// <c>(bundleId, snapshotHash)</c>. Bundles are immutable post-insert
+/// (P8.1's SaveChanges immutability sweep), so a stale entry is
+/// impossible: any change to the row implies a new <c>snapshotHash</c>
+/// which produces a different key. Cache TTL is 5 minutes — a soft
+/// upper bound to keep memory usage bounded under unbounded bundle
+/// counts; on miss we re-deserialise from the row.
+/// </para>
+/// <para>
+/// <b>Soft-delete posture.</b> Bundles in
+/// <see cref="BundleState.Deleted"/> are excluded from resolution —
+/// callers see a 404 from the controller. The bundle row remains in
+/// the table for audit-chain integrity, but is not addressable from
+/// the resolution surface.
+/// </para>
+/// </remarks>
+public sealed class BundleResolver : IBundleResolver
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+
+    private static readonly JsonSerializerOptions SnapshotJsonOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly AppDbContext _db;
+    private readonly IMemoryCache _cache;
+
+    public BundleResolver(AppDbContext db, IMemoryCache cache)
+    {
+        _db = db;
+        _cache = cache;
+    }
+
+    public async Task<BundleResolveResult?> ResolveAsync(
+        Guid bundleId,
+        BindingTargetType targetType,
+        string targetRef,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(targetRef);
+
+        var carrier = await LoadAsync(bundleId, ct).ConfigureAwait(false);
+        if (carrier is null)
+        {
+            return null;
+        }
+
+        var targetTypeWire = targetType.ToString();
+        var rows = carrier.Snapshot.Bindings
+            .Where(b => string.Equals(b.TargetType, targetTypeWire, StringComparison.Ordinal)
+                     && string.Equals(b.TargetRef, targetRef, StringComparison.Ordinal))
+            .ToList();
+
+        // Dedup by PolicyVersionId — Mandatory beats Recommended.
+        // (Same rule as the live BindingResolver from P3.4. Snapshots
+        // are pre-deduped at create time but the rule is cheap to
+        // re-apply and defends against a future migration that
+        // adds rows.)
+        var policyById = carrier.Snapshot.Policies.ToDictionary(p => p.PolicyVersionId);
+        var deduped = rows
+            .GroupBy(r => r.PolicyVersionId)
+            .Select(g => g
+                .OrderBy(r => ParseStrength(r.BindStrength))
+                .First())
+            .ToList();
+
+        var ordered = deduped
+            .Select(b =>
+            {
+                policyById.TryGetValue(b.PolicyVersionId, out var policy);
+                return new BundleResolvedBindingDto(
+                    BindingId: b.BindingId,
+                    PolicyId: policy?.PolicyId ?? Guid.Empty,
+                    PolicyName: policy?.Name ?? string.Empty,
+                    PolicyVersionId: b.PolicyVersionId,
+                    VersionNumber: policy?.Version ?? 0,
+                    Enforcement: ToEnforcementWire(policy?.Enforcement),
+                    Severity: ToSeverityWire(policy?.Severity),
+                    Scopes: policy?.Scopes ?? Array.Empty<string>(),
+                    BindStrength: ParseStrength(b.BindStrength));
+            })
+            .OrderBy(d => d.PolicyName, StringComparer.Ordinal)
+            .ThenByDescending(d => d.VersionNumber)
+            .ToList();
+
+        return new BundleResolveResult(
+            BundleId: carrier.Id,
+            BundleName: carrier.Name,
+            SnapshotHash: carrier.SnapshotHash,
+            CapturedAt: carrier.Snapshot.CapturedAt,
+            TargetType: targetType,
+            TargetRef: targetRef,
+            Bindings: ordered,
+            Count: ordered.Count);
+    }
+
+    public async Task<BundlePinnedPolicyDto?> GetPinnedPolicyAsync(
+        Guid bundleId,
+        Guid policyId,
+        CancellationToken ct = default)
+    {
+        var carrier = await LoadAsync(bundleId, ct).ConfigureAwait(false);
+        if (carrier is null)
+        {
+            return null;
+        }
+
+        var policy = carrier.Snapshot.Policies.FirstOrDefault(p => p.PolicyId == policyId);
+        if (policy is null)
+        {
+            return null;
+        }
+
+        return new BundlePinnedPolicyDto(
+            BundleId: carrier.Id,
+            BundleName: carrier.Name,
+            SnapshotHash: carrier.SnapshotHash,
+            CapturedAt: carrier.Snapshot.CapturedAt,
+            PolicyId: policy.PolicyId,
+            PolicyName: policy.Name,
+            PolicyVersionId: policy.PolicyVersionId,
+            VersionNumber: policy.Version,
+            Enforcement: ToEnforcementWire(policy.Enforcement),
+            Severity: ToSeverityWire(policy.Severity),
+            Scopes: policy.Scopes,
+            RulesJson: policy.RulesJson,
+            Summary: policy.Summary);
+    }
+
+    /// <summary>
+    /// Load the bundle row + parsed snapshot. Returns <c>null</c>
+    /// when the bundle is missing or soft-deleted. The parsed
+    /// snapshot is cached keyed by <c>(bundleId, snapshotHash)</c>
+    /// so two requests against the same bundle pay the JSON parse
+    /// cost only once within the TTL.
+    /// </summary>
+    private async Task<SnapshotCarrier?> LoadAsync(Guid bundleId, CancellationToken ct)
+    {
+        var head = await _db.Bundles
+            .AsNoTracking()
+            .Where(b => b.Id == bundleId && b.State == BundleState.Active)
+            .Select(b => new { b.Id, b.Name, b.SnapshotHash, b.SnapshotJson })
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+        if (head is null) return null;
+
+        var cacheKey = ($"bundle-snapshot::{head.Id:N}::{head.SnapshotHash}", typeof(SnapshotCarrier));
+        if (_cache.TryGetValue(cacheKey, out SnapshotCarrier? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        var snapshot = JsonSerializer.Deserialize<BundleSnapshot>(head.SnapshotJson, SnapshotJsonOptions)
+            ?? throw new InvalidOperationException(
+                $"Bundle {bundleId} has a SnapshotJson that did not deserialise into a BundleSnapshot.");
+
+        var carrier = new SnapshotCarrier(head.Id, head.Name, head.SnapshotHash, snapshot);
+        _cache.Set(cacheKey, carrier, CacheTtl);
+        return carrier;
+    }
+
+    private static BindStrength ParseStrength(string wire)
+        => Enum.TryParse<BindStrength>(wire, ignoreCase: true, out var bs)
+            ? bs
+            : BindStrength.Recommended;
+
+    private static string ToEnforcementWire(string? snapshotValue)
+    {
+        // Snapshot stores Enforcement.ToString() — i.e. "May", "Should", "Must".
+        // Wire convention from ADR 0001 §6 is the upper-case RFC 2119 token.
+        if (string.IsNullOrEmpty(snapshotValue)) return string.Empty;
+        return snapshotValue.ToUpperInvariant();
+    }
+
+    private static string ToSeverityWire(string? snapshotValue)
+    {
+        // Snapshot stores Severity.ToString() — "Info", "Moderate", "Critical".
+        // Wire convention is lowercase.
+        if (string.IsNullOrEmpty(snapshotValue)) return string.Empty;
+        return snapshotValue.ToLowerInvariant();
+    }
+
+    private sealed record SnapshotCarrier(
+        Guid Id, string Name, string SnapshotHash, BundleSnapshot Snapshot);
+}

--- a/tests/Andy.Policies.Tests.Integration/Controllers/BundlesControllerTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/BundlesControllerTests.cs
@@ -1,0 +1,319 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Controllers;
+
+/// <summary>
+/// HTTP-level integration tests for <c>GET /api/bundles/{id}/resolve</c>
+/// and <c>GET /api/bundles/{id}/policies/{policyId}</c> (P8.3, story
+/// rivoli-ai/andy-policies#83). Pins the wire contract: ETag from
+/// snapshot hash, 304 on If-None-Match, 404 on soft-delete /
+/// unknown-id, 400 on missing targetRef. The reproducibility
+/// invariant — same bundle, same answer regardless of live mutations
+/// — is the load-bearing assertion.
+/// </summary>
+public class BundlesControllerTests : IClassFixture<PoliciesApiFactory>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private readonly PoliciesApiFactory _factory;
+    private readonly HttpClient _client;
+
+    public BundlesControllerTests(PoliciesApiFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    private async Task<(Guid bundleId, string snapshotHash, Guid policyId, Guid policyVersionId)>
+        SeedActiveBundleAsync(string bundleName, string policyName, string targetRef)
+    {
+        // Reach into the factory's DI to use the real IBundleService +
+        // BundleSnapshotBuilder + AuditChain. This guarantees the bundle's
+        // SnapshotJson is shape-identical to what production callers will
+        // see, instead of a hand-built fixture that could drift.
+        using var scope = _factory.Services.CreateScope();
+        var sp = scope.ServiceProvider;
+        var db = sp.GetRequiredService<AppDbContext>();
+        var bundles = sp.GetRequiredService<IBundleService>();
+
+        var policy = new Policy
+        {
+            Id = Guid.NewGuid(),
+            Name = policyName,
+            CreatedBySubjectId = "seed",
+        };
+        var version = new PolicyVersion
+        {
+            Id = Guid.NewGuid(),
+            PolicyId = policy.Id,
+            Version = 1,
+            State = LifecycleState.Active,
+            Enforcement = EnforcementLevel.Should,
+            Severity = Severity.Moderate,
+            Scopes = new List<string>(),
+            Summary = "fixture",
+            RulesJson = "{}",
+            CreatedBySubjectId = "seed",
+            ProposerSubjectId = "seed",
+            PublishedAt = DateTimeOffset.UtcNow,
+            PublishedBySubjectId = "seed",
+        };
+        var binding = new Binding
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = version.Id,
+            TargetType = BindingTargetType.Repo,
+            TargetRef = targetRef,
+            BindStrength = BindStrength.Mandatory,
+            CreatedBySubjectId = "seed",
+        };
+        db.Policies.Add(policy);
+        db.PolicyVersions.Add(version);
+        db.Bindings.Add(binding);
+        await db.SaveChangesAsync();
+
+        var dto = await bundles.CreateAsync(
+            new CreateBundleRequest(bundleName, null, "initial"),
+            "seed",
+            CancellationToken.None);
+        return (dto.Id, dto.SnapshotHash, policy.Id, version.Id);
+    }
+
+    [Fact]
+    public async Task Resolve_HappyPath_Returns200_WithETagEqualToSnapshotHash()
+    {
+        var (bundleId, hash, _, _) = await SeedActiveBundleAsync(
+            $"snap-{Guid.NewGuid():N}".Substring(0, 16),
+            $"p-{Guid.NewGuid():N}".Substring(0, 12),
+            "repo:rivoli-ai/x");
+
+        var resp = await _client.GetAsync(
+            $"/api/bundles/{bundleId}/resolve?targetType=Repo&targetRef=repo:rivoli-ai/x");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        resp.Headers.ETag.Should().NotBeNull();
+        resp.Headers.ETag!.Tag.Should().Be(
+            $"\"{hash}\"",
+            "the strong validator must equal the snapshot hash so caches and " +
+            "If-None-Match clients can dedupe identical bundle reads");
+        resp.Headers.CacheControl?.Public.Should().BeTrue();
+        resp.Headers.CacheControl?.MaxAge.Should().Be(TimeSpan.FromDays(365));
+    }
+
+    [Fact]
+    public async Task Resolve_IfNoneMatchMatchesSnapshotHash_Returns304()
+    {
+        var (bundleId, hash, _, _) = await SeedActiveBundleAsync(
+            $"snap-{Guid.NewGuid():N}".Substring(0, 16),
+            $"p-{Guid.NewGuid():N}".Substring(0, 12),
+            "repo:rivoli-ai/x");
+
+        var req = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/api/bundles/{bundleId}/resolve?targetType=Repo&targetRef=repo:rivoli-ai/x");
+        req.Headers.Add("If-None-Match", $"\"{hash}\"");
+
+        var resp = await _client.SendAsync(req);
+
+        resp.StatusCode.Should().Be(
+            HttpStatusCode.NotModified,
+            "an If-None-Match that exactly matches the strong ETag must " +
+            "short-circuit before the body is rendered");
+    }
+
+    [Fact]
+    public async Task Resolve_IfNoneMatchMismatch_Returns200_WithFreshBody()
+    {
+        var (bundleId, _, _, _) = await SeedActiveBundleAsync(
+            $"snap-{Guid.NewGuid():N}".Substring(0, 16),
+            $"p-{Guid.NewGuid():N}".Substring(0, 12),
+            "repo:rivoli-ai/x");
+
+        var req = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/api/bundles/{bundleId}/resolve?targetType=Repo&targetRef=repo:rivoli-ai/x");
+        req.Headers.Add("If-None-Match", "\"some-other-hash\"");
+
+        var resp = await _client.SendAsync(req);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Resolve_OnUnknownBundleId_Returns404()
+    {
+        var resp = await _client.GetAsync(
+            $"/api/bundles/{Guid.NewGuid()}/resolve?targetType=Repo&targetRef=repo:any");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Resolve_OnSoftDeletedBundle_Returns404()
+    {
+        var (bundleId, _, _, _) = await SeedActiveBundleAsync(
+            $"snap-{Guid.NewGuid():N}".Substring(0, 16),
+            $"p-{Guid.NewGuid():N}".Substring(0, 12),
+            "repo:rivoli-ai/x");
+
+        // Tombstone via the service so the audit chain stays consistent.
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var bundles = scope.ServiceProvider.GetRequiredService<IBundleService>();
+            (await bundles.SoftDeleteAsync(bundleId, "op", "decommission", CancellationToken.None))
+                .Should().BeTrue();
+        }
+
+        var resp = await _client.GetAsync(
+            $"/api/bundles/{bundleId}/resolve?targetType=Repo&targetRef=repo:rivoli-ai/x");
+
+        resp.StatusCode.Should().Be(
+            HttpStatusCode.NotFound,
+            "soft-deleted bundles must be invisible to the resolution surface");
+    }
+
+    [Fact]
+    public async Task Resolve_WithEmptyTargetRef_Returns400()
+    {
+        var (bundleId, _, _, _) = await SeedActiveBundleAsync(
+            $"snap-{Guid.NewGuid():N}".Substring(0, 16),
+            $"p-{Guid.NewGuid():N}".Substring(0, 12),
+            "repo:rivoli-ai/x");
+
+        var resp = await _client.GetAsync(
+            $"/api/bundles/{bundleId}/resolve?targetType=Repo&targetRef=");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Resolve_AnswerIsStable_AcrossSubsequentCatalogMutations()
+    {
+        // The reproducibility headline: pin a bundle, change the live
+        // catalog, re-resolve against the bundle, get the same answer.
+        var bundleName = $"stable-{Guid.NewGuid():N}".Substring(0, 16);
+        var policyName = $"p-{Guid.NewGuid():N}".Substring(0, 12);
+        var (bundleId, hash, _, _) = await SeedActiveBundleAsync(
+            bundleName, policyName, "repo:rivoli-ai/stable");
+
+        var firstUrl =
+            $"/api/bundles/{bundleId}/resolve?targetType=Repo&targetRef=repo:rivoli-ai/stable";
+        var firstBody = await _client.GetStringAsync(firstUrl);
+
+        // Land a brand-new active version + a brand-new binding on the
+        // same target between the two resolves. The bundle resolve must
+        // not see either.
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var sp = scope.ServiceProvider;
+            var db = sp.GetRequiredService<AppDbContext>();
+            var newPolicy = new Policy
+            {
+                Id = Guid.NewGuid(),
+                Name = $"intruder-{Guid.NewGuid():N}".Substring(0, 16),
+                CreatedBySubjectId = "later",
+            };
+            var newVersion = new PolicyVersion
+            {
+                Id = Guid.NewGuid(),
+                PolicyId = newPolicy.Id,
+                Version = 1,
+                State = LifecycleState.Active,
+                Enforcement = EnforcementLevel.Must,
+                Severity = Severity.Critical,
+                Scopes = new List<string>(),
+                Summary = "post-bundle",
+                RulesJson = "{}",
+                CreatedBySubjectId = "later",
+                ProposerSubjectId = "later",
+                PublishedAt = DateTimeOffset.UtcNow,
+                PublishedBySubjectId = "later",
+            };
+            var newBinding = new Binding
+            {
+                Id = Guid.NewGuid(),
+                PolicyVersionId = newVersion.Id,
+                TargetType = BindingTargetType.Repo,
+                TargetRef = "repo:rivoli-ai/stable",
+                BindStrength = BindStrength.Mandatory,
+                CreatedBySubjectId = "later",
+            };
+            db.Policies.Add(newPolicy);
+            db.PolicyVersions.Add(newVersion);
+            db.Bindings.Add(newBinding);
+            await db.SaveChangesAsync();
+        }
+
+        var secondBody = await _client.GetStringAsync(firstUrl);
+
+        secondBody.Should().Be(
+            firstBody,
+            "the bundle is a frozen view; a new live binding for the same target " +
+            "must NOT appear in the bundle resolve, otherwise pinning is broken");
+
+        // Defence in depth: the SnapshotHash echoed in the payload must
+        // still equal the original hash.
+        var doc = JsonDocument.Parse(secondBody);
+        doc.RootElement.GetProperty("snapshotHash").GetString()
+            .Should().Be(hash);
+    }
+
+    [Fact]
+    public async Task GetPinnedPolicy_HappyPath_Returns200_WithETagAndBody()
+    {
+        var (bundleId, hash, policyId, policyVersionId) = await SeedActiveBundleAsync(
+            $"snap-{Guid.NewGuid():N}".Substring(0, 16),
+            $"p-{Guid.NewGuid():N}".Substring(0, 12),
+            "repo:rivoli-ai/x");
+
+        var resp = await _client.GetAsync($"/api/bundles/{bundleId}/policies/{policyId}");
+        resp.EnsureSuccessStatusCode();
+
+        resp.Headers.ETag!.Tag.Should().Be($"\"{hash}\"");
+        var dto = await resp.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        dto.GetProperty("policyId").GetGuid().Should().Be(policyId);
+        dto.GetProperty("policyVersionId").GetGuid().Should().Be(policyVersionId);
+        dto.GetProperty("snapshotHash").GetString().Should().Be(hash);
+    }
+
+    [Fact]
+    public async Task GetPinnedPolicy_OnUnknownPolicyId_Returns404()
+    {
+        var (bundleId, _, _, _) = await SeedActiveBundleAsync(
+            $"snap-{Guid.NewGuid():N}".Substring(0, 16),
+            $"p-{Guid.NewGuid():N}".Substring(0, 12),
+            "repo:rivoli-ai/x");
+
+        var resp = await _client.GetAsync(
+            $"/api/bundles/{bundleId}/policies/{Guid.NewGuid()}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetPinnedPolicy_OnUnknownBundleId_Returns404()
+    {
+        var resp = await _client.GetAsync(
+            $"/api/bundles/{Guid.NewGuid()}/policies/{Guid.NewGuid()}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Services/BundleResolverTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/BundleResolverTests.cs
@@ -1,0 +1,300 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Domain.ValueObjects;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Infrastructure.Services;
+using Andy.Policies.Shared.Auditing;
+using Andy.Policies.Tests.Unit.Fixtures;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Services;
+
+/// <summary>
+/// Unit tests for <see cref="BundleResolver"/> (P8.3, story
+/// rivoli-ai/andy-policies#83). Drives the resolver against EF Core
+/// InMemory bundles whose <c>SnapshotJson</c> is hand-built so the
+/// algorithm — exact-match filtering, dedup by PolicyVersionId, the
+/// snapshot cache identity — is pinned independently of the P8.2
+/// builder.
+/// </summary>
+public class BundleResolverTests
+{
+    private static readonly DateTimeOffset CapturedAt =
+        DateTimeOffset.Parse("2026-05-05T18:00:00Z");
+
+    private static (BundleResolver resolver, AppDbContext db, IMemoryCache cache) NewResolver()
+    {
+        var db = InMemoryDbFixture.Create();
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        return (new BundleResolver(db, cache), db, cache);
+    }
+
+    private static BundleSnapshot Snapshot(
+        IEnumerable<BundlePolicyEntry>? policies = null,
+        IEnumerable<BundleBindingEntry>? bindings = null) => new(
+            SchemaVersion: "1",
+            CapturedAt: CapturedAt,
+            AuditTailHash: new string('0', 64),
+            Policies: (policies ?? Array.Empty<BundlePolicyEntry>()).ToList(),
+            Bindings: (bindings ?? Array.Empty<BundleBindingEntry>()).ToList(),
+            Overrides: Array.Empty<BundleOverrideEntry>(),
+            Scopes: Array.Empty<BundleScopeEntry>());
+
+    private static async Task<Bundle> SeedBundleAsync(
+        AppDbContext db,
+        BundleSnapshot snapshot,
+        BundleState state = BundleState.Active,
+        string name = "snap-1")
+    {
+        var canonical = CanonicalJson.SerializeObject(snapshot);
+        var json = Encoding.UTF8.GetString(canonical);
+        var hash = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(canonical))
+            .ToLowerInvariant();
+
+        var bundle = new Bundle
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            CreatedAt = CapturedAt,
+            CreatedBySubjectId = "test",
+            SnapshotJson = json,
+            SnapshotHash = hash,
+            State = state,
+        };
+        if (state == BundleState.Deleted)
+        {
+            bundle.DeletedAt = CapturedAt;
+            bundle.DeletedBySubjectId = "op";
+        }
+        db.Bundles.Add(bundle);
+        await db.SaveChangesAsync();
+        return bundle;
+    }
+
+    private static BundlePolicyEntry Policy(
+        Guid policyVersionId, string name = "p1", int version = 1) => new(
+            PolicyId: Guid.NewGuid(),
+            Name: name,
+            PolicyVersionId: policyVersionId,
+            Version: version,
+            Enforcement: "Should",
+            Severity: "Moderate",
+            Scopes: Array.Empty<string>(),
+            RulesJson: "{}",
+            Summary: "fixture");
+
+    private static BundleBindingEntry Binding(
+        Guid policyVersionId,
+        string targetType = "Repo",
+        string targetRef = "repo:rivoli-ai/x",
+        BindStrength strength = BindStrength.Recommended) => new(
+            BindingId: Guid.NewGuid(),
+            PolicyVersionId: policyVersionId,
+            TargetType: targetType,
+            TargetRef: targetRef,
+            BindStrength: strength.ToString());
+
+    [Fact]
+    public async Task Resolve_ReturnsNull_WhenBundleDoesNotExist()
+    {
+        var (resolver, _, _) = NewResolver();
+
+        var result = await resolver.ResolveAsync(
+            Guid.NewGuid(), BindingTargetType.Repo, "repo:any", default);
+
+        result.Should().BeNull(
+            "an unknown bundle id is a 404 path; returning an empty result " +
+            "would mask consumer pinning bugs (e.g. typo'd id) as silent " +
+            "no-policy answers");
+    }
+
+    [Fact]
+    public async Task Resolve_ReturnsNull_WhenBundleIsSoftDeleted()
+    {
+        var (resolver, db, _) = NewResolver();
+        var bundle = await SeedBundleAsync(db, Snapshot(), state: BundleState.Deleted);
+
+        var result = await resolver.ResolveAsync(
+            bundle.Id, BindingTargetType.Repo, "repo:any", default);
+
+        result.Should().BeNull(
+            "soft-deleted bundles must be invisible to the resolution surface; " +
+            "the row remains for audit-chain integrity but is not addressable");
+    }
+
+    [Fact]
+    public async Task Resolve_ReturnsEmpty_WhenNoBindingsMatchTarget()
+    {
+        var (resolver, db, _) = NewResolver();
+        var pvId = Guid.NewGuid();
+        var bundle = await SeedBundleAsync(db, Snapshot(
+            policies: new[] { Policy(pvId) },
+            bindings: new[] { Binding(pvId, "Repo", "repo:other") }));
+
+        var result = await resolver.ResolveAsync(
+            bundle.Id, BindingTargetType.Repo, "repo:rivoli-ai/x", default);
+
+        result.Should().NotBeNull();
+        result!.Bindings.Should().BeEmpty();
+        result.SnapshotHash.Should().Be(bundle.SnapshotHash);
+    }
+
+    [Fact]
+    public async Task Resolve_FiltersByExactTargetTypeAndRef()
+    {
+        var (resolver, db, _) = NewResolver();
+        var pvA = Guid.NewGuid();
+        var pvB = Guid.NewGuid();
+        var bundle = await SeedBundleAsync(db, Snapshot(
+            policies: new[]
+            {
+                Policy(pvA, "policy-a"),
+                Policy(pvB, "policy-b", version: 2),
+            },
+            bindings: new[]
+            {
+                Binding(pvA, "Repo", "repo:rivoli-ai/match", BindStrength.Mandatory),
+                Binding(pvB, "Repo", "repo:rivoli-ai/other"),
+                Binding(pvA, "Template", "template:t1"),
+            }));
+
+        var result = await resolver.ResolveAsync(
+            bundle.Id, BindingTargetType.Repo, "repo:rivoli-ai/match", default);
+
+        result!.Bindings.Should().ContainSingle();
+        result.Bindings[0].PolicyVersionId.Should().Be(pvA);
+        result.Bindings[0].BindStrength.Should().Be(BindStrength.Mandatory);
+    }
+
+    [Fact]
+    public async Task Resolve_DeduplicatesByPolicyVersionId_KeepingMandatory()
+    {
+        // Belt-and-braces: P8.2 dedups at create time via the OrderBy
+        // on bindings, but a future migration that adds rows could
+        // reintroduce duplicates. The resolver guards the wire
+        // contract so consumers don't see redundant pairs.
+        var (resolver, db, _) = NewResolver();
+        var pvId = Guid.NewGuid();
+        var bundle = await SeedBundleAsync(db, Snapshot(
+            policies: new[] { Policy(pvId) },
+            bindings: new[]
+            {
+                Binding(pvId, "Repo", "repo:dup", BindStrength.Recommended),
+                Binding(pvId, "Repo", "repo:dup", BindStrength.Mandatory),
+            }));
+
+        var result = await resolver.ResolveAsync(
+            bundle.Id, BindingTargetType.Repo, "repo:dup", default);
+
+        result!.Bindings.Should().ContainSingle();
+        result.Bindings[0].BindStrength.Should().Be(
+            BindStrength.Mandatory,
+            "the strictest BindStrength wins; a Recommended row beating a " +
+            "Mandatory would loosen the consumer's posture without an audit " +
+            "event documenting the change");
+    }
+
+    [Fact]
+    public async Task Resolve_OrderingIsDeterministic_ByPolicyName()
+    {
+        var (resolver, db, _) = NewResolver();
+        var pvA = Guid.NewGuid();
+        var pvB = Guid.NewGuid();
+        var pvC = Guid.NewGuid();
+        var bundle = await SeedBundleAsync(db, Snapshot(
+            policies: new[]
+            {
+                Policy(pvA, "zzz-policy"),
+                Policy(pvB, "aaa-policy"),
+                Policy(pvC, "mmm-policy"),
+            },
+            bindings: new[]
+            {
+                Binding(pvA, "Repo", "repo:order"),
+                Binding(pvB, "Repo", "repo:order"),
+                Binding(pvC, "Repo", "repo:order"),
+            }));
+
+        var result = await resolver.ResolveAsync(
+            bundle.Id, BindingTargetType.Repo, "repo:order", default);
+
+        result!.Bindings.Select(b => b.PolicyName).Should().Equal(
+            "aaa-policy", "mmm-policy", "zzz-policy");
+    }
+
+    [Fact]
+    public async Task GetPinnedPolicy_Returns_ForKnownPolicyId()
+    {
+        var (resolver, db, _) = NewResolver();
+        var pvId = Guid.NewGuid();
+        var policyEntry = Policy(pvId, name: "pinned-policy", version: 7);
+        var bundle = await SeedBundleAsync(db, Snapshot(
+            policies: new[] { policyEntry }));
+
+        var dto = await resolver.GetPinnedPolicyAsync(bundle.Id, policyEntry.PolicyId, default);
+
+        dto.Should().NotBeNull();
+        dto!.PolicyName.Should().Be("pinned-policy");
+        dto.VersionNumber.Should().Be(7);
+        dto.SnapshotHash.Should().Be(bundle.SnapshotHash);
+    }
+
+    [Fact]
+    public async Task GetPinnedPolicy_ReturnsNull_WhenPolicyNotInBundle()
+    {
+        var (resolver, db, _) = NewResolver();
+        var bundle = await SeedBundleAsync(db, Snapshot());
+
+        var dto = await resolver.GetPinnedPolicyAsync(bundle.Id, Guid.NewGuid(), default);
+
+        dto.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetPinnedPolicy_ReturnsNull_WhenBundleSoftDeleted()
+    {
+        var (resolver, db, _) = NewResolver();
+        var pvId = Guid.NewGuid();
+        var entry = Policy(pvId);
+        var bundle = await SeedBundleAsync(
+            db,
+            Snapshot(policies: new[] { entry }),
+            state: BundleState.Deleted);
+
+        var dto = await resolver.GetPinnedPolicyAsync(bundle.Id, entry.PolicyId, default);
+
+        dto.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Resolve_SecondCall_HitsCache_AndProducesIdenticalResult()
+    {
+        // The cache identity is (bundleId, snapshotHash). Bundles are
+        // immutable post-insert, so a cache hit is by definition fresh.
+        // This test pins identical answers across two consecutive
+        // calls — a regression that caches the wrong shape would
+        // diverge on second read.
+        var (resolver, db, cache) = NewResolver();
+        var pvId = Guid.NewGuid();
+        var bundle = await SeedBundleAsync(db, Snapshot(
+            policies: new[] { Policy(pvId) },
+            bindings: new[] { Binding(pvId, "Repo", "repo:cached") }));
+
+        var first = await resolver.ResolveAsync(
+            bundle.Id, BindingTargetType.Repo, "repo:cached", default);
+        var second = await resolver.ResolveAsync(
+            bundle.Id, BindingTargetType.Repo, "repo:cached", default);
+
+        second.Should().BeEquivalentTo(first,
+            "second-call answer must match the first byte-for-byte; a cache " +
+            "hit that produced a different shape would mean the resolver is " +
+            "mutating the cached snapshot in place");
+    }
+}


### PR DESCRIPTION
## Summary

Adds the read surface consumers actually call to answer "given this target, what policies apply under this frozen bundle?" — without depending on live catalog state.

- `IBundleResolver` (Application) + DTOs: `ResolveAsync(bundleId, targetType, targetRef)` returns `BundleResolveResult` with bundle identity + snapshot coordinates + sorted bindings. `GetPinnedPolicyAsync` returns `BundlePinnedPolicyDto` for a policyId in the snapshot.
- `BundleResolver` (Infrastructure): pulls the Bundle row, deserialises `SnapshotJson` once per `(bundleId, snapshotHash)` into `IMemoryCache` with a 5-minute soft TTL. Bundles are immutable post-insert (P8.1's `SaveChanges` sweep), so a cache hit is by definition fresh — any change to the row implies a new `snapshotHash` which produces a different cache key. Soft-deleted bundles return null (404 from the controller).
- Resolution algorithm: exact-match filter on `(TargetType, TargetRef)`, dedup by `PolicyVersionId` keeping the strictest `BindStrength`, order by `PolicyName` ASC then `VersionNumber` DESC. Mirrors the live `BindingResolver` from P3.4. Override application is intentionally out of scope; ADR 0008 (P8.8) will pin the override-scope-from-JWT semantics.
- `BundlesController` (Api):
  - `GET /api/bundles/{id}/resolve?targetType=&targetRef=`
  - `GET /api/bundles/{id}/policies/{policyId}`
  
  Both `[Authorize(Policy="andy-policies:bundle:read")]` and emit `ETag: "<snapshotHash>"` + `Cache-Control: public, max-age=31536000, immutable`. `If-None-Match` matching the snapshot hash short-circuits to 304. Returns 404 on unknown / soft-deleted bundles or unknown-policy-in-bundle, 400 on empty targetRef.

Closes #83.

## Test plan

- [x] `dotnet build` clean (zero warnings under `TreatWarningsAsErrors`)
- [x] `dotnet test` — Unit 505/505 (+10 new), Integration 538/538 (+10 new), E2E 6/6
- [x] `BundleResolverTests` (10 unit): null on unknown / soft-deleted bundle, exact-match filter by targetType+targetRef, dedup by `PolicyVersionId` keeping `Mandatory`, deterministic ordering by policy name, `GetPinnedPolicy` hit + miss + soft-delete miss, cache-second-call returns identical shape
- [x] `BundlesControllerTests` (10 integration, SQLite + `WebApplicationFactory`): 200 with `ETag` equal to snapshot hash, 304 on `If-None-Match` match, 200 on mismatch, 404 on unknown / soft-deleted bundle, 400 on empty targetRef, reproducibility headline (resolve body byte-identical across an intervening live publish + binding), pinned policy hit + miss + unknown-bundle miss

🤖 Generated with [Claude Code](https://claude.com/claude-code)