### PR TITLE
Implement P8.4 — bundle-pinning gate via [RequiresBundlePin] (#84)

### DIFF
--- a/docs/openapi/andy-policies-v1.yaml
+++ b/docs/openapi/andy-policies-v1.yaml
@@ -286,6 +286,11 @@ paths:
           in: query
           schema:
             type: string
+        - name: bundleId
+          in: query
+          schema:
+            type: string
+            format: uuid
       responses:
         '200':
           description: OK
@@ -295,6 +300,12 @@ paths:
                 $ref: '#/components/schemas/ResolveBindingsResponse'
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
           content:
             application/json:
               schema:
@@ -946,6 +957,11 @@ paths:
           schema:
             type: integer
             format: int32
+        - name: bundleId
+          in: query
+          schema:
+            type: string
+            format: uuid
       responses:
         '200':
           description: OK
@@ -1005,6 +1021,11 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: bundleId
+          in: query
+          schema:
+            type: string
+            format: uuid
       responses:
         '200':
           description: OK
@@ -1029,6 +1050,11 @@ paths:
           required: true
           schema:
             type: string
+        - name: bundleId
+          in: query
+          schema:
+            type: string
+            format: uuid
       responses:
         '200':
           description: OK
@@ -1051,6 +1077,11 @@ paths:
         - name: id
           in: path
           required: true
+          schema:
+            type: string
+            format: uuid
+        - name: bundleId
+          in: query
           schema:
             type: string
             format: uuid
@@ -1086,6 +1117,11 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: bundleId
+          in: query
+          schema:
+            type: string
+            format: uuid
       responses:
         '200':
           description: OK
@@ -1114,6 +1150,11 @@ paths:
         - name: versionId
           in: path
           required: true
+          schema:
+            type: string
+            format: uuid
+        - name: bundleId
+          in: query
           schema:
             type: string
             format: uuid
@@ -1571,6 +1612,11 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: bundleId
+          in: query
+          schema:
+            type: string
+            format: uuid
       responses:
         '200':
           description: OK
@@ -1578,6 +1624,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EffectivePolicySetDto'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
         '404':
           description: Not Found
           content:

--- a/src/Andy.Policies.Api/Controllers/BindingsController.cs
+++ b/src/Andy.Policies.Api/Controllers/BindingsController.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Security.Claims;
+using Andy.Policies.Api.Filters;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Domain.Enums;
@@ -137,18 +138,48 @@ public sealed class BindingsController : ControllerBase
     /// </summary>
     [HttpGet("resolve")]
     [Authorize(Policy = "andy-policies:binding:read")]
+    [RequiresBundlePin]
     [ProducesResponseType(typeof(ResolveBindingsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ResolveBindingsResponse>> Resolve(
         [FromQuery] BindingTargetType targetType,
         [FromQuery] string targetRef,
+        [FromQuery] Guid? bundleId,
         [FromServices] IBindingResolver resolver,
+        [FromServices] IBundleResolver bundleResolver,
         CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(targetRef))
         {
             return ValidationProblem("targetRef query parameter is required.");
         }
+
+        if (bundleId is { } pinned)
+        {
+            // P8.4 (#84) — snapshot-backed dispatch. Translate the
+            // BundleResolveResult shape to the existing
+            // ResolveBindingsResponse so consumers see one wire shape
+            // regardless of pinning. Missing/deleted bundle is a 404.
+            var pinnedResult = await bundleResolver.ResolveAsync(pinned, targetType, targetRef, ct);
+            if (pinnedResult is null) return NotFound();
+
+            var dtos = pinnedResult.Bindings
+                .Select(b => new ResolvedBindingDto(
+                    BindingId: b.BindingId,
+                    PolicyId: b.PolicyId,
+                    PolicyName: b.PolicyName,
+                    PolicyVersionId: b.PolicyVersionId,
+                    VersionNumber: b.VersionNumber,
+                    VersionState: LifecycleState.Active.ToString(),
+                    Enforcement: b.Enforcement,
+                    Severity: b.Severity,
+                    Scopes: b.Scopes,
+                    BindStrength: b.BindStrength))
+                .ToList();
+            return Ok(new ResolveBindingsResponse(targetType, targetRef, dtos, dtos.Count));
+        }
+
         var response = await resolver.ResolveExactAsync(targetType, targetRef, ct);
         return Ok(response);
     }

--- a/src/Andy.Policies.Api/Controllers/PoliciesController.cs
+++ b/src/Andy.Policies.Api/Controllers/PoliciesController.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using Andy.Policies.Api.Filters;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Application.Queries;
@@ -20,14 +21,17 @@ namespace Andy.Policies.Api.Controllers;
 public class PoliciesController : ControllerBase
 {
     private readonly IPolicyService _policies;
+    private readonly IBundleBackedPolicyReader _bundleReader;
 
-    public PoliciesController(IPolicyService policies)
+    public PoliciesController(IPolicyService policies, IBundleBackedPolicyReader bundleReader)
     {
         _policies = policies;
+        _bundleReader = bundleReader;
     }
 
     [HttpGet]
     [Authorize(Policy = "andy-policies:policy:read")]
+    [RequiresBundlePin]
     public async Task<ActionResult<IReadOnlyList<PolicyDto>>> List(
         [FromQuery] string? namePrefix,
         [FromQuery] string? scope,
@@ -35,6 +39,7 @@ public class PoliciesController : ControllerBase
         [FromQuery] string? severity,
         [FromQuery] int? skip,
         [FromQuery] int? take,
+        [FromQuery] Guid? bundleId,
         CancellationToken ct)
     {
         var query = new ListPoliciesQuery(
@@ -45,33 +50,58 @@ public class PoliciesController : ControllerBase
             Skip: skip ?? 0,
             Take: take ?? 100);
 
+        if (bundleId is { } pinned)
+        {
+            var pinnedResults = await _bundleReader.ListPoliciesAsync(pinned, query, ct);
+            return pinnedResults is null ? NotFound() : Ok(pinnedResults);
+        }
         var results = await _policies.ListPoliciesAsync(query, ct);
         return Ok(results);
     }
 
     [HttpGet("{id:guid}")]
     [Authorize(Policy = "andy-policies:policy:read")]
-    public async Task<ActionResult<PolicyDto>> Get(Guid id, CancellationToken ct)
+    [RequiresBundlePin]
+    public async Task<ActionResult<PolicyDto>> Get(
+        Guid id, [FromQuery] Guid? bundleId, CancellationToken ct)
     {
+        if (bundleId is { } pinned)
+        {
+            var pinnedDto = await _bundleReader.GetPolicyAsync(pinned, id, ct);
+            return pinnedDto is null ? NotFound() : Ok(pinnedDto);
+        }
         var policy = await _policies.GetPolicyAsync(id, ct);
         return policy is null ? NotFound() : Ok(policy);
     }
 
     [HttpGet("by-name/{name}")]
     [Authorize(Policy = "andy-policies:policy:read")]
-    public async Task<ActionResult<PolicyDto>> GetByName(string name, CancellationToken ct)
+    [RequiresBundlePin]
+    public async Task<ActionResult<PolicyDto>> GetByName(
+        string name, [FromQuery] Guid? bundleId, CancellationToken ct)
     {
+        if (bundleId is { } pinned)
+        {
+            var pinnedDto = await _bundleReader.GetPolicyByNameAsync(pinned, name, ct);
+            return pinnedDto is null ? NotFound() : Ok(pinnedDto);
+        }
         var policy = await _policies.GetPolicyByNameAsync(name, ct);
         return policy is null ? NotFound() : Ok(policy);
     }
 
     [HttpGet("{id:guid}/versions")]
     [Authorize(Policy = "andy-policies:policy:read")]
+    [RequiresBundlePin]
     public async Task<ActionResult<IReadOnlyList<PolicyVersionDto>>> ListVersions(
-        Guid id, CancellationToken ct)
+        Guid id, [FromQuery] Guid? bundleId, CancellationToken ct)
     {
-        var versions = await _policies.ListVersionsAsync(id, ct);
-        return Ok(versions);
+        if (bundleId is { } pinned)
+        {
+            var versions = await _bundleReader.ListVersionsAsync(pinned, id, ct);
+            return versions is null ? NotFound() : Ok(versions);
+        }
+        var live = await _policies.ListVersionsAsync(id, ct);
+        return Ok(live);
     }
 
     /// <summary>
@@ -82,18 +112,30 @@ public class PoliciesController : ControllerBase
     /// </summary>
     [HttpGet("{id:guid}/versions/active")]
     [Authorize(Policy = "andy-policies:policy:read")]
+    [RequiresBundlePin]
     public async Task<ActionResult<PolicyVersionDto>> GetActiveVersion(
-        Guid id, CancellationToken ct)
+        Guid id, [FromQuery] Guid? bundleId, CancellationToken ct)
     {
+        if (bundleId is { } pinned)
+        {
+            var pinnedActive = await _bundleReader.GetActiveVersionAsync(pinned, id, ct);
+            return pinnedActive is null ? NotFound() : Ok(pinnedActive);
+        }
         var active = await _policies.GetActiveVersionAsync(id, ct);
         return active is null ? NotFound() : Ok(active);
     }
 
     [HttpGet("{id:guid}/versions/{versionId:guid}")]
     [Authorize(Policy = "andy-policies:policy:read")]
+    [RequiresBundlePin]
     public async Task<ActionResult<PolicyVersionDto>> GetVersion(
-        Guid id, Guid versionId, CancellationToken ct)
+        Guid id, Guid versionId, [FromQuery] Guid? bundleId, CancellationToken ct)
     {
+        if (bundleId is { } pinned)
+        {
+            var pinnedVersion = await _bundleReader.GetVersionAsync(pinned, id, versionId, ct);
+            return pinnedVersion is null ? NotFound() : Ok(pinnedVersion);
+        }
         var version = await _policies.GetVersionAsync(id, versionId, ct);
         return version is null ? NotFound() : Ok(version);
     }

--- a/src/Andy.Policies.Api/Controllers/ScopesController.cs
+++ b/src/Andy.Policies.Api/Controllers/ScopesController.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using Andy.Policies.Api.Filters;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Domain.Enums;
@@ -90,10 +91,21 @@ public sealed class ScopesController : ControllerBase
     /// </summary>
     [HttpGet("{id:guid}/effective-policies")]
     [Authorize(Policy = "andy-policies:scope:read")]
+    [RequiresBundlePin]
     [ProducesResponseType(typeof(EffectivePolicySetDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<EffectivePolicySetDto>> Effective(Guid id, CancellationToken ct)
+    public async Task<ActionResult<EffectivePolicySetDto>> Effective(
+        Guid id,
+        [FromQuery] Guid? bundleId,
+        [FromServices] IBundleResolver bundleResolver,
+        CancellationToken ct)
     {
+        if (bundleId is { } pinned)
+        {
+            var snapshotResult = await bundleResolver.ResolveEffectiveForScopeAsync(pinned, id, ct);
+            return snapshotResult is null ? NotFound() : Ok(snapshotResult);
+        }
         var result = await _resolver.ResolveForScopeAsync(id, ct);
         return Ok(result);
     }

--- a/src/Andy.Policies.Api/Filters/BundlePinningFilter.cs
+++ b/src/Andy.Policies.Api/Filters/BundlePinningFilter.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Diagnostics.Metrics;
+using Andy.Policies.Application.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Andy.Policies.Api.Filters;
+
+/// <summary>
+/// Per-action filter that enforces the bundle-pinning gate from P8.4
+/// (rivoli-ai/andy-policies#84). When the action carries
+/// <see cref="RequiresBundlePinAttribute"/> and
+/// <see cref="IPinningPolicy.IsPinningRequired"/> is <c>true</c>, the
+/// filter rejects requests that do not provide a non-empty
+/// <c>?bundleId=</c> query parameter with a 400 Problem Details
+/// response (<c>type</c> = <c>https://andy.local/problems/bundle-pin-required</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why per-action, not global middleware.</b> A blanket gate would
+/// require an exhaustive negative allowlist (health, swagger, the
+/// bundle endpoints themselves, audit, settings…) and one missing
+/// entry would brick a public route. Positive annotation keeps the
+/// gated set audit-able from the controller source.
+/// </para>
+/// <para>
+/// <b>Pass-through cases:</b>
+/// <list type="bullet">
+///   <item>Action lacks the attribute → bypass.</item>
+///   <item>Caller supplied a non-empty <c>bundleId</c> → bypass; the
+///     action body decides whether the id is valid (a missing
+///     bundle is a 404, not 400 — 400 is reserved for the
+///     missing-parameter path).</item>
+///   <item>Pinning is currently optional
+///     (<see cref="IPinningPolicy.IsPinningRequired"/> = <c>false</c>) →
+///     bypass.</item>
+/// </list>
+/// </para>
+/// </remarks>
+public sealed class BundlePinningFilter : IAsyncActionFilter, IDisposable
+{
+    /// <summary>Stable URI used for the Problem Details <c>type</c>.
+    /// Consumers can match programmatically without string-matching
+    /// the detail message.</summary>
+    public const string ProblemTypeUri = "https://andy.local/problems/bundle-pin-required";
+
+    /// <summary>OpenTelemetry meter name. Increments
+    /// <c>andy_policies_pinning_gate_decisions_total</c> with a
+    /// <c>decision</c> label on every evaluation.</summary>
+    public const string MeterName = "Andy.Policies.PinningGate";
+
+    private readonly IPinningPolicy _pinning;
+    private readonly Meter _meter;
+    private readonly Counter<long> _decisionsCounter;
+
+    public BundlePinningFilter(IPinningPolicy pinning)
+    {
+        _pinning = pinning;
+        _meter = new Meter(MeterName);
+        _decisionsCounter = _meter.CreateCounter<long>(
+            name: "andy_policies_pinning_gate_decisions_total",
+            description: "Bundle-pinning gate decisions, labelled by outcome.");
+    }
+
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        var hasAttr = context.ActionDescriptor.EndpointMetadata
+            .OfType<RequiresBundlePinAttribute>()
+            .Any();
+        if (!hasAttr)
+        {
+            await next().ConfigureAwait(false);
+            return;
+        }
+
+        var query = context.HttpContext.Request.Query;
+        var hasBundle = query.TryGetValue("bundleId", out var values)
+            && !string.IsNullOrWhiteSpace(values.ToString());
+        if (hasBundle)
+        {
+            _decisionsCounter.Add(1, new KeyValuePair<string, object?>("decision", "pass"));
+            await next().ConfigureAwait(false);
+            return;
+        }
+
+        if (!_pinning.IsPinningRequired)
+        {
+            _decisionsCounter.Add(1, new KeyValuePair<string, object?>("decision", "pass-pinning-off"));
+            await next().ConfigureAwait(false);
+            return;
+        }
+
+        _decisionsCounter.Add(1, new KeyValuePair<string, object?>("decision", "block"));
+        var problem = new ProblemDetails
+        {
+            Status = StatusCodes.Status400BadRequest,
+            Title = "Pinning required",
+            Detail = "Pinning required: pass ?bundleId=<guid>.",
+            Type = ProblemTypeUri,
+        };
+        context.Result = new ObjectResult(problem)
+        {
+            StatusCode = StatusCodes.Status400BadRequest,
+            ContentTypes = { "application/problem+json" },
+        };
+    }
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/src/Andy.Policies.Api/Filters/RequiresBundlePinAttribute.cs
+++ b/src/Andy.Policies.Api/Filters/RequiresBundlePinAttribute.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Api.Filters;
+
+/// <summary>
+/// Marker attribute applied to read endpoints that must enforce the
+/// bundle-pinning gate from P8.4 (rivoli-ai/andy-policies#84). Paired
+/// with <see cref="BundlePinningFilter"/> which inspects this metadata
+/// per-action — the gate is positive-annotation rather than blanket
+/// middleware so a missing entry can never cause a service-wide
+/// regression.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+public sealed class RequiresBundlePinAttribute : Attribute
+{
+}

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -177,6 +177,14 @@ builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBundleService, 
 // because it depends on the per-request DbContext; the cached
 // parsed-snapshot lives in the singleton IMemoryCache below.
 builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBundleResolver, Andy.Policies.Infrastructure.Services.BundleResolver>();
+// P8.4 (#84): bundle-pinning gate. PinningPolicy is the live
+// adapter over andy-settings; the BundleBackedPolicyReader projects
+// snapshot rows into PolicyDto/PolicyVersionDto for /api/policies*
+// dispatched via ?bundleId=. The gate filter is registered
+// alongside AddControllers below.
+builder.Services.AddSingleton<Andy.Policies.Application.Interfaces.IPinningPolicy, Andy.Policies.Infrastructure.Settings.PinningPolicy>();
+builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBundleBackedPolicyReader, Andy.Policies.Infrastructure.Services.BundleBackedPolicyReader>();
+builder.Services.AddSingleton<Andy.Policies.Api.Filters.BundlePinningFilter>();
 
 // P7.2 (#51): IRbacChecker delegates POST /api/check to andy-rbac.
 // AndyRbac:BaseUrl is required (no auth-bypass — same posture as
@@ -269,6 +277,13 @@ builder.Services.AddControllers(options =>
         // path remains as a second guarantee for code paths that
         // bypass the filter (e.g. background workers).
         options.Filters.Add<Andy.Policies.Api.Filters.RationaleRequiredFilter>();
+        // P8.4 (#84): bundle-pinning gate. Reads
+        // andy.policies.bundleVersionPinning and rejects requests to
+        // [RequiresBundlePin]-annotated read endpoints that omit
+        // ?bundleId= when pinning is required. Per-action attribute
+        // beats blanket middleware so a missing entry can never brick
+        // a public route.
+        options.Filters.AddService<Andy.Policies.Api.Filters.BundlePinningFilter>();
     })
     .AddJsonOptions(options =>
     {

--- a/src/Andy.Policies.Application/Interfaces/IBundleBackedPolicyReader.cs
+++ b/src/Andy.Policies.Application/Interfaces/IBundleBackedPolicyReader.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Queries;
+
+namespace Andy.Policies.Application.Interfaces;
+
+/// <summary>
+/// Snapshot-backed read shim for the P1.5 policy endpoints (P8.4,
+/// rivoli-ai/andy-policies#84). When a caller pins
+/// <c>?bundleId=&lt;guid&gt;</c> and pinning is required, the API
+/// dispatches here instead of <see cref="IPolicyService"/>; the
+/// answer comes from the bundle's frozen <c>SnapshotJson</c> rather
+/// than live tables.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Shape compatibility, not data parity.</b> The returned
+/// <see cref="PolicyDto"/> / <see cref="PolicyVersionDto"/> use the
+/// existing wire shapes so consumers don't fork their schemas, but
+/// fields that the snapshot does not carry — <c>CreatedAt</c>,
+/// <c>CreatedBySubjectId</c>, <c>ProposerSubjectId</c>,
+/// <c>VersionCount</c>, <c>ActiveVersionId</c> on
+/// <see cref="PolicyDto"/> — are filled with snapshot-derived
+/// surrogates: <c>CapturedAt</c> for timestamps, <c>"snapshot"</c>
+/// for subject ids, the active version's <c>VersionId</c> for the
+/// active link. A consumer that needs the original creator metadata
+/// must read live state.
+/// </para>
+/// <para>
+/// <b>Version history.</b> A bundle snapshot only carries the
+/// <see cref="Domain.Enums.LifecycleState.Active"/> version per
+/// policy. The bundle-backed <c>ListVersions</c> therefore returns
+/// at most one entry per policy (the pinned active), not the full
+/// historical ladder.
+/// </para>
+/// <para>
+/// <b>Filter applicability.</b> <c>ListPoliciesAsync</c> applies the
+/// same filters as <see cref="IPolicyService.ListPoliciesAsync"/>
+/// (name prefix, scope membership, enforcement, severity) against
+/// the snapshot rows. Skip / take pagination is honoured. Filters
+/// that don't apply to a snapshot (e.g. ones predicated on live
+/// state) are no-ops.
+/// </para>
+/// </remarks>
+public interface IBundleBackedPolicyReader
+{
+    /// <summary>List policies in the snapshot, optionally filtered.
+    /// Returns <c>null</c> when the bundle is missing / deleted.</summary>
+    Task<IReadOnlyList<PolicyDto>?> ListPoliciesAsync(
+        Guid bundleId, ListPoliciesQuery query, CancellationToken ct = default);
+
+    Task<PolicyDto?> GetPolicyAsync(Guid bundleId, Guid policyId, CancellationToken ct = default);
+
+    Task<PolicyDto?> GetPolicyByNameAsync(Guid bundleId, string name, CancellationToken ct = default);
+
+    Task<IReadOnlyList<PolicyVersionDto>?> ListVersionsAsync(
+        Guid bundleId, Guid policyId, CancellationToken ct = default);
+
+    Task<PolicyVersionDto?> GetVersionAsync(
+        Guid bundleId, Guid policyId, Guid versionId, CancellationToken ct = default);
+
+    Task<PolicyVersionDto?> GetActiveVersionAsync(
+        Guid bundleId, Guid policyId, CancellationToken ct = default);
+}

--- a/src/Andy.Policies.Application/Interfaces/IBundleResolver.cs
+++ b/src/Andy.Policies.Application/Interfaces/IBundleResolver.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using Andy.Policies.Application.Dtos;
 using Andy.Policies.Domain.Enums;
+using Andy.Policies.Domain.ValueObjects;
 
 namespace Andy.Policies.Application.Interfaces;
 
@@ -46,7 +48,53 @@ public interface IBundleResolver
         Guid bundleId,
         Guid policyId,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Return the parsed <see cref="BundleSnapshot"/> for the given
+    /// bundle, sharing the resolver's <c>(bundleId, snapshotHash)</c>
+    /// cache. P8.4 (#84) added this so the policy / effective-policy
+    /// snapshot-backed readers don't each re-parse the same JSON;
+    /// also yields the bundle name and hash for callers that need
+    /// to stamp envelopes with snapshot coordinates. Returns
+    /// <c>null</c> when the bundle is missing / soft-deleted.
+    /// </summary>
+    Task<BundleSnapshotView?> GetSnapshotAsync(Guid bundleId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Snapshot-backed equivalent of
+    /// <see cref="IBindingResolutionService.ResolveForScopeAsync"/>
+    /// (P8.4, #84). Walks the bundle's scope tree from the target
+    /// node up to its root and folds matching bindings with
+    /// stricter-tightens-only semantics. Returns <c>null</c> when
+    /// the bundle is missing / soft-deleted; returns an
+    /// <see cref="EffectivePolicySetDto"/> with empty
+    /// <c>Policies</c> when the bundle exists but the scope node
+    /// is absent from it.
+    /// </summary>
+    /// <remarks>
+    /// <b>Scope of dispatch.</b> This method matches only
+    /// <c>TargetType=ScopeNode</c> bindings keyed by
+    /// <c>scope:{nodeId}</c>. The bridge logic from
+    /// <c>BindingResolutionService</c> (which also matches
+    /// <c>Repo</c> / <c>Tenant</c> / <c>Org</c> / <c>Template</c>
+    /// targets against the chain's external refs) is deferred to
+    /// a follow-up; consumers using bridge-typed bindings should
+    /// keep <c>bundleVersionPinning=false</c> until then.
+    /// </remarks>
+    Task<EffectivePolicySetDto?> ResolveEffectiveForScopeAsync(
+        Guid bundleId, Guid scopeNodeId, CancellationToken ct = default);
 }
+
+/// <summary>
+/// View of a bundle row + its parsed snapshot (P8.4, #84). Carries
+/// the identity coordinates so callers projecting the snapshot into
+/// surface DTOs can stamp the bundle id, name, and hash.
+/// </summary>
+public sealed record BundleSnapshotView(
+    Guid BundleId,
+    string BundleName,
+    string SnapshotHash,
+    BundleSnapshot Snapshot);
 
 /// <summary>
 /// Envelope for <see cref="IBundleResolver.ResolveAsync"/>. Carries

--- a/src/Andy.Policies.Application/Interfaces/IPinningPolicy.cs
+++ b/src/Andy.Policies.Application/Interfaces/IPinningPolicy.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.Interfaces;
+
+/// <summary>
+/// Reads <c>andy.policies.bundleVersionPinning</c> from andy-settings
+/// (P8.4, story rivoli-ai/andy-policies#84). When <c>true</c> (the
+/// shipped default per <c>config/registration.json</c>) the gated
+/// read endpoints (<c>GET /api/policies*</c>,
+/// <c>GET /api/bindings/resolve</c>,
+/// <c>GET /api/scopes/{id}/effective-policies</c>) reject requests
+/// that omit <c>?bundleId=</c> with a 400 Problem Details response.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mirrors the <see cref="IRationalePolicy"/> + experimental-overrides
+/// gate shape from P5.4 — sync read off the live
+/// <c>ISettingsSnapshot</c>, fail-safe to the manifest default if the
+/// snapshot has not yet observed the key. Fail-closed (i.e. require
+/// pinning when in doubt) is the safer posture: returning 400 is
+/// never a correctness regression, while silently serving live state
+/// under a transient settings outage would be.
+/// </para>
+/// </remarks>
+public interface IPinningPolicy
+{
+    /// <summary>
+    /// <c>true</c> when callers must supply <c>?bundleId=</c> on
+    /// pinning-gated reads.
+    /// </summary>
+    bool IsPinningRequired { get; }
+}

--- a/src/Andy.Policies.Infrastructure/Services/BundleBackedPolicyReader.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BundleBackedPolicyReader.cs
@@ -1,0 +1,182 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Application.Queries;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Domain.ValueObjects;
+
+namespace Andy.Policies.Infrastructure.Services;
+
+/// <summary>
+/// Snapshot-backed implementation of <see cref="IBundleBackedPolicyReader"/>
+/// (P8.4, rivoli-ai/andy-policies#84). Delegates to
+/// <see cref="IBundleResolver.GetSnapshotAsync"/> for the cached
+/// parsed <see cref="BundleSnapshot"/>, then projects entries into
+/// the existing wire DTOs with snapshot-derived surrogates for
+/// fields the snapshot does not carry.
+/// </summary>
+public sealed class BundleBackedPolicyReader : IBundleBackedPolicyReader
+{
+    /// <summary>Sentinel value used for subject-id columns the
+    /// snapshot does not carry. Distinct from any real Andy Auth
+    /// subject id so consumers cannot accidentally mistake it for
+    /// an actor.</summary>
+    public const string SnapshotSubjectIdSentinel = "snapshot";
+
+    /// <summary>Hard upper bound on take, mirrors
+    /// <c>PolicyService.MaxPageSize</c>.</summary>
+    private const int MaxPageSize = 500;
+
+    private readonly IBundleResolver _resolver;
+
+    public BundleBackedPolicyReader(IBundleResolver resolver)
+    {
+        _resolver = resolver;
+    }
+
+    public async Task<IReadOnlyList<PolicyDto>?> ListPoliciesAsync(
+        Guid bundleId, ListPoliciesQuery query, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        var view = await _resolver.GetSnapshotAsync(bundleId, ct).ConfigureAwait(false);
+        if (view is null) return null;
+
+        IEnumerable<BundlePolicyEntry> rows = view.Snapshot.Policies;
+
+        if (!string.IsNullOrEmpty(query.NamePrefix))
+        {
+            rows = rows.Where(p => p.Name.StartsWith(query.NamePrefix, StringComparison.Ordinal));
+        }
+        if (!string.IsNullOrEmpty(query.Scope))
+        {
+            rows = rows.Where(p => p.Scopes.Contains(query.Scope, StringComparer.Ordinal));
+        }
+        if (!string.IsNullOrEmpty(query.Enforcement))
+        {
+            // Snapshot stores Enforcement.ToString() (e.g. "Should");
+            // query passes either case-insensitive enum name or wire
+            // form (e.g. "SHOULD"). Compare via parsed enum so both
+            // shapes work.
+            if (Enum.TryParse<EnforcementLevel>(query.Enforcement, ignoreCase: true, out var parsed))
+            {
+                rows = rows.Where(p => string.Equals(
+                    p.Enforcement, parsed.ToString(), StringComparison.Ordinal));
+            }
+            else
+            {
+                rows = Enumerable.Empty<BundlePolicyEntry>();
+            }
+        }
+        if (!string.IsNullOrEmpty(query.Severity))
+        {
+            if (Enum.TryParse<Severity>(query.Severity, ignoreCase: true, out var parsed))
+            {
+                rows = rows.Where(p => string.Equals(
+                    p.Severity, parsed.ToString(), StringComparison.Ordinal));
+            }
+            else
+            {
+                rows = Enumerable.Empty<BundlePolicyEntry>();
+            }
+        }
+
+        var skip = Math.Max(0, query.Skip);
+        var take = Math.Clamp(query.Take, 1, MaxPageSize);
+
+        // Distinct by PolicyId — the snapshot carries one Active
+        // version per policy by construction (P8.2 builder enforces
+        // it via the Active filter), but defending against a future
+        // schema change keeps the DTO contract right.
+        var distinct = rows
+            .GroupBy(p => p.PolicyId)
+            .Select(g => g.First())
+            .OrderBy(p => p.Name, StringComparer.Ordinal)
+            .Skip(skip)
+            .Take(take)
+            .ToList();
+
+        return distinct.Select(p => MapPolicy(view, p)).ToList();
+    }
+
+    public async Task<PolicyDto?> GetPolicyAsync(
+        Guid bundleId, Guid policyId, CancellationToken ct = default)
+    {
+        var view = await _resolver.GetSnapshotAsync(bundleId, ct).ConfigureAwait(false);
+        if (view is null) return null;
+        var entry = view.Snapshot.Policies.FirstOrDefault(p => p.PolicyId == policyId);
+        return entry is null ? null : MapPolicy(view, entry);
+    }
+
+    public async Task<PolicyDto?> GetPolicyByNameAsync(
+        Guid bundleId, string name, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        var view = await _resolver.GetSnapshotAsync(bundleId, ct).ConfigureAwait(false);
+        if (view is null) return null;
+        var entry = view.Snapshot.Policies.FirstOrDefault(p =>
+            string.Equals(p.Name, name, StringComparison.Ordinal));
+        return entry is null ? null : MapPolicy(view, entry);
+    }
+
+    public async Task<IReadOnlyList<PolicyVersionDto>?> ListVersionsAsync(
+        Guid bundleId, Guid policyId, CancellationToken ct = default)
+    {
+        var view = await _resolver.GetSnapshotAsync(bundleId, ct).ConfigureAwait(false);
+        if (view is null) return null;
+        var entries = view.Snapshot.Policies.Where(p => p.PolicyId == policyId).ToList();
+        // The snapshot carries only the Active version per policy, so
+        // ListVersions returns at most one row — by design. Documented
+        // on IBundleBackedPolicyReader.
+        return entries.Select(e => MapVersion(view, e)).ToList();
+    }
+
+    public async Task<PolicyVersionDto?> GetVersionAsync(
+        Guid bundleId, Guid policyId, Guid versionId, CancellationToken ct = default)
+    {
+        var view = await _resolver.GetSnapshotAsync(bundleId, ct).ConfigureAwait(false);
+        if (view is null) return null;
+        var entry = view.Snapshot.Policies.FirstOrDefault(p =>
+            p.PolicyId == policyId && p.PolicyVersionId == versionId);
+        return entry is null ? null : MapVersion(view, entry);
+    }
+
+    public async Task<PolicyVersionDto?> GetActiveVersionAsync(
+        Guid bundleId, Guid policyId, CancellationToken ct = default)
+    {
+        var view = await _resolver.GetSnapshotAsync(bundleId, ct).ConfigureAwait(false);
+        if (view is null) return null;
+        var entry = view.Snapshot.Policies.FirstOrDefault(p => p.PolicyId == policyId);
+        return entry is null ? null : MapVersion(view, entry);
+    }
+
+    private static PolicyDto MapPolicy(BundleSnapshotView view, BundlePolicyEntry entry) => new(
+        Id: entry.PolicyId,
+        Name: entry.Name,
+        Description: null,
+        CreatedAt: view.Snapshot.CapturedAt,
+        CreatedBySubjectId: SnapshotSubjectIdSentinel,
+        VersionCount: 1,
+        ActiveVersionId: entry.PolicyVersionId);
+
+    private static PolicyVersionDto MapVersion(BundleSnapshotView view, BundlePolicyEntry entry) => new(
+        Id: entry.PolicyVersionId,
+        PolicyId: entry.PolicyId,
+        Version: entry.Version,
+        State: LifecycleState.Active.ToString(),
+        Enforcement: ToEnforcementWire(entry.Enforcement),
+        Severity: ToSeverityWire(entry.Severity),
+        Scopes: entry.Scopes,
+        Summary: entry.Summary,
+        RulesJson: entry.RulesJson,
+        CreatedAt: view.Snapshot.CapturedAt,
+        CreatedBySubjectId: SnapshotSubjectIdSentinel,
+        ProposerSubjectId: SnapshotSubjectIdSentinel);
+
+    private static string ToEnforcementWire(string snapshotValue) =>
+        string.IsNullOrEmpty(snapshotValue) ? string.Empty : snapshotValue.ToUpperInvariant();
+
+    private static string ToSeverityWire(string snapshotValue) =>
+        string.IsNullOrEmpty(snapshotValue) ? string.Empty : snapshotValue.ToLowerInvariant();
+}

--- a/src/Andy.Policies.Infrastructure/Services/BundleResolver.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BundleResolver.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Domain.Enums;
 using Andy.Policies.Domain.ValueObjects;
@@ -118,6 +119,127 @@ public sealed class BundleResolver : IBundleResolver
             Bindings: ordered,
             Count: ordered.Count);
     }
+
+    public async Task<BundleSnapshotView?> GetSnapshotAsync(
+        Guid bundleId, CancellationToken ct = default)
+    {
+        var carrier = await LoadAsync(bundleId, ct).ConfigureAwait(false);
+        return carrier is null
+            ? null
+            : new BundleSnapshotView(carrier.Id, carrier.Name, carrier.SnapshotHash, carrier.Snapshot);
+    }
+
+    public async Task<EffectivePolicySetDto?> ResolveEffectiveForScopeAsync(
+        Guid bundleId, Guid scopeNodeId, CancellationToken ct = default)
+    {
+        var carrier = await LoadAsync(bundleId, ct).ConfigureAwait(false);
+        if (carrier is null) return null;
+
+        // Walk the scope chain via ParentId from the snapshot. The
+        // snapshot doesn't carry materialised paths, so we hand-walk;
+        // depth defaults to chain index (0 at the root).
+        var scopeById = carrier.Snapshot.Scopes.ToDictionary(s => s.ScopeNodeId);
+        if (!scopeById.ContainsKey(scopeNodeId))
+        {
+            // Bundle exists but the scope node is not in the snapshot.
+            // Mirror the live empty-set semantics rather than 404 — the
+            // caller addressed a real bundle, just at a node that
+            // doesn't appear there.
+            return new EffectivePolicySetDto(
+                ScopeNodeId: scopeNodeId,
+                Policies: Array.Empty<EffectivePolicyDto>());
+        }
+
+        var chain = WalkAncestorChain(scopeById, scopeNodeId);
+        var policiesByVersionId = carrier.Snapshot.Policies.ToDictionary(p => p.PolicyVersionId);
+
+        // Match bindings that target ScopeNode and reference a chain
+        // node via "scope:{nodeId}". Each candidate is tagged with its
+        // node's depth (its position in the root→leaf chain) so the
+        // tighten-only fold can prefer deeper Mandatory rows.
+        var depthByNodeId = chain
+            .Select((n, idx) => (n.ScopeNodeId, Depth: idx))
+            .ToDictionary(p => p.ScopeNodeId, p => p.Depth);
+        var candidates = new List<EffectiveCandidate>();
+        foreach (var b in carrier.Snapshot.Bindings)
+        {
+            if (!string.Equals(b.TargetType, BindingTargetType.ScopeNode.ToString(), StringComparison.Ordinal))
+            {
+                continue;
+            }
+            if (!b.TargetRef.StartsWith("scope:", StringComparison.Ordinal)
+                || !Guid.TryParse(b.TargetRef.AsSpan("scope:".Length), out var nodeId))
+            {
+                continue;
+            }
+            if (!depthByNodeId.TryGetValue(nodeId, out var depth)) continue;
+            if (!policiesByVersionId.TryGetValue(b.PolicyVersionId, out var policy)) continue;
+            var node = scopeById[nodeId];
+            candidates.Add(new EffectiveCandidate(
+                b, policy, depth, nodeId, ParseScopeType(node.Type)));
+        }
+
+        var folded = candidates
+            .GroupBy(c => c.Policy.PolicyId)
+            .Select(group =>
+            {
+                var mandatory = group
+                    .Where(c => ParseStrength(c.Binding.BindStrength) == BindStrength.Mandatory)
+                    .ToList();
+                var winner = (mandatory.Count > 0 ? mandatory : group.ToList())
+                    .OrderByDescending(c => c.Depth)
+                    .First();
+                return new EffectivePolicyDto(
+                    PolicyId: winner.Policy.PolicyId,
+                    PolicyVersionId: winner.Policy.PolicyVersionId,
+                    PolicyKey: winner.Policy.Name,
+                    Version: winner.Policy.Version,
+                    BindStrength: ParseStrength(winner.Binding.BindStrength),
+                    SourceBindingId: winner.Binding.BindingId,
+                    SourceScopeNodeId: winner.ScopeNodeId,
+                    SourceScopeType: winner.ScopeType,
+                    SourceDepth: winner.Depth);
+            })
+            .OrderBy(p => p.BindStrength)
+            .ThenBy(p => p.PolicyKey, StringComparer.Ordinal)
+            .ToList();
+
+        return new EffectivePolicySetDto(scopeNodeId, folded);
+    }
+
+    /// <summary>Root-to-leaf chain of scope nodes. The leaf is at the
+    /// end of the list; depth increases with index. Stops at the
+    /// first ancestor that is not in <paramref name="scopeById"/> —
+    /// snapshots can be partial (the builder includes every node the
+    /// catalog had at capture time, but a corrupted snapshot or a
+    /// future schema-tightening could drop ancestors).</summary>
+    private static List<BundleScopeEntry> WalkAncestorChain(
+        IReadOnlyDictionary<Guid, BundleScopeEntry> scopeById, Guid leafId)
+    {
+        var visited = new HashSet<Guid>();
+        var leafToRoot = new List<BundleScopeEntry>();
+        var cursor = scopeById[leafId];
+        while (true)
+        {
+            if (!visited.Add(cursor.ScopeNodeId)) break; // defensive: cycle
+            leafToRoot.Add(cursor);
+            if (cursor.ParentId is null) break;
+            if (!scopeById.TryGetValue(cursor.ParentId.Value, out var parent)) break;
+            cursor = parent;
+        }
+        leafToRoot.Reverse();
+        return leafToRoot;
+    }
+
+    private static ScopeType ParseScopeType(string wire)
+        => Enum.TryParse<ScopeType>(wire, ignoreCase: true, out var st) ? st : default;
+
+    private sealed record EffectiveCandidate(
+        BundleBindingEntry Binding,
+        BundlePolicyEntry Policy,
+        int Depth,
+        Guid ScopeNodeId,
+        ScopeType ScopeType);
 
     public async Task<BundlePinnedPolicyDto?> GetPinnedPolicyAsync(
         Guid bundleId,

--- a/src/Andy.Policies.Infrastructure/Settings/PinningPolicy.cs
+++ b/src/Andy.Policies.Infrastructure/Settings/PinningPolicy.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Diagnostics.Metrics;
+using Andy.Policies.Application.Interfaces;
+using Andy.Settings.Client;
+
+namespace Andy.Policies.Infrastructure.Settings;
+
+/// <summary>
+/// Live <see cref="IPinningPolicy"/> backed by andy-settings (P8.4,
+/// story rivoli-ai/andy-policies#84). Mirrors
+/// <see cref="ExperimentalOverridesGate"/> + the rationale-policy
+/// shape: read fresh from <see cref="ISettingsSnapshot"/> on every
+/// check, with an OTel gauge so operators can confirm the toggle
+/// reached the live process.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Fail-safe default.</b> The shipped default in
+/// <c>config/registration.json</c> is <c>true</c>; the snapshot
+/// returns <c>null</c> until andy-settings has observed the key.
+/// We coalesce to the manifest default — never relax pinning under
+/// a transient settings outage.
+/// </para>
+/// <para>
+/// <b>Hot reload.</b> The snapshot is refreshed by the package's
+/// hosted refresh service on the configured cadence. A flip in the
+/// andy-settings admin UI takes effect on the next read after the
+/// next refresh, without an andy-policies restart.
+/// </para>
+/// </remarks>
+public sealed class PinningPolicy : IPinningPolicy, IDisposable
+{
+    /// <summary>The andy-settings key, registered in
+    /// <c>config/registration.json</c> with default <c>"true"</c>.</summary>
+    public const string SettingKey = "andy.policies.bundleVersionPinning";
+
+    /// <summary>Manifest default applied when the snapshot has no
+    /// observation for the key. The catalog's reproducibility
+    /// posture means missing → required.</summary>
+    public const bool ManifestDefault = true;
+
+    /// <summary>OpenTelemetry meter name. Matches the convention used
+    /// by sibling settings adapters so a single pipeline registration
+    /// surfaces every toggle gauge.</summary>
+    public const string MeterName = "Andy.Policies.PinningPolicy";
+
+    private readonly ISettingsSnapshot _snapshot;
+    private readonly Meter _meter;
+
+    public PinningPolicy(ISettingsSnapshot snapshot)
+    {
+        _snapshot = snapshot;
+        _meter = new Meter(MeterName);
+        _meter.CreateObservableGauge(
+            name: "andy_policies_bundle_version_pinning_required",
+            observeValue: () => IsPinningRequired ? 1 : 0,
+            description: "Current value of andy.policies.bundleVersionPinning (1 = required, 0 = optional).");
+    }
+
+    public bool IsPinningRequired => _snapshot.GetBool(SettingKey) ?? ManifestDefault;
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/tests/Andy.Policies.Tests.Integration/Api/BundlePinningGateTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Api/BundlePinningGateTests.cs
@@ -1,0 +1,226 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Andy.Policies.Api.Filters;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Tests.Integration.Controllers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Api;
+
+/// <summary>
+/// End-to-end tests for the bundle-pinning gate (P8.4, story
+/// rivoli-ai/andy-policies#84). Pins the seven scenarios from the
+/// spec: 400 + Problem-Details on missing bundleId / pinning-on,
+/// 200 with snapshot-backed payload on bundleId / pinning-on, 200
+/// from live state on missing bundleId / pinning-off, the gate
+/// applies to the bindings and scopes read endpoints, the gate
+/// does NOT apply to non-annotated endpoints (audit), and an
+/// unknown bundleId returns 404 (the 400 path is reserved for the
+/// missing-parameter case).
+/// </summary>
+public class BundlePinningGateTests : IClassFixture<PoliciesApiFactory>
+{
+    private readonly PoliciesApiFactory _baseFactory;
+
+    public BundlePinningGateTests(PoliciesApiFactory factory)
+    {
+        _baseFactory = factory;
+    }
+
+    /// <summary>
+    /// The base factory stubs <see cref="IPinningPolicy"/> with
+    /// pinning OFF so the wider integration suite stays focused on
+    /// non-gate behaviour. <see cref="WithPinning"/> overrides the
+    /// stub per-test to flip the gate.
+    /// </summary>
+    private WebApplicationFactory<Program> WithPinning(bool required) =>
+        _baseFactory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var existing = services
+                    .Where(d => d.ServiceType == typeof(IPinningPolicy))
+                    .ToList();
+                foreach (var d in existing) services.Remove(d);
+                services.AddSingleton<IPinningPolicy>(
+                    new PoliciesApiFactory.StaticPinningPolicy(required));
+            });
+        });
+
+    private async Task<(Guid bundleId, Guid policyId)> SeedBundleAsync(WebApplicationFactory<Program> factory)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var bundles = scope.ServiceProvider.GetRequiredService<IBundleService>();
+
+        var policy = new Policy
+        {
+            Id = Guid.NewGuid(),
+            Name = $"p-{Guid.NewGuid():N}".Substring(0, 14),
+            CreatedBySubjectId = "seed",
+        };
+        var version = new PolicyVersion
+        {
+            Id = Guid.NewGuid(),
+            PolicyId = policy.Id,
+            Version = 1,
+            State = LifecycleState.Active,
+            Enforcement = EnforcementLevel.Should,
+            Severity = Severity.Moderate,
+            Scopes = new List<string>(),
+            Summary = "fixture",
+            RulesJson = "{}",
+            CreatedBySubjectId = "seed",
+            ProposerSubjectId = "seed",
+            PublishedAt = DateTimeOffset.UtcNow,
+            PublishedBySubjectId = "seed",
+        };
+        db.Policies.Add(policy);
+        db.PolicyVersions.Add(version);
+        await db.SaveChangesAsync();
+
+        var dto = await bundles.CreateAsync(
+            new CreateBundleRequest($"snap-{Guid.NewGuid():N}".Substring(0, 16), null, "initial"),
+            "seed",
+            CancellationToken.None);
+        return (dto.Id, policy.Id);
+    }
+
+    [Fact]
+    public async Task ListPolicies_PinningOn_NoBundleId_Returns400_WithProblemTypeUri()
+    {
+        var factory = WithPinning(required: true);
+        using var client = factory.CreateClient();
+
+        var resp = await client.GetAsync("/api/policies");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("type").GetString()
+            .Should().Be(BundlePinningFilter.ProblemTypeUri);
+        doc.RootElement.GetProperty("detail").GetString()
+            .Should().Contain("Pinning required: pass ?bundleId=");
+    }
+
+    [Fact]
+    public async Task ListPolicies_PinningOn_BundleIdProvided_Returns200_WithSnapshotPayload()
+    {
+        var factory = WithPinning(required: true);
+        using var client = factory.CreateClient();
+        var (bundleId, policyId) = await SeedBundleAsync(factory);
+
+        var resp = await client.GetAsync($"/api/policies?bundleId={bundleId}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        // The factory is shared across the class fixture, so the
+        // snapshot can include policies seeded by sibling gate tests.
+        // Assert the just-seeded id appears, not that it's the only
+        // entry — that's the dispatch-against-snapshot guarantee.
+        var ids = doc.RootElement.EnumerateArray()
+            .Select(e => e.GetProperty("id").GetGuid())
+            .ToList();
+        ids.Should().Contain(
+            policyId,
+            "the snapshot carries the seeded policy and the dispatch must " +
+            "return it instead of going to live state");
+    }
+
+    [Fact]
+    public async Task ListPolicies_PinningOff_NoBundleId_Returns200_WithLivePayload()
+    {
+        var factory = WithPinning(required: false);
+        using var client = factory.CreateClient();
+        // The legacy live path is what /api/policies returns when
+        // pinning is off — even with no bundleId. An empty catalog
+        // is still a valid response (200 [] not 400).
+
+        var resp = await client.GetAsync("/api/policies");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task GetPolicy_PinningOn_UnknownBundleId_Returns404_NotBadRequest()
+    {
+        var factory = WithPinning(required: true);
+        using var client = factory.CreateClient();
+
+        var resp = await client.GetAsync($"/api/policies/{Guid.NewGuid()}?bundleId={Guid.NewGuid()}");
+
+        resp.StatusCode.Should().Be(
+            HttpStatusCode.NotFound,
+            "an unknown bundleId is a 404 path; 400 is reserved for the " +
+            "missing-parameter case so a consumer can tell pinning-violation " +
+            "from typo'd-id");
+    }
+
+    [Fact]
+    public async Task BindingsResolve_PinningOn_NoBundleId_Returns400()
+    {
+        var factory = WithPinning(required: true);
+        using var client = factory.CreateClient();
+
+        var resp = await client.GetAsync("/api/bindings/resolve?targetType=Repo&targetRef=repo:any");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("type").GetString()
+            .Should().Be(BundlePinningFilter.ProblemTypeUri);
+    }
+
+    [Fact]
+    public async Task ScopesEffective_PinningOn_NoBundleId_Returns400()
+    {
+        var factory = WithPinning(required: true);
+        using var client = factory.CreateClient();
+
+        var resp = await client.GetAsync($"/api/scopes/{Guid.NewGuid()}/effective-policies");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task AuditList_IsNotGated_ByPinning()
+    {
+        var factory = WithPinning(required: true);
+        using var client = factory.CreateClient();
+
+        var resp = await client.GetAsync("/api/audit");
+
+        resp.StatusCode.Should().NotBe(
+            HttpStatusCode.BadRequest,
+            "the gate is per-action via [RequiresBundlePin]; audit endpoints " +
+            "must not be over-applied or admin tooling that runs on a service " +
+            "token without a bundle pin would lose access to the audit chain");
+    }
+
+    [Fact]
+    public async Task BundlesController_IsNotGated_ByPinning()
+    {
+        // Negative test: the bundle endpoints themselves must not be
+        // gated, otherwise consumers couldn't bootstrap a pin (chicken
+        // and egg).
+        var factory = WithPinning(required: true);
+        using var client = factory.CreateClient();
+        var (bundleId, _) = await SeedBundleAsync(factory);
+
+        var resp = await client.GetAsync(
+            $"/api/bundles/{bundleId}/resolve?targetType=Repo&targetRef=repo:any");
+
+        resp.StatusCode.Should().NotBe(HttpStatusCode.BadRequest);
+    }
+
+}

--- a/tests/Andy.Policies.Tests.Integration/Controllers/PoliciesApiFactory.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/PoliciesApiFactory.cs
@@ -96,6 +96,21 @@ public sealed class PoliciesApiFactory : WebApplicationFactory<Program>
             foreach (var d in rbacDescriptors) services.Remove(d);
             services.AddSingleton<IRbacChecker>(new AllowAllStubRbacChecker());
 
+            // P8.4 (#84): the bundle-pinning gate defaults to `true` per
+            // the manifest. The bulk of pre-P8.4 integration tests
+            // exercise the live read paths (no `?bundleId=`); flipping
+            // pinning ON inside the factory would 400 every one of
+            // them. Stub IPinningPolicy with pinning OFF so the legacy
+            // tests stay focused on what they were testing. The gate
+            // itself gets exercised by BundlePinningGateTests via its
+            // own factory variant that pins ON.
+            var pinDescriptors = services
+                .Where(d => d.ServiceType == typeof(Andy.Policies.Application.Interfaces.IPinningPolicy))
+                .ToList();
+            foreach (var d in pinDescriptors) services.Remove(d);
+            services.AddSingleton<Andy.Policies.Application.Interfaces.IPinningPolicy>(
+                new StaticPinningPolicy(required: false));
+
             // Build the schema once on the shared connection.
             using var sp = services.BuildServiceProvider();
             using var scope = sp.CreateScope();
@@ -119,5 +134,16 @@ public sealed class PoliciesApiFactory : WebApplicationFactory<Program>
             string? resourceInstanceId,
             CancellationToken ct)
             => Task.FromResult(new RbacDecision(true, "test-allow"));
+    }
+
+    /// <summary>
+    /// Static <see cref="Andy.Policies.Application.Interfaces.IPinningPolicy"/> for tests
+    /// that don't exercise the gate themselves; <see cref="BundlePinningGateTests"/> uses
+    /// its own factory variant for tests that flip the value.
+    /// </summary>
+    internal sealed class StaticPinningPolicy : Andy.Policies.Application.Interfaces.IPinningPolicy
+    {
+        public StaticPinningPolicy(bool required) => IsPinningRequired = required;
+        public bool IsPinningRequired { get; }
     }
 }

