### PR TITLE
Implement P8.6 — gRPC BundleService + CLI bundles subcommands with diff (#86)

### DIFF
--- a/docs/openapi/andy-policies-v1.yaml
+++ b/docs/openapi/andy-policies-v1.yaml
@@ -310,6 +310,179 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
+  /api/bundles:
+    post:
+      tags:
+        - Bundles
+      summary: "Create a new bundle (frozen snapshot of the live catalog).\r\nReturns 201 with the Andy.Policies.Application.Interfaces.BundleDto + `Location`\r\nheader pointing at `GET /api/bundles/{id}`.\r\nMaps Andy.Policies.Application.Exceptions.ValidationException → 400 and\r\nAndy.Policies.Application.Exceptions.ConflictException → 409 (duplicate active name).\r\nP8.6 (#86) — the CLI from this story is the first REST consumer."
+      operationId: Bundles_Create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateBundleRequest'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/CreateBundleRequest'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/CreateBundleRequest'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BundleDto'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+    get:
+      tags:
+        - Bundles
+      summary: "List bundles. `?includeDeleted=true` includes soft-deleted\r\nrows; `take` is clamped server-side. P8.6 (#86)."
+      operationId: Bundles_List
+      parameters:
+        - name: includeDeleted
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: skip
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 0
+        - name: take
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 50
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BundleDto'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+  '/api/bundles/{id}':
+    get:
+      tags:
+        - Bundles
+      summary: "Get a bundle by id. Returns 200 with Andy.Policies.Application.Interfaces.BundleDto or\r\n404 when the bundle is missing. Soft-deleted bundles are\r\naddressable here (the row remains for audit-chain integrity);\r\npass `?includeDeleted=true` on `GET /api/bundles` to\r\nlist them. P8.6 (#86)."
+      operationId: Bundles_Get
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BundleDto'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+    delete:
+      tags:
+        - Bundles
+      summary: "Soft-delete a bundle. State flips to\r\nAndy.Policies.Domain.Enums.BundleState.Deleted; the row remains in the table\r\nfor audit-chain integrity. Idempotent: a second delete on the\r\nsame id returns 404. P8.6 (#86)."
+      operationId: Bundles_Delete
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: rationale
+          in: query
+          schema:
+            type: string
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
   '/api/bundles/{id}/resolve':
     get:
       tags:
@@ -392,6 +565,55 @@ paths:
                 $ref: '#/components/schemas/BundlePinnedPolicyDto'
         '304':
           description: Not Modified
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+  '/api/bundles/{id}/diff':
+    get:
+      tags:
+        - Bundles
+      summary: "Emit an RFC-6902 JSON Patch between two bundles' frozen\r\nsnapshots (P8.6, story rivoli-ai/andy-policies#86). Returns\r\n200 with a Andy.Policies.Application.Interfaces.BundleDiffResult; 404 when either\r\nbundle is missing or soft-deleted; 400 when the same id is\r\npassed for both id and `to` (the\r\ntrivial empty-patch case is allowed via two distinct ids\r\nthat happen to resolve to identical canonical bytes — the\r\ndiff returns `[]`; same-id is rejected as a likely\r\ncaller mistake)."
+      operationId: Bundles_Diff
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: to
+          in: query
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BundleDiffResult'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
         '401':
           description: Unauthorized
           content:
@@ -1754,6 +1976,67 @@ components:
         - Tenant
         - Org
       type: string
+    BundleDiffResult:
+      type: object
+      properties:
+        fromId:
+          type: string
+          format: uuid
+        fromSnapshotHash:
+          type: string
+          nullable: true
+        toId:
+          type: string
+          format: uuid
+        toSnapshotHash:
+          type: string
+          nullable: true
+        rfc6902PatchJson:
+          type: string
+          nullable: true
+        opCount:
+          type: integer
+          format: int32
+      additionalProperties: false
+      description: 'Result envelope for M:Andy.Policies.Application.Interfaces.IBundleDiffService.DiffAsync(System.Guid,System.Guid,System.Threading.CancellationToken).'
+    BundleDto:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        createdBySubjectId:
+          type: string
+          nullable: true
+        snapshotHash:
+          type: string
+          nullable: true
+        state:
+          enum:
+            - Draft
+            - Active
+            - WindingDown
+            - Retired
+          type: string
+          nullable: true
+        deletedAt:
+          type: string
+          format: date-time
+          nullable: true
+        deletedBySubjectId:
+          type: string
+          nullable: true
+      additionalProperties: false
+      description: "Wire shape returned by Andy.Policies.Application.Interfaces.IBundleService. Excludes the\r\n(potentially large) `SnapshotJson` payload — surfaces fetch\r\nthat separately on demand via `BundlesController` in P8.3."
     BundlePinnedPolicyDto:
       type: object
       properties:
@@ -1915,6 +2198,23 @@ components:
           $ref: '#/components/schemas/BindStrength'
       additionalProperties: false
       description: "Request payload for `IBindingService.CreateAsync` (P3.2, story\r\nrivoli-ai/andy-policies#20). The target version must exist and not be in\r\n`LifecycleState.Retired`; the service throws\r\n`BindingRetiredVersionException` on a retired target."
+    CreateBundleRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: "Slug shape: `^[a-z0-9][a-z0-9-]{0,62}$`.\r\n            Active bundles are unique by name; soft-deleted bundles release\r\n            the slug for reuse."
+          nullable: true
+        description:
+          type: string
+          description: Optional human-readable summary.
+          nullable: true
+        rationale:
+          type: string
+          description: "Required non-empty rationale recorded\r\n            against the audit event."
+          nullable: true
+      additionalProperties: false
+      description: 'Inputs to M:Andy.Policies.Application.Interfaces.IBundleService.CreateAsync(Andy.Policies.Application.Interfaces.CreateBundleRequest,System.String,System.Threading.CancellationToken).'
     CreateItemRequest:
       type: object
       properties:

--- a/src/Andy.Policies.Api/Andy.Policies.Api.csproj
+++ b/src/Andy.Policies.Api/Andy.Policies.Api.csproj
@@ -60,6 +60,11 @@
          export over the same IAuditQuery / IAuditChain /
          IAuditExporter as REST + MCP. -->
     <Protobuf Include="Protos\audit.proto" GrpcServices="Both" />
+    <!-- bundles.proto: P8.6 (#86). Bundle pinning with an
+         RFC-6902 DiffBundles RPC alongside the create / list /
+         get / resolve / delete parity over IBundleService +
+         IBundleResolver. -->
+    <Protobuf Include="Protos\bundles.proto" GrpcServices="Both" />
   </ItemGroup>
 
 </Project>

--- a/src/Andy.Policies.Api/Controllers/BundlesController.cs
+++ b/src/Andy.Policies.Api/Controllers/BundlesController.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using System.Security.Claims;
+using Andy.Policies.Application.Exceptions;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Domain.Enums;
 using Microsoft.AspNetCore.Authorization;
@@ -41,10 +43,117 @@ namespace Andy.Policies.Api.Controllers;
 public sealed class BundlesController : ControllerBase
 {
     private readonly IBundleResolver _resolver;
+    private readonly IBundleDiffService _diff;
+    private readonly IBundleService _bundles;
 
-    public BundlesController(IBundleResolver resolver)
+    public BundlesController(
+        IBundleResolver resolver,
+        IBundleDiffService diff,
+        IBundleService bundles)
     {
         _resolver = resolver;
+        _diff = diff;
+        _bundles = bundles;
+    }
+
+    /// <summary>
+    /// Create a new bundle (frozen snapshot of the live catalog).
+    /// Returns 201 with the <see cref="BundleDto"/> + <c>Location</c>
+    /// header pointing at <c>GET /api/bundles/{id}</c>.
+    /// Maps <see cref="ValidationException"/> → 400 and
+    /// <see cref="ConflictException"/> → 409 (duplicate active name).
+    /// P8.6 (#86) — the CLI from this story is the first REST consumer.
+    /// </summary>
+    [HttpPost]
+    [Authorize(Policy = "andy-policies:bundle:create")]
+    [ProducesResponseType(typeof(BundleDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<BundleDto>> Create(
+        [FromBody] CreateBundleRequest request,
+        CancellationToken ct)
+    {
+        var actor = ResolveActor();
+        if (actor is null) return Unauthorized();
+
+        var dto = await _bundles.CreateAsync(request, actor, ct);
+        return CreatedAtAction(nameof(Get), new { id = dto.Id }, dto);
+    }
+
+    /// <summary>
+    /// List bundles. <c>?includeDeleted=true</c> includes soft-deleted
+    /// rows; <c>take</c> is clamped server-side. P8.6 (#86).
+    /// </summary>
+    [HttpGet]
+    [Authorize(Policy = "andy-policies:bundle:read")]
+    [ProducesResponseType(typeof(IReadOnlyList<BundleDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult<IReadOnlyList<BundleDto>>> List(
+        [FromQuery] bool includeDeleted = false,
+        [FromQuery] int skip = 0,
+        [FromQuery] int take = 50,
+        CancellationToken ct = default)
+    {
+        var rows = await _bundles.ListAsync(new ListBundlesFilter(includeDeleted, skip, take), ct);
+        return Ok(rows);
+    }
+
+    /// <summary>
+    /// Get a bundle by id. Returns 200 with <see cref="BundleDto"/> or
+    /// 404 when the bundle is missing. Soft-deleted bundles are
+    /// addressable here (the row remains for audit-chain integrity);
+    /// pass <c>?includeDeleted=true</c> on <c>GET /api/bundles</c> to
+    /// list them. P8.6 (#86).
+    /// </summary>
+    [HttpGet("{id:guid}")]
+    [Authorize(Policy = "andy-policies:bundle:read")]
+    [ProducesResponseType(typeof(BundleDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<BundleDto>> Get(Guid id, CancellationToken ct)
+    {
+        var dto = await _bundles.GetAsync(id, ct);
+        return dto is null ? NotFound() : Ok(dto);
+    }
+
+    /// <summary>
+    /// Soft-delete a bundle. State flips to
+    /// <see cref="BundleState.Deleted"/>; the row remains in the table
+    /// for audit-chain integrity. Idempotent: a second delete on the
+    /// same id returns 404. P8.6 (#86).
+    /// </summary>
+    [HttpDelete("{id:guid}")]
+    [Authorize(Policy = "andy-policies:bundle:delete")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Delete(
+        Guid id,
+        [FromQuery] string rationale,
+        CancellationToken ct)
+    {
+        var actor = ResolveActor();
+        if (actor is null) return Unauthorized();
+
+        if (string.IsNullOrWhiteSpace(rationale))
+        {
+            return ValidationProblem("rationale query parameter is required.");
+        }
+
+        var deleted = await _bundles.SoftDeleteAsync(id, actor, rationale, ct);
+        return deleted ? NoContent() : NotFound();
+    }
+
+    private string? ResolveActor()
+    {
+        var sub = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? User.Identity?.Name;
+        return string.IsNullOrEmpty(sub) ? null : sub;
     }
 
     /// <summary>
@@ -114,6 +223,42 @@ public sealed class BundlesController : ControllerBase
 
         SetSnapshotCacheHeaders(dto.SnapshotHash);
         return Ok(dto);
+    }
+
+    /// <summary>
+    /// Emit an RFC-6902 JSON Patch between two bundles' frozen
+    /// snapshots (P8.6, story rivoli-ai/andy-policies#86). Returns
+    /// 200 with a <see cref="BundleDiffResult"/>; 404 when either
+    /// bundle is missing or soft-deleted; 400 when the same id is
+    /// passed for both <paramref name="id"/> and <c>to</c> (the
+    /// trivial empty-patch case is allowed via two distinct ids
+    /// that happen to resolve to identical canonical bytes — the
+    /// diff returns <c>[]</c>; same-id is rejected as a likely
+    /// caller mistake).
+    /// </summary>
+    [HttpGet("{id:guid}/diff")]
+    [Authorize(Policy = "andy-policies:bundle:read")]
+    [ProducesResponseType(typeof(BundleDiffResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Diff(
+        Guid id,
+        [FromQuery] Guid to,
+        CancellationToken ct)
+    {
+        if (id == to)
+        {
+            return ValidationProblem(
+                "Diff requires distinct from / to bundle ids; pass the same id only when " +
+                "you actually want to diff a bundle against a different bundle whose " +
+                "snapshot happens to be identical.");
+        }
+
+        var result = await _diff.DiffAsync(id, to, ct);
+        if (result is null) return NotFound();
+        return Ok(result);
     }
 
     private bool TryReturnNotModified(string snapshotHash, out IActionResult result)

--- a/src/Andy.Policies.Api/GrpcServices/Authorization/GrpcMethodPermissionMap.cs
+++ b/src/Andy.Policies.Api/GrpcServices/Authorization/GrpcMethodPermissionMap.cs
@@ -72,6 +72,16 @@ public sealed class GrpcMethodPermissionMap : IGrpcMethodPermissionMap
         ["/andy_policies.AuditService/GetAudit"]     = "andy-policies:audit:read",
         ["/andy_policies.AuditService/VerifyAudit"]  = "andy-policies:audit:verify",
         ["/andy_policies.AuditService/ExportAudit"]  = "andy-policies:audit:export",
+
+        // BundleService — P8.6 (#86) parity over IBundleService /
+        // IBundleResolver / IBundleDiffService. Diff is treated as
+        // a read (it's a snapshot comparison; no mutation).
+        ["/andy_policies.BundleService/CreateBundle"]  = "andy-policies:bundle:create",
+        ["/andy_policies.BundleService/ListBundles"]   = "andy-policies:bundle:read",
+        ["/andy_policies.BundleService/GetBundle"]     = "andy-policies:bundle:read",
+        ["/andy_policies.BundleService/ResolveBundle"] = "andy-policies:bundle:read",
+        ["/andy_policies.BundleService/DeleteBundle"]  = "andy-policies:bundle:delete",
+        ["/andy_policies.BundleService/DiffBundles"]   = "andy-policies:bundle:read",
     };
 
     /// <summary>Services not in this set are allowed to bypass RBAC.
@@ -84,6 +94,7 @@ public sealed class GrpcMethodPermissionMap : IGrpcMethodPermissionMap
         "/andy_policies.ScopesService",
         "/andy_policies.OverridesService",
         "/andy_policies.AuditService",
+        "/andy_policies.BundleService",
     };
 
     public IReadOnlyDictionary<string, string> Entries => Map;

--- a/src/Andy.Policies.Api/GrpcServices/BundleGrpcService.cs
+++ b/src/Andy.Policies.Api/GrpcServices/BundleGrpcService.cs
@@ -1,0 +1,244 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Claims;
+using Andy.Policies.Api.Protos;
+using Andy.Policies.Application.Exceptions;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Enums;
+using Grpc.Core;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Andy.Policies.Api.GrpcServices;
+
+/// <summary>
+/// gRPC surface for bundle pinning (P8.6, story
+/// rivoli-ai/andy-policies#86). Six RPCs delegate to the same
+/// <see cref="IBundleService"/> + <see cref="IBundleResolver"/> +
+/// <see cref="IBundleDiffService"/> powering REST (P8.3) and MCP
+/// (P8.5) — zero duplicated business logic.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Status mapping.</b> <see cref="ValidationException"/> →
+/// <see cref="StatusCode.InvalidArgument"/>;
+/// <see cref="ConflictException"/> → <see cref="StatusCode.AlreadyExists"/>;
+/// missing subject → <see cref="StatusCode.Unauthenticated"/>;
+/// unknown id → <see cref="StatusCode.NotFound"/>; unmapped
+/// internal failures bubble as <see cref="StatusCode.Internal"/>
+/// via the framework.
+/// </para>
+/// </remarks>
+[Authorize]
+public class BundleGrpcService : Andy.Policies.Api.Protos.BundleService.BundleServiceBase
+{
+    private const int DefaultPageSize = 50;
+    private const int MaxPageSize = 200;
+
+    private readonly IBundleService _bundles;
+    private readonly IBundleResolver _resolver;
+    private readonly IBundleDiffService _diff;
+
+    public BundleGrpcService(
+        IBundleService bundles,
+        IBundleResolver resolver,
+        IBundleDiffService diff)
+    {
+        _bundles = bundles;
+        _resolver = resolver;
+        _diff = diff;
+    }
+
+    public override async Task<BundleMessage> CreateBundle(
+        Andy.Policies.Api.Protos.CreateBundleRequest request, ServerCallContext context)
+    {
+        var actor = ResolveActor(context);
+        try
+        {
+            var dto = await _bundles.CreateAsync(
+                new Application.Interfaces.CreateBundleRequest(
+                    request.Name,
+                    request.HasDescription ? request.Description : null,
+                    request.Rationale),
+                actor,
+                context.CancellationToken).ConfigureAwait(false);
+            return ToMessage(dto);
+        }
+        catch (ValidationException ex)
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument, ex.Message));
+        }
+        catch (ConflictException ex)
+        {
+            throw new RpcException(new Status(StatusCode.AlreadyExists, ex.Message));
+        }
+    }
+
+    public override async Task<ListBundlesResponse> ListBundles(
+        ListBundlesRequest request, ServerCallContext context)
+    {
+        var skip = Math.Max(0, request.Skip);
+        var take = request.Take <= 0
+            ? DefaultPageSize
+            : Math.Clamp(request.Take, 1, MaxPageSize);
+        var rows = await _bundles.ListAsync(
+            new ListBundlesFilter(request.IncludeDeleted, skip, take),
+            context.CancellationToken).ConfigureAwait(false);
+        var resp = new ListBundlesResponse();
+        foreach (var dto in rows) resp.Bundles.Add(ToMessage(dto));
+        return resp;
+    }
+
+    public override async Task<BundleMessage> GetBundle(
+        GetBundleRequest request, ServerCallContext context)
+    {
+        if (!Guid.TryParse(request.Id, out var bid))
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument, $"'{request.Id}' is not a valid GUID."));
+        }
+        var dto = await _bundles.GetAsync(bid, context.CancellationToken).ConfigureAwait(false);
+        if (dto is null)
+        {
+            throw new RpcException(new Status(StatusCode.NotFound, $"Bundle {bid} not found."));
+        }
+        return ToMessage(dto);
+    }
+
+    public override async Task<ResolveBundleResponse> ResolveBundle(
+        ResolveBundleRequest request, ServerCallContext context)
+    {
+        if (!Guid.TryParse(request.Id, out var bid))
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument, $"'{request.Id}' is not a valid GUID."));
+        }
+        if (!Enum.TryParse<BindingTargetType>(request.TargetType, ignoreCase: true, out var tt))
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument,
+                $"target_type '{request.TargetType}' is not a valid BindingTargetType."));
+        }
+        if (string.IsNullOrWhiteSpace(request.TargetRef))
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument, "target_ref is required."));
+        }
+
+        var result = await _resolver.ResolveAsync(bid, tt, request.TargetRef, context.CancellationToken)
+            .ConfigureAwait(false);
+        if (result is null)
+        {
+            throw new RpcException(new Status(StatusCode.NotFound,
+                $"Bundle {bid} does not exist or is soft-deleted."));
+        }
+
+        var resp = new ResolveBundleResponse
+        {
+            BundleId = result.BundleId.ToString(),
+            BundleName = result.BundleName,
+            SnapshotHash = result.SnapshotHash,
+            CapturedAt = result.CapturedAt.ToString("o"),
+            TargetType = result.TargetType.ToString(),
+            TargetRef = result.TargetRef,
+            Count = result.Count,
+        };
+        foreach (var b in result.Bindings)
+        {
+            var msg = new ResolvedBundleBindingMessage
+            {
+                BindingId = b.BindingId.ToString(),
+                PolicyId = b.PolicyId.ToString(),
+                PolicyName = b.PolicyName,
+                PolicyVersionId = b.PolicyVersionId.ToString(),
+                VersionNumber = b.VersionNumber,
+                Enforcement = b.Enforcement,
+                Severity = b.Severity,
+                BindStrength = b.BindStrength.ToString(),
+            };
+            foreach (var s in b.Scopes) msg.Scopes.Add(s);
+            resp.Bindings.Add(msg);
+        }
+        return resp;
+    }
+
+    public override async Task<BundleMessage> DeleteBundle(
+        DeleteBundleRequest request, ServerCallContext context)
+    {
+        if (!Guid.TryParse(request.Id, out var bid))
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument, $"'{request.Id}' is not a valid GUID."));
+        }
+        var actor = ResolveActor(context);
+        try
+        {
+            var deleted = await _bundles.SoftDeleteAsync(bid, actor, request.Rationale, context.CancellationToken)
+                .ConfigureAwait(false);
+            if (!deleted)
+            {
+                throw new RpcException(new Status(StatusCode.NotFound,
+                    $"Bundle {bid} does not exist or is already soft-deleted."));
+            }
+            var dto = await _bundles.GetAsync(bid, context.CancellationToken).ConfigureAwait(false);
+            return ToMessage(dto!);
+        }
+        catch (ValidationException ex)
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument, ex.Message));
+        }
+    }
+
+    public override async Task<DiffBundlesResponse> DiffBundles(
+        DiffBundlesRequest request, ServerCallContext context)
+    {
+        if (!Guid.TryParse(request.FromId, out var fromId))
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument, $"from_id '{request.FromId}' is not a valid GUID."));
+        }
+        if (!Guid.TryParse(request.ToId, out var toId))
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument, $"to_id '{request.ToId}' is not a valid GUID."));
+        }
+
+        var result = await _diff.DiffAsync(fromId, toId, context.CancellationToken).ConfigureAwait(false);
+        if (result is null)
+        {
+            throw new RpcException(new Status(StatusCode.NotFound,
+                "One or both bundles not found or soft-deleted."));
+        }
+
+        return new DiffBundlesResponse
+        {
+            FromId = result.FromId.ToString(),
+            FromSnapshotHash = result.FromSnapshotHash,
+            ToId = result.ToId.ToString(),
+            ToSnapshotHash = result.ToSnapshotHash,
+            Rfc6902PatchJson = result.Rfc6902PatchJson,
+            OpCount = result.OpCount,
+        };
+    }
+
+    private static string ResolveActor(ServerCallContext context)
+    {
+        var user = context.GetHttpContext().User;
+        var sub = user.FindFirstValue(ClaimTypes.NameIdentifier) ?? user.Identity?.Name;
+        if (string.IsNullOrEmpty(sub))
+        {
+            throw new RpcException(new Status(StatusCode.Unauthenticated, "no subject claim"));
+        }
+        return sub;
+    }
+
+    private static BundleMessage ToMessage(BundleDto dto)
+    {
+        var msg = new BundleMessage
+        {
+            Id = dto.Id.ToString(),
+            Name = dto.Name,
+            CreatedAt = dto.CreatedAt.ToString("o"),
+            CreatedBySubjectId = dto.CreatedBySubjectId,
+            SnapshotHash = dto.SnapshotHash,
+            State = dto.State,
+        };
+        if (dto.Description is not null) msg.Description = dto.Description;
+        if (dto.DeletedAt is { } da) msg.DeletedAt = da.ToString("o");
+        if (dto.DeletedBySubjectId is not null) msg.DeletedBySubjectId = dto.DeletedBySubjectId;
+        return msg;
+    }
+}

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -177,6 +177,8 @@ builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBundleService, 
 // because it depends on the per-request DbContext; the cached
 // parsed-snapshot lives in the singleton IMemoryCache below.
 builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBundleResolver, Andy.Policies.Infrastructure.Services.BundleResolver>();
+// P8.6 (#86): RFC-6902 diff between two bundle snapshots.
+builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBundleDiffService, Andy.Policies.Infrastructure.Services.BundleDiffService>();
 // P8.4 (#84): bundle-pinning gate. PinningPolicy is the live
 // adapter over andy-settings; the BundleBackedPolicyReader projects
 // snapshot rows into PolicyDto/PolicyVersionDto for /api/policies*
@@ -441,6 +443,7 @@ app.MapGrpcService<Andy.Policies.Api.GrpcServices.BindingsGrpcService>();
 app.MapGrpcService<Andy.Policies.Api.GrpcServices.ScopesGrpcService>();
 app.MapGrpcService<Andy.Policies.Api.GrpcServices.OverridesGrpcService>();
 app.MapGrpcService<Andy.Policies.Api.GrpcServices.AuditGrpcService>();
+app.MapGrpcService<Andy.Policies.Api.GrpcServices.BundleGrpcService>();
 
 // --- MCP endpoint ---
 app.MapMcp("/mcp")

--- a/src/Andy.Policies.Api/Protos/bundles.proto
+++ b/src/Andy.Policies.Api/Protos/bundles.proto
@@ -1,0 +1,114 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+//
+// Wire contract for the bundle pinning gRPC surface (P8.6,
+// rivoli-ai/andy-policies#86). All operations delegate to
+// IBundleService / IBundleResolver / IBundleDiffService — the
+// same services powering REST (P8.3) and MCP (P8.5). Diff
+// produces an RFC-6902 JSON Patch between two bundles' frozen
+// snapshots; the patch_json field is a JSON-encoded array of
+// op objects so consumers can pipe it through any compliant
+// patch applier.
+
+syntax = "proto3";
+
+option csharp_namespace = "Andy.Policies.Api.Protos";
+
+package andy_policies;
+
+service BundleService {
+  rpc CreateBundle (CreateBundleRequest)   returns (BundleMessage);
+  rpc ListBundles (ListBundlesRequest)     returns (ListBundlesResponse);
+  rpc GetBundle (GetBundleRequest)         returns (BundleMessage);
+  rpc ResolveBundle (ResolveBundleRequest) returns (ResolveBundleResponse);
+  rpc DeleteBundle (DeleteBundleRequest)   returns (BundleMessage);
+  rpc DiffBundles (DiffBundlesRequest)     returns (DiffBundlesResponse);
+}
+
+// -- shared messages -------------------------------------------------------
+
+message BundleMessage {
+  string id = 1;
+  string name = 2;
+  optional string description = 3;
+  string created_at = 4;                  // ISO 8601 (DateTimeOffset.ToString("o"))
+  string created_by_subject_id = 5;
+  string snapshot_hash = 6;
+  string state = 7;                       // "Active" | "Deleted"
+  optional string deleted_at = 8;
+  optional string deleted_by_subject_id = 9;
+}
+
+// -- create / list / get / delete -------------------------------------------
+
+message CreateBundleRequest {
+  string name = 1;
+  optional string description = 2;
+  string rationale = 3;                   // required, captured in audit chain
+}
+
+message ListBundlesRequest {
+  bool include_deleted = 1;
+  int32 skip = 2;                         // default 0
+  int32 take = 3;                         // default 50, clamped to [1, 200]
+}
+
+message ListBundlesResponse {
+  repeated BundleMessage bundles = 1;
+}
+
+message GetBundleRequest {
+  string id = 1;                          // bundle id (GUID)
+}
+
+message DeleteBundleRequest {
+  string id = 1;                          // bundle id (GUID)
+  string rationale = 2;                   // required, captured in audit chain
+}
+
+// -- resolve ---------------------------------------------------------------
+
+message ResolveBundleRequest {
+  string id = 1;                          // bundle id (GUID)
+  string target_type = 2;                 // Template | Repo | ScopeNode | Tenant | Org
+  string target_ref = 3;                  // e.g. "repo:rivoli-ai/conductor"
+}
+
+message ResolveBundleResponse {
+  string bundle_id = 1;
+  string bundle_name = 2;
+  string snapshot_hash = 3;
+  string captured_at = 4;                 // ISO 8601
+  string target_type = 5;
+  string target_ref = 6;
+  repeated ResolvedBundleBindingMessage bindings = 7;
+  int32 count = 8;
+}
+
+message ResolvedBundleBindingMessage {
+  string binding_id = 1;
+  string policy_id = 2;
+  string policy_name = 3;
+  string policy_version_id = 4;
+  int32 version_number = 5;
+  string enforcement = 6;                 // wire casing (uppercase RFC 2119)
+  string severity = 7;                    // wire casing (lowercase)
+  repeated string scopes = 8;
+  string bind_strength = 9;               // "Mandatory" | "Recommended"
+}
+
+// -- diff ------------------------------------------------------------------
+
+message DiffBundlesRequest {
+  string from_id = 1;                     // source bundle id (GUID)
+  string to_id = 2;                       // target bundle id (GUID)
+}
+
+message DiffBundlesResponse {
+  string from_id = 1;
+  string from_snapshot_hash = 2;
+  string to_id = 3;
+  string to_snapshot_hash = 4;
+  string rfc6902_patch_json = 5;          // JSON-encoded array of patch ops
+  int32 op_count = 6;                     // length of the patch array
+}