--- a/tests/Andy.Policies.Tests.Integration/Filters/BundlePinningFilterTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Filters/BundlePinningFilterTests.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Api.Filters;
+using Andy.Policies.Application.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Filters;
+
+/// <summary>
+/// Unit tests for <see cref="BundlePinningFilter"/> (P8.4, story
+/// rivoli-ai/andy-policies#84). Drives the filter against
+/// hand-built <see cref="ActionExecutingContext"/> fixtures so the
+/// gate logic is locked down independently of the HTTP / DI pipeline.
+/// Pinning is applied per-action via
+/// <see cref="RequiresBundlePinAttribute"/>; the filter must:
+/// <list type="bullet">
+///   <item>Pass through when the attribute is absent.</item>
+///   <item>Pass through when <c>?bundleId=</c> is non-empty,
+///     irrespective of pinning state.</item>
+///   <item>Pass through when pinning is off.</item>
+///   <item>Block with a 400 Problem Details when pinning is on
+///     and <c>bundleId</c> is missing or empty.</item>
+/// </list>
+/// </summary>
+public class BundlePinningFilterTests
+{
+    private sealed class StubPinning : IPinningPolicy
+    {
+        public StubPinning(bool required) => IsPinningRequired = required;
+        public bool IsPinningRequired { get; }
+    }
+
+    private static ActionExecutingContext NewContext(
+        bool hasAttr,
+        IDictionary<string, Microsoft.Extensions.Primitives.StringValues>? query = null)
+    {
+        var http = new DefaultHttpContext();
+        if (query is not null)
+        {
+            http.Request.QueryString = new QueryString(
+                "?" + string.Join("&", query.Select(kv => $"{kv.Key}={kv.Value}")));
+        }
+        var actionDescriptor = new ActionDescriptor
+        {
+            EndpointMetadata = hasAttr
+                ? new List<object> { new RequiresBundlePinAttribute() }
+                : new List<object>(),
+        };
+        var routeData = new RouteData();
+        var actionContext = new Microsoft.AspNetCore.Mvc.ActionContext(http, routeData, actionDescriptor);
+        return new ActionExecutingContext(
+            actionContext,
+            filters: new List<IFilterMetadata>(),
+            actionArguments: new Dictionary<string, object?>(),
+            controller: new object());
+    }
+
+    private static Task<ActionExecutedContext> NoOpNext(ActionExecutingContext ctx) =>
+        Task.FromResult(new ActionExecutedContext(ctx, new List<IFilterMetadata>(), ctx.Controller));
+
+    [Fact]
+    public async Task AttributeAbsent_PassesThrough_NoMatterPinningState()
+    {
+        var filter = new BundlePinningFilter(new StubPinning(required: true));
+        var ctx = NewContext(hasAttr: false);
+        var nextCalled = false;
+
+        await filter.OnActionExecutionAsync(ctx, () =>
+        {
+            nextCalled = true;
+            return NoOpNext(ctx);
+        });
+
+        nextCalled.Should().BeTrue();
+        ctx.Result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AttributePresent_BundleIdProvided_PassesThrough()
+    {
+        var filter = new BundlePinningFilter(new StubPinning(required: true));
+        var ctx = NewContext(hasAttr: true,
+            query: new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+            {
+                ["bundleId"] = Guid.NewGuid().ToString(),
+            });
+        var nextCalled = false;
+
+        await filter.OnActionExecutionAsync(ctx, () =>
+        {
+            nextCalled = true;
+            return NoOpNext(ctx);
+        });
+
+        nextCalled.Should().BeTrue(
+            "a non-empty bundleId is the consumer pinning what they want; the gate " +
+            "doesn't care whether the id resolves — that's the action body's job");
+    }
+
+    [Fact]
+    public async Task AttributePresent_BundleIdMissing_PinningOn_Returns400ProblemDetails()
+    {
+        var filter = new BundlePinningFilter(new StubPinning(required: true));
+        var ctx = NewContext(hasAttr: true);
+        var nextCalled = false;
+
+        await filter.OnActionExecutionAsync(ctx, () =>
+        {
+            nextCalled = true;
+            return NoOpNext(ctx);
+        });
+
+        nextCalled.Should().BeFalse("the gate must short-circuit before the action body runs");
+        var result = ctx.Result.Should().BeOfType<ObjectResult>().Subject;
+        result.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        var problem = result.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problem.Type.Should().Be(BundlePinningFilter.ProblemTypeUri);
+        problem.Detail.Should().Contain("Pinning required: pass ?bundleId=");
+    }
+
+    [Fact]
+    public async Task AttributePresent_BundleIdMissing_PinningOff_PassesThrough()
+    {
+        var filter = new BundlePinningFilter(new StubPinning(required: false));
+        var ctx = NewContext(hasAttr: true);
+        var nextCalled = false;
+
+        await filter.OnActionExecutionAsync(ctx, () =>
+        {
+            nextCalled = true;
+            return NoOpNext(ctx);
+        });
+
+        nextCalled.Should().BeTrue(
+            "with pinning off, missing bundleId falls through to the live read path");
+    }
+
+    [Fact]
+    public async Task AttributePresent_BundleIdEmpty_PinningOn_Returns400()
+    {
+        // ?bundleId= with no value (empty string) must be treated as
+        // missing — otherwise a consumer could trivially bypass the
+        // gate by appending the param without a value.
+        var filter = new BundlePinningFilter(new StubPinning(required: true));
+        var ctx = NewContext(hasAttr: true,
+            query: new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+            {
+                ["bundleId"] = "",
+            });
+
+        await filter.OnActionExecutionAsync(ctx, () => NoOpNext(ctx));
+
+        var result = ctx.Result.Should().BeOfType<ObjectResult>().Subject;
+        result.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Fixtures/RbacTestApplicationFactory.cs
+++ b/tests/Andy.Policies.Tests.Integration/Fixtures/RbacTestApplicationFactory.cs
@@ -69,6 +69,17 @@ public sealed class RbacTestApplicationFactory : WebApplicationFactory<Program>
                     .Build();
             });
 
+            // P8.4 (#84): same stub posture as PoliciesApiFactory —
+            // legacy P7.5 RBAC tests don't pass `?bundleId=` and
+            // shouldn't be 400'd by the gate. The pinning gate has
+            // its own dedicated tests.
+            var pinDescriptors = services
+                .Where(d => d.ServiceType == typeof(Andy.Policies.Application.Interfaces.IPinningPolicy))
+                .ToList();
+            foreach (var d in pinDescriptors) services.Remove(d);
+            services.AddSingleton<Andy.Policies.Application.Interfaces.IPinningPolicy>(
+                new PoliciesApiFactory.StaticPinningPolicy(required: false));
+
             using var sp = services.BuildServiceProvider();
             using var scope = sp.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();

--- a/tests/Andy.Policies.Tests.Unit/Settings/PinningPolicyTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Settings/PinningPolicyTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Infrastructure.Settings;
+using Andy.Settings.Client;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Settings;
+
+/// <summary>
+/// Unit tests for <see cref="PinningPolicy"/> (P8.4, story
+/// rivoli-ai/andy-policies#84). Drives the adapter against an
+/// in-memory <see cref="ISettingsSnapshot"/> stub to pin: a true
+/// reading flips the gate on, a false reading flips it off, a
+/// missing reading falls back to the manifest default (true), and
+/// a snapshot that throws is treated as missing (fail-safe).
+/// </summary>
+public class PinningPolicyTests
+{
+    private sealed class StubSnapshot : ISettingsSnapshot
+    {
+        public bool? StoredBool { get; set; }
+        public bool? GetBool(string key) =>
+            key == PinningPolicy.SettingKey ? StoredBool : null;
+        public string? GetString(string key) => null;
+        public int? GetInt(string key) => null;
+        public IReadOnlyCollection<string> Keys => Array.Empty<string>();
+        public DateTimeOffset? LastRefreshedAt => null;
+    }
+
+    [Fact]
+    public void IsPinningRequired_SettingTrue_ReturnsTrue()
+    {
+        var policy = new PinningPolicy(new StubSnapshot { StoredBool = true });
+        policy.IsPinningRequired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsPinningRequired_SettingFalse_ReturnsFalse()
+    {
+        var policy = new PinningPolicy(new StubSnapshot { StoredBool = false });
+        policy.IsPinningRequired.Should().BeFalse(
+            "an explicit false flips pinning off — used by dev environments");
+    }
+
+    [Fact]
+    public void IsPinningRequired_SettingMissing_ReturnsManifestDefaultTrue()
+    {
+        var policy = new PinningPolicy(new StubSnapshot { StoredBool = null });
+        policy.IsPinningRequired.Should().Be(
+            PinningPolicy.ManifestDefault,
+            "a snapshot that has not yet observed the key must NOT silently " +
+            "relax pinning — fail-safe to the manifest default");
+    }
+
+    [Fact]
+    public void ManifestDefault_IsTrue_MatchingRegistrationJson()
+    {
+        // Sanity check: if someone flips the manifest default, this
+        // test forces a deliberate update here so the contract
+        // between adapter and manifest stays explicit.
+        PinningPolicy.ManifestDefault.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SettingKey_MatchesRegistrationManifestKey()
+    {
+        PinningPolicy.SettingKey.Should().Be("andy.policies.bundleVersionPinning");
+    }
+}


### PR DESCRIPTION
## Summary

When `andy.policies.bundleVersionPinning=true` (the manifest default), the gated read endpoints reject requests that omit `?bundleId=` with a 400 Problem Details (`type=https://andy.local/problems/bundle-pin-required`). When the setting is false, the same endpoints fall through to live state. Either way, a non-empty `bundleId` dispatches to the snapshot-backed reader/resolver.

- `IPinningPolicy` + `PinningPolicy`: live adapter over `ISettingsSnapshot`, fail-safe to manifest default `true` when missing. Mirrors the rationale-policy + experimental-overrides shape from P5.4.
- `RequiresBundlePinAttribute` + `BundlePinningFilter`: per-action positive-annotation gate (per-action beats blanket middleware — a missing entry can never brick a public route). Increments `andy_policies_pinning_gate_decisions_total{decision=pass|block}` on every evaluation.
- `IBundleBackedPolicyReader` + impl: snapshot-backed read shim for the P1.5 endpoints. Projects `BundlePolicyEntry` into `PolicyDto`/`PolicyVersionDto` with snapshot-derived surrogates (CapturedAt for timestamps, `"snapshot"` sentinel for subject-id columns) for fields the snapshot does not carry.
- `IBundleResolver` gains `GetSnapshotAsync` and `ResolveEffectiveForScopeAsync` — snapshot-backed equivalent of `BindingResolutionService.ResolveForScopeAsync` walking the chain via `ParentId` and applying tighten-only fold over ScopeNode-typed bindings. Bridge logic for `Repo`/`Tenant` targets is deferred per the comment on the method.
- Controllers wired:
  - **`PoliciesController`** — 5 read actions get `[RequiresBundlePin]` + `[FromQuery] Guid? bundleId`; bundleId present → `IBundleBackedPolicyReader`.
  - **`BindingsController.Resolve`** — same; bundleId present → existing `IBundleResolver`, translated into the `ResolveBindingsResponse` shape so callers see a stable wire format.
  - **`ScopesController.Effective`** — same; bundleId present → `IBundleResolver.ResolveEffectiveForScopeAsync`.
- Test factories (`PoliciesApiFactory` + `RbacTestApplicationFactory`) stub `IPinningPolicy` with `required=false` so the legacy integration tests stay focused on the live path. The gate has its own dedicated tests.

OpenAPI regenerated for the new `bundleId` query parameters + `ProblemDetails` responses.

Closes #84.

## Test plan

- [x] `dotnet build` clean (zero warnings under `TreatWarningsAsErrors`)
- [x] `dotnet test` — Unit 510/510 (+5 new), Integration 551/551 (+13 new), E2E 6/6
- [x] `PinningPolicyTests` (5 unit): true / false / missing → manifest default; manifest default sentinel; setting key matches the manifest entry
- [x] `BundlePinningFilterTests` (5): attribute absent → pass-through; bundleId provided → pass-through; bundleId missing + pinning on → 400 ProblemDetails with the type URI; bundleId missing + pinning off → pass-through; empty bundleId treated as missing (cannot bypass the gate with `?bundleId=`)
- [x] `BundlePinningGateTests` (8 end-to-end HTTP): list policies pinning-on / no bundle → 400 (with `type` URI in body); pinning-on / bundle → 200 with snapshot payload; pinning-off / no bundle → 200 with live payload; pinning-on / unknown bundle → 404 (not 400, distinguishes pinning violation from typo'd id); `/api/bindings/resolve` and `/api/scopes/{id}/effective-policies` are gated; `/api/audit` and `/api/bundles/*` are NOT gated (negative tests)

## Notes

- Bridge bindings (Repo / Tenant / Org / Template targets matched against the chain's external refs) on the `/scopes/{id}/effective-policies` snapshot dispatch are deferred to a follow-up; only ScopeNode-typed bindings are resolved against the snapshot today. Production deployments using bridge bindings should keep `bundleVersionPinning=false` until then.
- OpenAPI was regenerated per the saved memory rule on REST endpoint changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)