--- a/src/Andy.Policies.Application/Interfaces/IBundleDiffService.cs
+++ b/src/Andy.Policies.Application/Interfaces/IBundleDiffService.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.Interfaces;
+
+/// <summary>
+/// Emits an RFC-6902 JSON Patch between two bundles' frozen
+/// snapshots (P8.6, story rivoli-ai/andy-policies#86). Reuses the
+/// canonical-JSON shape persisted in <c>Bundle.SnapshotJson</c> so
+/// the patch is deterministic — running the diff twice on the same
+/// pair yields byte-identical output.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Scope.</b> Compares two bundles in this catalog only. Diff
+/// against live state, against bundles in another deployment, or
+/// against external systems is out of scope per Epic P8 non-goals;
+/// adding such capabilities would encourage consumers to use this
+/// service as a drift detector, which is Conductor's job.
+/// </para>
+/// <para>
+/// <b>Why RFC-6902 vs RFC-7396.</b> JSON Merge Patch (7396) cannot
+/// express array element removals precisely; we need "removed
+/// binding at index 42" semantics so an auditor can grep
+/// <c>"path": "/bindings/42"</c> in the output. JSON Patch
+/// (6902) preserves indexed paths and round-trips cleanly against
+/// jsonb storage.
+/// </para>
+/// </remarks>
+public interface IBundleDiffService
+{
+    /// <summary>
+    /// Compute the patch from <paramref name="fromId"/> to
+    /// <paramref name="toId"/>. Returns <c>null</c> when either
+    /// bundle is missing or soft-deleted.
+    /// </summary>
+    Task<BundleDiffResult?> DiffAsync(Guid fromId, Guid toId, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Result envelope for <see cref="IBundleDiffService.DiffAsync"/>.
+/// </summary>
+public sealed record BundleDiffResult(
+    Guid FromId,
+    string FromSnapshotHash,
+    Guid ToId,
+    string ToSnapshotHash,
+    string Rfc6902PatchJson,
+    int OpCount);

--- a/src/Andy.Policies.Infrastructure/Services/BundleDiffService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BundleDiffService.cs
@@ -1,0 +1,250 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text;
+using System.Text.Json;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Andy.Policies.Infrastructure.Services;
+
+/// <summary>
+/// EF-backed <see cref="IBundleDiffService"/> implementation (P8.6,
+/// story rivoli-ai/andy-policies#86). Loads the two bundles' canonical
+/// <c>SnapshotJson</c> blobs and walks them as
+/// <see cref="JsonElement"/> trees, emitting RFC-6902 ops in
+/// deterministic order so two invocations on the same pair produce
+/// byte-identical output.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Determinism.</b> Object keys are walked in lexicographic
+/// order; arrays are walked by index. The canonical bytes from
+/// P8.2 already sort keys, so a parsed-then-walked traversal here
+/// matches the on-disk shape. The patch JSON itself is emitted
+/// without insignificant whitespace.
+/// </para>
+/// <para>
+/// <b>Soft-deleted bundles.</b> Diff requires both bundles to exist
+/// and be addressable. Soft-deleted rows return <c>null</c> from
+/// the loader so the caller surfaces 404, mirroring the
+/// resolution surface (P8.3).
+/// </para>
+/// </remarks>
+public sealed class BundleDiffService : IBundleDiffService
+{
+    private static readonly JsonWriterOptions PatchWriterOptions = new()
+    {
+        Indented = false,
+        SkipValidation = false,
+    };
+
+    private readonly AppDbContext _db;
+
+    public BundleDiffService(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<BundleDiffResult?> DiffAsync(
+        Guid fromId, Guid toId, CancellationToken ct = default)
+    {
+        var rows = await _db.Bundles
+            .AsNoTracking()
+            .Where(b => (b.Id == fromId || b.Id == toId) && b.State == BundleState.Active)
+            .Select(b => new { b.Id, b.SnapshotHash, b.SnapshotJson })
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var from = rows.FirstOrDefault(r => r.Id == fromId);
+        var to = rows.FirstOrDefault(r => r.Id == toId);
+        if (from is null || to is null) return null;
+
+        using var fromDoc = JsonDocument.Parse(from.SnapshotJson);
+        using var toDoc = JsonDocument.Parse(to.SnapshotJson);
+
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer, PatchWriterOptions))
+        {
+            writer.WriteStartArray();
+            var ops = 0;
+            EmitDiff(writer, "", fromDoc.RootElement, toDoc.RootElement, ref ops);
+            writer.WriteEndArray();
+        }
+
+        var patchJson = Encoding.UTF8.GetString(buffer.ToArray());
+        // Re-walk the parsed array to get the op count without
+        // tracking it in the writer (the count we tracked above is
+        // private). A second parse is cheap on a typical patch.
+        using var patchDoc = JsonDocument.Parse(patchJson);
+        var opCount = patchDoc.RootElement.GetArrayLength();
+
+        return new BundleDiffResult(
+            FromId: fromId,
+            FromSnapshotHash: from.SnapshotHash,
+            ToId: toId,
+            ToSnapshotHash: to.SnapshotHash,
+            Rfc6902PatchJson: patchJson,
+            OpCount: opCount);
+    }
+
+    /// <summary>
+    /// Recursively walk <paramref name="from"/> + <paramref name="to"/>
+    /// at the same JSON path. Emits one RFC-6902 op per leaf-level
+    /// difference; recurses into objects + arrays. <paramref name="ops"/>
+    /// counts emitted ops (used for telemetry — not the patch shape).
+    /// </summary>
+    /// <remarks>
+    /// Strategy:
+    /// <list type="bullet">
+    ///   <item>If kinds differ → <c>replace</c> the whole subtree.</item>
+    ///   <item>Object: union the keys (sorted). Key in only one side →
+    ///     <c>add</c> / <c>remove</c>. Key in both → recurse.</item>
+    ///   <item>Array: index-aligned compare. Trailing extras get
+    ///     <c>add</c> at the end (in order); missing tails get
+    ///     <c>remove</c> at the same index repeatedly. The
+    ///     index-aligned strategy is a deliberate trade-off — it
+    ///     produces verbose patches for inserted-in-the-middle
+    ///     elements but keeps the algorithm O(n) and deterministic.
+    ///     Bundle snapshots already sort by id (P8.2 builder), so
+    ///     "insert in the middle" is rare in practice.</item>
+    ///   <item>Primitives: structural compare via canonical text;
+    ///     differ → <c>replace</c>.</item>
+    /// </list>
+    /// </remarks>
+    private static void EmitDiff(
+        Utf8JsonWriter writer,
+        string path,
+        JsonElement from,
+        JsonElement to,
+        ref int ops)
+    {
+        if (from.ValueKind != to.ValueKind)
+        {
+            EmitOp(writer, "replace", path, to);
+            ops++;
+            return;
+        }
+
+        switch (from.ValueKind)
+        {
+            case JsonValueKind.Object:
+                DiffObjects(writer, path, from, to, ref ops);
+                break;
+            case JsonValueKind.Array:
+                DiffArrays(writer, path, from, to, ref ops);
+                break;
+            case JsonValueKind.String:
+                if (!string.Equals(from.GetString(), to.GetString(), StringComparison.Ordinal))
+                {
+                    EmitOp(writer, "replace", path, to);
+                    ops++;
+                }
+                break;
+            case JsonValueKind.Number:
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+            case JsonValueKind.Null:
+                if (!string.Equals(from.GetRawText(), to.GetRawText(), StringComparison.Ordinal))
+                {
+                    EmitOp(writer, "replace", path, to);
+                    ops++;
+                }
+                break;
+        }
+    }
+
+    private static void DiffObjects(
+        Utf8JsonWriter writer, string path, JsonElement from, JsonElement to, ref int ops)
+    {
+        var fromKeys = new SortedSet<string>(StringComparer.Ordinal);
+        var toKeys = new SortedSet<string>(StringComparer.Ordinal);
+        foreach (var p in from.EnumerateObject()) fromKeys.Add(p.Name);
+        foreach (var p in to.EnumerateObject()) toKeys.Add(p.Name);
+
+        var allKeys = new SortedSet<string>(StringComparer.Ordinal);
+        foreach (var k in fromKeys) allKeys.Add(k);
+        foreach (var k in toKeys) allKeys.Add(k);
+
+        foreach (var key in allKeys)
+        {
+            var childPath = path + "/" + EscapePathSegment(key);
+            var inFrom = fromKeys.Contains(key);
+            var inTo = toKeys.Contains(key);
+            if (!inFrom)
+            {
+                EmitOp(writer, "add", childPath, to.GetProperty(key));
+                ops++;
+            }
+            else if (!inTo)
+            {
+                EmitOpNoValue(writer, "remove", childPath);
+                ops++;
+            }
+            else
+            {
+                EmitDiff(writer, childPath, from.GetProperty(key), to.GetProperty(key), ref ops);
+            }
+        }
+    }
+
+    private static void DiffArrays(
+        Utf8JsonWriter writer, string path, JsonElement from, JsonElement to, ref int ops)
+    {
+        var fromLen = from.GetArrayLength();
+        var toLen = to.GetArrayLength();
+        var common = Math.Min(fromLen, toLen);
+
+        for (var i = 0; i < common; i++)
+        {
+            EmitDiff(writer, path + "/" + i, from[i], to[i], ref ops);
+        }
+
+        // Trailing additions in `to`: emit `add` at the array tail
+        // (RFC 6902 supports `path: "/items/-"` to mean append, but
+        // an explicit index keeps the patch addressable for tools).
+        for (var i = common; i < toLen; i++)
+        {
+            EmitOp(writer, "add", path + "/" + i, to[i]);
+            ops++;
+        }
+
+        // Trailing removals in `from`: emit `remove` at the same
+        // index repeatedly because each remove shifts the rest down
+        // (per RFC 6902 §4.2).
+        for (var i = common; i < fromLen; i++)
+        {
+            EmitOpNoValue(writer, "remove", path + "/" + common);
+            ops++;
+        }
+    }
+
+    private static void EmitOp(Utf8JsonWriter writer, string op, string path, JsonElement value)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("op", op);
+        writer.WriteString("path", path);
+        writer.WritePropertyName("value");
+        value.WriteTo(writer);
+        writer.WriteEndObject();
+    }
+
+    private static void EmitOpNoValue(Utf8JsonWriter writer, string op, string path)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("op", op);
+        writer.WriteString("path", path);
+        writer.WriteEndObject();
+    }
+
+    /// <summary>
+    /// Escape a JSON Pointer path segment per RFC 6901 §3:
+    /// '~' → '~0', '/' → '~1'. Done in that order so a literal '~1'
+    /// in the key doesn't get double-escaped.
+    /// </summary>
+    private static string EscapePathSegment(string segment)
+        => segment.Replace("~", "~0", StringComparison.Ordinal)
+                  .Replace("/", "~1", StringComparison.Ordinal);
+}

--- a/tests/Andy.Policies.Tests.Integration/Authorization/GrpcPermissionMapCoverageTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Authorization/GrpcPermissionMapCoverageTests.cs
@@ -29,6 +29,7 @@ public class GrpcPermissionMapCoverageTests
         new object[] { typeof(ScopesService.ScopesServiceBase) },
         new object[] { typeof(OverridesService.OverridesServiceBase) },
         new object[] { typeof(AuditService.AuditServiceBase) },
+        new object[] { typeof(BundleService.BundleServiceBase) },
     };
 
     [Theory]

--- a/tests/Andy.Policies.Tests.Integration/GrpcServices/BundleGrpcServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/GrpcServices/BundleGrpcServiceTests.cs
@@ -1,0 +1,249 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json;
+using Andy.Policies.Api.Protos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Tests.Integration.Controllers;
+using FluentAssertions;
+using Grpc.Core;
+using Grpc.Net.Client;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.GrpcServices;
+
+/// <summary>
+/// End-to-end gRPC tests for <see cref="Andy.Policies.Api.GrpcServices.BundleGrpcService"/>
+/// (P8.6, story rivoli-ai/andy-policies#86). Each RPC is exercised
+/// over an in-process HTTP/2 channel to confirm the proto contract,
+/// the generated stubs, the exception → status mapping, and the
+/// shared service-layer wiring (no duplicated business logic vs.
+/// REST/MCP). The diff RPC also pins byte-identical output across
+/// two invocations.
+/// </summary>
+public class BundleGrpcServiceTests : IClassFixture<PoliciesApiFactory>
+{
+    private readonly PoliciesApiFactory _factory;
+    private readonly BundleService.BundleServiceClient _client;
+    private readonly GrpcChannel _channel;
+
+    public BundleGrpcServiceTests(PoliciesApiFactory factory)
+    {
+        _factory = factory;
+        var handler = factory.Server.CreateHandler();
+        _channel = GrpcChannel.ForAddress(factory.Server.BaseAddress, new GrpcChannelOptions
+        {
+            HttpHandler = handler,
+        });
+        _client = new BundleService.BundleServiceClient(_channel);
+    }
+
+    private async Task SeedActiveVersionAsync(string slug)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var policy = new Policy
+        {
+            Id = Guid.NewGuid(),
+            Name = slug,
+            CreatedBySubjectId = "seed",
+        };
+        var version = new PolicyVersion
+        {
+            Id = Guid.NewGuid(),
+            PolicyId = policy.Id,
+            Version = 1,
+            State = LifecycleState.Active,
+            Enforcement = EnforcementLevel.Should,
+            Severity = Severity.Moderate,
+            Scopes = new List<string>(),
+            Summary = "fixture",
+            RulesJson = "{}",
+            CreatedBySubjectId = "seed",
+            ProposerSubjectId = "seed",
+            PublishedAt = DateTimeOffset.UtcNow,
+            PublishedBySubjectId = "seed",
+        };
+        db.Policies.Add(policy);
+        db.PolicyVersions.Add(version);
+        await db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task CreateBundle_HappyPath_ReturnsBundleMessage_WithSnapshotHash()
+    {
+        await SeedActiveVersionAsync($"p-{Guid.NewGuid():N}".Substring(0, 12));
+        var name = $"snap-{Guid.NewGuid():N}".Substring(0, 16);
+
+        var resp = await _client.CreateBundleAsync(new Andy.Policies.Api.Protos.CreateBundleRequest
+        {
+            Name = name,
+            Rationale = "initial",
+        });
+
+        resp.Name.Should().Be(name);
+        resp.SnapshotHash.Should().HaveLength(64);
+        resp.State.Should().Be("Active");
+    }
+
+    [Fact]
+    public async Task CreateBundle_DuplicateActiveName_ThrowsAlreadyExists()
+    {
+        await SeedActiveVersionAsync($"p-{Guid.NewGuid():N}".Substring(0, 12));
+        var name = $"dup-{Guid.NewGuid():N}".Substring(0, 16);
+        await _client.CreateBundleAsync(new Andy.Policies.Api.Protos.CreateBundleRequest
+        {
+            Name = name, Rationale = "first",
+        });
+
+        var act = async () => await _client.CreateBundleAsync(new Andy.Policies.Api.Protos.CreateBundleRequest
+        {
+            Name = name, Rationale = "second",
+        }).ResponseAsync;
+
+        var ex = await Assert.ThrowsAsync<RpcException>(act);
+        ex.StatusCode.Should().Be(StatusCode.AlreadyExists);
+    }
+
+    [Fact]
+    public async Task GetBundle_UnknownId_ThrowsNotFound()
+    {
+        var act = async () => await _client.GetBundleAsync(new GetBundleRequest
+        {
+            Id = Guid.NewGuid().ToString(),
+        }).ResponseAsync;
+
+        var ex = await Assert.ThrowsAsync<RpcException>(act);
+        ex.StatusCode.Should().Be(StatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetBundle_BadGuid_ThrowsInvalidArgument()
+    {
+        var act = async () => await _client.GetBundleAsync(new GetBundleRequest
+        {
+            Id = "not-a-guid",
+        }).ResponseAsync;
+
+        var ex = await Assert.ThrowsAsync<RpcException>(act);
+        ex.StatusCode.Should().Be(StatusCode.InvalidArgument);
+    }
+
+    [Fact]
+    public async Task ListBundles_ReturnsCreatedBundles()
+    {
+        await SeedActiveVersionAsync($"p-{Guid.NewGuid():N}".Substring(0, 12));
+        var name = $"list-{Guid.NewGuid():N}".Substring(0, 16);
+        var created = await _client.CreateBundleAsync(new Andy.Policies.Api.Protos.CreateBundleRequest
+        {
+            Name = name, Rationale = "x",
+        });
+
+        var resp = await _client.ListBundlesAsync(new ListBundlesRequest { Take = 200 });
+
+        resp.Bundles.Should().Contain(b => b.Id == created.Id);
+    }
+
+    [Fact]
+    public async Task DeleteBundle_SoftFlips_AndAuditRowAppears()
+    {
+        await SeedActiveVersionAsync($"p-{Guid.NewGuid():N}".Substring(0, 12));
+        var name = $"del-{Guid.NewGuid():N}".Substring(0, 16);
+        var created = await _client.CreateBundleAsync(new Andy.Policies.Api.Protos.CreateBundleRequest
+        {
+            Name = name, Rationale = "x",
+        });
+
+        var deleted = await _client.DeleteBundleAsync(new DeleteBundleRequest
+        {
+            Id = created.Id, Rationale = "decommission",
+        });
+
+        deleted.State.Should().Be("Deleted");
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var auditCount = await db.AuditEvents.AsNoTracking()
+            .Where(e => e.Action == "bundle.delete" && e.EntityId == created.Id)
+            .CountAsync();
+        auditCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DiffBundles_TwoInvocationsOnSamePair_ProduceByteIdenticalPatch()
+    {
+        await SeedActiveVersionAsync($"p-{Guid.NewGuid():N}".Substring(0, 12));
+        var nameA = $"diff-a-{Guid.NewGuid():N}".Substring(0, 14);
+        var nameB = $"diff-b-{Guid.NewGuid():N}".Substring(0, 14);
+        var a = await _client.CreateBundleAsync(new Andy.Policies.Api.Protos.CreateBundleRequest
+        {
+            Name = nameA, Rationale = "x",
+        });
+        var b = await _client.CreateBundleAsync(new Andy.Policies.Api.Protos.CreateBundleRequest
+        {
+            Name = nameB, Rationale = "x",
+        });
+
+        var first = await _client.DiffBundlesAsync(new DiffBundlesRequest { FromId = a.Id, ToId = b.Id });
+        var second = await _client.DiffBundlesAsync(new DiffBundlesRequest { FromId = a.Id, ToId = b.Id });
+
+        second.Rfc6902PatchJson.Should().Be(
+            first.Rfc6902PatchJson,
+            "diff determinism is the floor under reproducibility — gRPC consumers " +
+            "rely on byte-identical patches for caching + idempotent retries");
+        first.FromSnapshotHash.Should().Be(a.SnapshotHash);
+        first.ToSnapshotHash.Should().Be(b.SnapshotHash);
+    }
+
+    [Fact]
+    public async Task DiffBundles_UnknownBundle_ThrowsNotFound()
+    {
+        await SeedActiveVersionAsync($"p-{Guid.NewGuid():N}".Substring(0, 12));
+        var present = await _client.CreateBundleAsync(new Andy.Policies.Api.Protos.CreateBundleRequest
+        {
+            Name = $"diff-{Guid.NewGuid():N}".Substring(0, 14), Rationale = "x",
+        });
+
+        var act = async () => await _client.DiffBundlesAsync(new DiffBundlesRequest
+        {
+            FromId = present.Id,
+            ToId = Guid.NewGuid().ToString(),
+        }).ResponseAsync;
+
+        var ex = await Assert.ThrowsAsync<RpcException>(act);
+        ex.StatusCode.Should().Be(StatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ResolveBundle_UnknownId_ThrowsNotFound()
+    {
+        var act = async () => await _client.ResolveBundleAsync(new ResolveBundleRequest
+        {
+            Id = Guid.NewGuid().ToString(),
+            TargetType = "Repo",
+            TargetRef = "repo:any",
+        }).ResponseAsync;
+
+        var ex = await Assert.ThrowsAsync<RpcException>(act);
+        ex.StatusCode.Should().Be(StatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ResolveBundle_BadTargetType_ThrowsInvalidArgument()
+    {
+        var act = async () => await _client.ResolveBundleAsync(new ResolveBundleRequest
+        {
+            Id = Guid.NewGuid().ToString(),
+            TargetType = "Unicorn",
+            TargetRef = "ref",
+        }).ResponseAsync;
+
+        var ex = await Assert.ThrowsAsync<RpcException>(act);
+        ex.StatusCode.Should().Be(StatusCode.InvalidArgument);
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Services/BundleDiffServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/BundleDiffServiceTests.cs
@@ -1,0 +1,249 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Domain.ValueObjects;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Infrastructure.Services;
+using Andy.Policies.Shared.Auditing;
+using Andy.Policies.Tests.Unit.Fixtures;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Services;
+
+/// <summary>
+/// Unit tests for <see cref="BundleDiffService"/> (P8.6, story
+/// rivoli-ai/andy-policies#86). Drives the differ against
+/// hand-built bundle pairs whose snapshots differ in known ways
+/// so the emitted RFC-6902 patch is pinned op-by-op. Determinism
+/// is the load-bearing assertion: two invocations on the same
+/// pair must produce byte-identical patch JSON.
+/// </summary>
+public class BundleDiffServiceTests
+{
+    private static readonly DateTimeOffset CapturedAt =
+        DateTimeOffset.Parse("2026-05-06T18:00:00Z");
+
+    private static BundleSnapshot SnapshotWith(
+        IEnumerable<BundlePolicyEntry>? policies = null,
+        IEnumerable<BundleBindingEntry>? bindings = null,
+        IEnumerable<BundleOverrideEntry>? overrides = null) => new(
+            SchemaVersion: "1",
+            CapturedAt: CapturedAt,
+            AuditTailHash: new string('0', 64),
+            Policies: (policies ?? Array.Empty<BundlePolicyEntry>()).ToList(),
+            Bindings: (bindings ?? Array.Empty<BundleBindingEntry>()).ToList(),
+            Overrides: (overrides ?? Array.Empty<BundleOverrideEntry>()).ToList(),
+            Scopes: Array.Empty<BundleScopeEntry>());
+
+    private static BundlePolicyEntry Policy(
+        Guid? id = null,
+        string name = "p1",
+        string enforcement = "Should",
+        string severity = "Moderate") => new(
+            PolicyId: id ?? Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            Name: name,
+            PolicyVersionId: Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            Version: 1,
+            Enforcement: enforcement,
+            Severity: severity,
+            Scopes: Array.Empty<string>(),
+            RulesJson: "{}",
+            Summary: "fixture");
+
+    private static BundleBindingEntry Binding(Guid? id = null, string targetRef = "repo:a") => new(
+        BindingId: id ?? Guid.Parse("33333333-3333-3333-3333-333333333333"),
+        PolicyVersionId: Guid.Parse("22222222-2222-2222-2222-222222222222"),
+        TargetType: "Repo",
+        TargetRef: targetRef,
+        BindStrength: "Recommended");
+
+    private static async Task<(BundleDiffService svc, AppDbContext db, Guid fromId, Guid toId)>
+        BuildPairAsync(BundleSnapshot from, BundleSnapshot to)
+    {
+        var db = InMemoryDbFixture.Create();
+
+        async Task<Guid> AddBundle(BundleSnapshot snap, string name)
+        {
+            var canonical = CanonicalJson.SerializeObject(snap);
+            var json = Encoding.UTF8.GetString(canonical);
+            var hash = Convert.ToHexString(SHA256.HashData(canonical)).ToLowerInvariant();
+            var b = new Bundle
+            {
+                Id = Guid.NewGuid(),
+                Name = name,
+                CreatedAt = CapturedAt,
+                CreatedBySubjectId = "test",
+                SnapshotJson = json,
+                SnapshotHash = hash,
+                State = BundleState.Active,
+            };
+            db.Bundles.Add(b);
+            await db.SaveChangesAsync();
+            return b.Id;
+        }
+
+        var fromId = await AddBundle(from, "from");
+        var toId = await AddBundle(to, "to");
+        return (new BundleDiffService(db), db, fromId, toId);
+    }
+
+    [Fact]
+    public async Task Diff_IdenticalSnapshots_ReturnsEmptyPatchArray()
+    {
+        var snap = SnapshotWith(policies: new[] { Policy() });
+        var (svc, _, fromId, toId) = await BuildPairAsync(snap, snap);
+
+        var result = await svc.DiffAsync(fromId, toId);
+
+        result.Should().NotBeNull();
+        result!.Rfc6902PatchJson.Should().Be(
+            "[]",
+            "logically identical snapshots emit no ops; canonical-JSON form " +
+            "from P8.2 makes the byte-comparison trivially succeed");
+        result.OpCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Diff_PolicyEnforcementChanged_EmitsReplaceOp_OnEnforcementPath()
+    {
+        var pid = Guid.Parse("aaaaaaaa-1111-1111-1111-111111111111");
+        var from = SnapshotWith(policies: new[] { Policy(pid, enforcement: "Should") });
+        var to = SnapshotWith(policies: new[] { Policy(pid, enforcement: "Must") });
+        var (svc, _, fromId, toId) = await BuildPairAsync(from, to);
+
+        var result = await svc.DiffAsync(fromId, toId);
+
+        var patch = JsonDocument.Parse(result!.Rfc6902PatchJson);
+        var ops = patch.RootElement.EnumerateArray().ToList();
+        ops.Should().ContainSingle(
+            o => o.GetProperty("op").GetString() == "replace"
+              && o.GetProperty("path").GetString() == "/Policies/0/Enforcement"
+              && o.GetProperty("value").GetString() == "Must",
+            "the differ must address the field that actually changed; a path " +
+            "of /Policies/0 (whole-policy replace) would lose the precision " +
+            "auditors rely on for grep");
+    }
+
+    [Fact]
+    public async Task Diff_BindingAdded_EmitsAddOp_AtEndOfArray()
+    {
+        var pid = Guid.Parse("aaaaaaaa-1111-1111-1111-111111111111");
+        var from = SnapshotWith(
+            policies: new[] { Policy(pid) },
+            bindings: new[] { Binding(targetRef: "repo:a") });
+        var to = SnapshotWith(
+            policies: new[] { Policy(pid) },
+            bindings: new[]
+            {
+                Binding(targetRef: "repo:a"),
+                Binding(id: Guid.Parse("99999999-9999-9999-9999-999999999999"), targetRef: "repo:b"),
+            });
+        var (svc, _, fromId, toId) = await BuildPairAsync(from, to);
+
+        var result = await svc.DiffAsync(fromId, toId);
+
+        var ops = JsonDocument.Parse(result!.Rfc6902PatchJson).RootElement.EnumerateArray().ToList();
+        ops.Should().ContainSingle(o =>
+            o.GetProperty("op").GetString() == "add"
+            && o.GetProperty("path").GetString() == "/Bindings/1");
+    }
+
+    [Fact]
+    public async Task Diff_BindingRemoved_EmitsRemoveOp_AtIndex()
+    {
+        var pid = Guid.Parse("aaaaaaaa-1111-1111-1111-111111111111");
+        var from = SnapshotWith(
+            policies: new[] { Policy(pid) },
+            bindings: new[]
+            {
+                Binding(targetRef: "repo:a"),
+                Binding(id: Guid.Parse("99999999-9999-9999-9999-999999999999"), targetRef: "repo:b"),
+            });
+        var to = SnapshotWith(
+            policies: new[] { Policy(pid) },
+            bindings: new[] { Binding(targetRef: "repo:a") });
+        var (svc, _, fromId, toId) = await BuildPairAsync(from, to);
+
+        var result = await svc.DiffAsync(fromId, toId);
+
+        var ops = JsonDocument.Parse(result!.Rfc6902PatchJson).RootElement.EnumerateArray().ToList();
+        ops.Should().ContainSingle(o =>
+            o.GetProperty("op").GetString() == "remove"
+            && o.GetProperty("path").GetString() == "/Bindings/1");
+    }
+
+    [Fact]
+    public async Task Diff_IsDeterministic_AcrossTwoInvocations()
+    {
+        var pid = Guid.Parse("aaaaaaaa-1111-1111-1111-111111111111");
+        var from = SnapshotWith(policies: new[] { Policy(pid, enforcement: "Should") });
+        var to = SnapshotWith(policies: new[] { Policy(pid, enforcement: "Must") });
+        var (svc, _, fromId, toId) = await BuildPairAsync(from, to);
+
+        var first = await svc.DiffAsync(fromId, toId);
+        var second = await svc.DiffAsync(fromId, toId);
+
+        second!.Rfc6902PatchJson.Should().Be(
+            first!.Rfc6902PatchJson,
+            "diff determinism is the floor under reproducibility — two consumers " +
+            "or two consecutive runs comparing the same pair must see byte-" +
+            "identical patches");
+    }
+
+    [Fact]
+    public async Task Diff_UnknownFromId_ReturnsNull()
+    {
+        var snap = SnapshotWith();
+        var (svc, _, _, toId) = await BuildPairAsync(snap, snap);
+
+        var result = await svc.DiffAsync(Guid.NewGuid(), toId);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Diff_SoftDeletedBundle_ReturnsNull()
+    {
+        var snap = SnapshotWith();
+        var (svc, db, fromId, toId) = await BuildPairAsync(snap, snap);
+
+        // Tombstone the from bundle directly so the load filter
+        // excludes it. Bypasses BundleService to avoid validating
+        // rationale rules in this unit test.
+        var tombstoned = await db.Bundles.FirstAsync(b => b.Id == fromId);
+        tombstoned.State = BundleState.Deleted;
+        tombstoned.DeletedAt = CapturedAt;
+        tombstoned.DeletedBySubjectId = "op";
+        await db.SaveChangesAsync();
+
+        var result = await svc.DiffAsync(fromId, toId);
+
+        result.Should().BeNull(
+            "soft-deleted bundles are invisible to the resolution surface; " +
+            "diff inherits that posture so a tombstoned bundle isn't a valid " +
+            "comparison target");
+    }
+
+    [Fact]
+    public async Task Diff_SnapshotHashes_AreEchoedInResult()
+    {
+        var snap = SnapshotWith(policies: new[] { Policy() });
+        var (svc, db, fromId, toId) = await BuildPairAsync(snap, snap);
+        var fromHash = (await db.Bundles.AsNoTracking().FirstAsync(b => b.Id == fromId)).SnapshotHash;
+        var toHash = (await db.Bundles.AsNoTracking().FirstAsync(b => b.Id == toId)).SnapshotHash;
+
+        var result = await svc.DiffAsync(fromId, toId);
+
+        result!.FromSnapshotHash.Should().Be(fromHash);
+        result.ToSnapshotHash.Should().Be(toHash);
+        result.FromId.Should().Be(fromId);
+        result.ToId.Should().Be(toId);
+    }
+}

--- a/tools/Andy.Policies.Cli/Commands/BundleCommands.cs
+++ b/tools/Andy.Policies.Cli/Commands/BundleCommands.cs
@@ -1,0 +1,244 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.CommandLine;
+using System.Net.Http.Json;
+using Andy.Policies.Cli.Http;
+using Andy.Policies.Cli.Output;
+
+namespace Andy.Policies.Cli.Commands;
+
+/// <summary>
+/// <c>andy-policies-cli bundles {create,list,get,resolve,diff}</c>
+/// (P8.6, story rivoli-ai/andy-policies#86). Mirrors the REST
+/// surface from P8.3 + the new <c>GET /api/bundles/{id}/diff</c>
+/// endpoint introduced in this story. Output flows through the
+/// shared <see cref="OutputRenderer"/> so <c>--output table|json|yaml</c>
+/// behaves the same as the other resource commands.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>HTTP-only.</b> The shared CLI stack speaks REST throughout —
+/// no <c>--grpc</c> transport switch. The gRPC <see cref="Andy.Policies.Api.GrpcServices.BundleGrpcService"/>
+/// exists for non-CLI consumers and is exercised via integration
+/// tests; the CLI keeps a single transport so error-handling +
+/// output-rendering paths stay uniform across commands.
+/// </para>
+/// <para>
+/// <b>Diff format.</b> <c>bundles diff</c> emits the RFC-6902 patch
+/// JSON verbatim by default — that's the canonical machine-readable
+/// shape consumers pipe through patch appliers. <c>--output table</c>
+/// renders one row per op for human eyeballing.
+/// </para>
+/// </remarks>
+internal static class BundleCommands
+{
+    public static void Register(
+        Command parent,
+        Option<string> apiUrlOption,
+        Option<string?> tokenOption,
+        Option<string> outputOption)
+    {
+        parent.AddCommand(BuildCreate(apiUrlOption, tokenOption, outputOption));
+        parent.AddCommand(BuildList(apiUrlOption, tokenOption, outputOption));
+        parent.AddCommand(BuildGet(apiUrlOption, tokenOption, outputOption));
+        parent.AddCommand(BuildResolve(apiUrlOption, tokenOption, outputOption));
+        parent.AddCommand(BuildDiff(apiUrlOption, tokenOption, outputOption));
+    }
+
+    private static Command BuildCreate(Option<string> apiUrl, Option<string?> token, Option<string> output)
+    {
+        var command = new Command("create", "Create a new bundle (frozen snapshot of the live catalog).");
+        var nameOpt = new Option<string>(
+            aliases: new[] { "--name", "-n" },
+            description: "Slug, ^[a-z0-9][a-z0-9-]{0,62}$.") { IsRequired = true };
+        var rationaleOpt = new Option<string>(
+            aliases: new[] { "--rationale", "-r" },
+            description: "Required non-empty rationale captured in the audit chain.") { IsRequired = true };
+        var descriptionOpt = new Option<string?>(
+            aliases: new[] { "--description", "-d" },
+            description: "Optional human-readable description.");
+        command.AddOption(nameOpt);
+        command.AddOption(rationaleOpt);
+        command.AddOption(descriptionOpt);
+
+        command.SetHandler(async ctx =>
+        {
+            var api = ctx.ParseResult.GetValueForOption(apiUrl)!;
+            var tok = ctx.ParseResult.GetValueForOption(token);
+            var fmt = ctx.ParseResult.GetValueForOption(output) ?? "table";
+            var name = ctx.ParseResult.GetValueForOption(nameOpt)!;
+            var rationale = ctx.ParseResult.GetValueForOption(rationaleOpt)!;
+            var description = ctx.ParseResult.GetValueForOption(descriptionOpt);
+            var ct = ctx.GetCancellationToken();
+
+            using var http = ClientFactory.Create(api, tok);
+            var resp = await http.PostAsJsonAsync(
+                "/api/bundles",
+                new { name, description, rationale },
+                ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+            {
+                ctx.ExitCode = await ExitCodes.HandleAsync(resp, ct).ConfigureAwait(false);
+                return;
+            }
+            var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            OutputRenderer.Write(body, fmt);
+        });
+        return command;
+    }
+
+    private static Command BuildList(Option<string> apiUrl, Option<string?> token, Option<string> output)
+    {
+        var command = new Command("list", "List bundles (active by default).");
+        var includeDeletedOpt = new Option<bool>(
+            aliases: new[] { "--include-deleted" },
+            description: "Include soft-deleted bundles (default false).");
+        var skipOpt = new Option<int>(aliases: new[] { "--skip" }, description: "Pagination skip (default 0).");
+        var takeOpt = new Option<int>(
+            aliases: new[] { "--take" },
+            description: "Pagination take; clamped to [1, 200] (default 50).");
+        command.AddOption(includeDeletedOpt);
+        command.AddOption(skipOpt);
+        command.AddOption(takeOpt);
+
+        command.SetHandler(async ctx =>
+        {
+            var api = ctx.ParseResult.GetValueForOption(apiUrl)!;
+            var tok = ctx.ParseResult.GetValueForOption(token);
+            var fmt = ctx.ParseResult.GetValueForOption(output) ?? "table";
+            var includeDeleted = ctx.ParseResult.GetValueForOption(includeDeletedOpt);
+            var skip = ctx.ParseResult.GetValueForOption(skipOpt);
+            var take = ctx.ParseResult.GetValueForOption(takeOpt);
+            var ct = ctx.GetCancellationToken();
+
+            // The REST surface (P8.3) doesn't currently expose a list
+            // endpoint — that lands as part of this story's CLI work
+            // implicitly via /api/bundles?... — but for now, the CLI
+            // hits the existing gRPC-equivalent through REST-style
+            // query params on /api/bundles. If the REST list endpoint
+            // is missing, surface a clear NotImplemented.
+            var query = Querystring.Build(
+                ("includeDeleted", includeDeleted ? "true" : null),
+                ("skip", skip > 0 ? skip.ToString() : null),
+                ("take", take > 0 ? take.ToString() : null));
+
+            using var http = ClientFactory.Create(api, tok);
+            var resp = await http.GetAsync($"/api/bundles{query}", ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+            {
+                ctx.ExitCode = await ExitCodes.HandleAsync(resp, ct).ConfigureAwait(false);
+                return;
+            }
+            var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            OutputRenderer.Write(body, fmt);
+        });
+        return command;
+    }
+
+    private static Command BuildGet(Option<string> apiUrl, Option<string?> token, Option<string> output)
+    {
+        var command = new Command("get", "Get a bundle by id.");
+        var idArg = new Argument<Guid>("id", "Bundle id (GUID).");
+        command.AddArgument(idArg);
+
+        command.SetHandler(async ctx =>
+        {
+            var api = ctx.ParseResult.GetValueForOption(apiUrl)!;
+            var tok = ctx.ParseResult.GetValueForOption(token);
+            var fmt = ctx.ParseResult.GetValueForOption(output) ?? "table";
+            var id = ctx.ParseResult.GetValueForArgument(idArg);
+            var ct = ctx.GetCancellationToken();
+
+            using var http = ClientFactory.Create(api, tok);
+            var resp = await http.GetAsync($"/api/bundles/{id}", ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+            {
+                ctx.ExitCode = await ExitCodes.HandleAsync(resp, ct).ConfigureAwait(false);
+                return;
+            }
+            var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            OutputRenderer.Write(body, fmt);
+        });
+        return command;
+    }
+
+    private static Command BuildResolve(Option<string> apiUrl, Option<string?> token, Option<string> output)
+    {
+        var command = new Command("resolve", "Resolve bindings for a target against a frozen bundle snapshot.");
+        var idArg = new Argument<Guid>("id", "Bundle id (GUID).");
+        var targetTypeOpt = new Option<string>(
+            aliases: new[] { "--target-type" },
+            description: "One of Template, Repo, ScopeNode, Tenant, Org.") { IsRequired = true };
+        var targetRefOpt = new Option<string>(
+            aliases: new[] { "--target-ref" },
+            description: "Target reference, e.g. 'repo:rivoli-ai/conductor'.") { IsRequired = true };
+        command.AddArgument(idArg);
+        command.AddOption(targetTypeOpt);
+        command.AddOption(targetRefOpt);
+
+        command.SetHandler(async ctx =>
+        {
+            var api = ctx.ParseResult.GetValueForOption(apiUrl)!;
+            var tok = ctx.ParseResult.GetValueForOption(token);
+            var fmt = ctx.ParseResult.GetValueForOption(output) ?? "table";
+            var id = ctx.ParseResult.GetValueForArgument(idArg);
+            var targetType = ctx.ParseResult.GetValueForOption(targetTypeOpt)!;
+            var targetRef = ctx.ParseResult.GetValueForOption(targetRefOpt)!;
+            var ct = ctx.GetCancellationToken();
+
+            var query = Querystring.Build(
+                ("targetType", targetType),
+                ("targetRef", targetRef));
+
+            using var http = ClientFactory.Create(api, tok);
+            var resp = await http.GetAsync($"/api/bundles/{id}/resolve{query}", ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+            {
+                ctx.ExitCode = await ExitCodes.HandleAsync(resp, ct).ConfigureAwait(false);
+                return;
+            }
+            var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            OutputRenderer.Write(body, fmt);
+        });
+        return command;
+    }
+
+    private static Command BuildDiff(Option<string> apiUrl, Option<string?> token, Option<string> output)
+    {
+        var command = new Command(
+            "diff",
+            "Emit an RFC-6902 JSON Patch between two bundles' frozen snapshots.");
+        var fromOpt = new Option<Guid>(
+            aliases: new[] { "--from" },
+            description: "Source bundle id (GUID).") { IsRequired = true };
+        var toOpt = new Option<Guid>(
+            aliases: new[] { "--to" },
+            description: "Target bundle id (GUID).") { IsRequired = true };
+        command.AddOption(fromOpt);
+        command.AddOption(toOpt);
+
+        command.SetHandler(async ctx =>
+        {
+            var api = ctx.ParseResult.GetValueForOption(apiUrl)!;
+            var tok = ctx.ParseResult.GetValueForOption(token);
+            var fmt = ctx.ParseResult.GetValueForOption(output) ?? "table";
+            var from = ctx.ParseResult.GetValueForOption(fromOpt);
+            var to = ctx.ParseResult.GetValueForOption(toOpt);
+            var ct = ctx.GetCancellationToken();
+
+            var query = Querystring.Build(("to", to.ToString()));
+
+            using var http = ClientFactory.Create(api, tok);
+            var resp = await http.GetAsync($"/api/bundles/{from}/diff{query}", ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+            {
+                ctx.ExitCode = await ExitCodes.HandleAsync(resp, ct).ConfigureAwait(false);
+                return;
+            }
+            var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            OutputRenderer.Write(body, fmt);
+        });
+        return command;
+    }
+}

--- a/tools/Andy.Policies.Cli/Program.cs
+++ b/tools/Andy.Policies.Cli/Program.cs
@@ -76,6 +76,10 @@ internal static class Program
         AuditCommands.Register(auditCommand, apiUrlOption, tokenOption, outputOption);
         rootCommand.AddCommand(auditCommand);
 
+        var bundlesCommand = new Command("bundles", "Manage policy bundles (frozen catalog snapshots)");
+        BundleCommands.Register(bundlesCommand, apiUrlOption, tokenOption, outputOption);
+        rootCommand.AddCommand(bundlesCommand);
+
         return await rootCommand.InvokeAsync(args);
     }
 }


### PR DESCRIPTION
## Summary

Closes the parity surfaces for bundle pinning. Same service layer as REST (P8.3) and MCP (P8.5) — no duplicated business logic.

- **New `bundles.proto`** with 6 RPCs (`CreateBundle`, `ListBundles`, `GetBundle`, `ResolveBundle`, `DeleteBundle`, `DiffBundles`); `GrpcServices=Both` so integration tests get client stubs alongside the server.
- **`BundleGrpcService`** implements all 6 RPCs by delegating to `IBundleService` / `IBundleResolver` / `IBundleDiffService`. Status mapping: `ValidationException` → `InvalidArgument`; `ConflictException` → `AlreadyExists`; missing subject → `Unauthenticated`; unknown id → `NotFound`; bad GUID → `InvalidArgument`.
- **`GrpcMethodPermissionMap`** (P7.6) gains entries for all 6 RPCs (`bundle:read` for reads, `bundle:create` for create, `bundle:delete` for delete; diff is read-only). Reflective coverage test extended to walk `BundleService.BundleServiceBase` so adding a new RPC without a mapping fails CI.
- **`IBundleDiffService` + `BundleDiffService`**: walks two parsed `SnapshotJson` trees as `JsonElement`, emits RFC-6902 `add`/`remove`/`replace` ops in deterministic order (object keys sorted, arrays index-aligned, RFC 6901 path escaping). Returns `null` when either bundle is missing or soft-deleted. Two invocations on the same pair produce byte-identical patch JSON.
- **`BundlesController`**: new `GET /api/bundles/{id}/diff?to=` plus the long-deferred `POST /api/bundles`, `GET /api/bundles`, `GET /api/bundles/{id}`, `DELETE /api/bundles/{id}` (P8.3 only landed resolve / get-pinned; this story's CLI is the first REST consumer of the rest).
- **CLI**: new `BundleCommands` with `create` / `list` / `get` / `resolve` / `diff`.

Closes #86.

## Test plan

- [x] `dotnet build` clean (zero warnings under `TreatWarningsAsErrors`)
- [x] `dotnet test` — Unit 518/518 (+8 new), Integration 584/584 (+12 new), E2E 6/6
- [x] `BundleDiffServiceTests` (8 unit): identical snapshots emit `[]`; field change → `replace` at the correct path; binding add/remove → `add`/`remove` with indexed paths; **determinism** across two invocations (byte-identical patch JSON); unknown id / soft-deleted bundle → `null`; snapshot hashes echoed in result
- [x] `BundleGrpcServiceTests` (10 integration, in-process HTTP/2 channel): every RPC's happy path; create → `AlreadyExists` on duplicate active name; get → `NotFound` / `InvalidArgument` as appropriate; list reflects created bundles; delete soft-flips state + writes `bundle.delete` audit event; diff byte-identical across two invocations; diff → `NotFound` when one bundle is missing; resolve → `NotFound` / `InvalidArgument` on failure paths
- [x] `GrpcPermissionMapCoverageTests` extended — BundleService is in the enforced set, all 6 RPCs map cleanly, no stale entries
- [x] OpenAPI regenerated for the new REST endpoints (`POST /api/bundles`, `GET /api/bundles`, `GET /api/bundles/{id}`, `DELETE /api/bundles/{id}`, `GET /api/bundles/{id}/diff`)

## Notes on scope reductions

- **CLI `--grpc` transport switch** mentioned in the spec is **out of scope**. The existing CLI stack (PolicyCommands, OverrideCommands, etc.) is REST-only; adding a transport flag CLI-wide is a separate cross-cutting refactor.
- **CLI `bundles delete`** subcommand is intentionally absent — the spec listed only `{create,list,get,resolve,diff}` and the REST `DELETE /api/bundles/{id}` endpoint added here covers the soft-delete need; CLI delete can land in a follow-up if anyone asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)