### PR TITLE
Implement P10.1 — SQLite-embedded boot via MigrateAsync (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,20 @@ docker compose up -d
 docker compose -f docker-compose.embedded.yml up -d
 ```
 
+### Embedded mode notes (P10.1, [#31](https://github.com/rivoli-ai/andy-policies/issues/31))
+
+The embedded compose runs the API against a SQLite file persisted to the `sqlite_data` named volume. EF migrations apply on every boot (idempotent — `Database.MigrateAsync` writes to `__EFMigrationsHistory` on first run and short-circuits thereafter), so upgrading the image against an existing volume is safe. The boot-time stock-policy seeder (P1.3) populates the catalog only when the database is empty; restart-booting against a populated volume preserves operator edits.
+
+After `up -d`, smoke check:
+
+```bash
+sleep 15  # allow migrate + seed
+curl -fsk https://localhost:5112/health
+curl -fsk https://localhost:5112/api/policies
+```
+
+The migration / model invariants are pinned by `SqliteModelCompatibilityTests`, `SqliteMigrationApplyTests`, and `SqliteBootTests`. A change to `AppDbContext.OnModelCreating` that introduces a Postgres-only column type (`jsonb`, `timestamptz`, `text[]`) without an `IsNpgsql()` branch fails the model-compat test before merge.
+
 ## Documentation
 
 Full documentation at [rivoli-ai.github.io/andy-policies](https://rivoli-ai.github.io/andy-policies/).

--- a/scripts/export-openapi.sh
+++ b/scripts/export-openapi.sh
@@ -32,7 +32,11 @@ dotnet build "$API_PROJECT" -c Release --nologo --verbosity minimal
 # file path is wiped on each run so the seed never carries over.
 TMP_DB="$(mktemp -t andy-policies-export-openapi-XXXXXX.db)"
 trap 'rm -f "$TMP_DB"' EXIT
-ASPNETCORE_ENVIRONMENT="Testing" \
+# P10.1 (#31): use Development env so Program.cs runs MigrateAsync
+# against the empty temp SQLite — the boot-time seeder needs a
+# schema. The "Testing" env is reserved for integration tests
+# whose own factories own schema initialisation.
+ASPNETCORE_ENVIRONMENT="Development" \
 AndyAuth__Authority="https://export.invalid" \
 AndyAuth__Audience="urn:andy-policies-api" \
 AndySettings__ApiBaseUrl="https://export.invalid" \

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -474,10 +474,24 @@ if (!string.IsNullOrEmpty(connectionString))
     {
         await db.Database.MigrateAsync();
     }
-    else if (db.Database.IsSqlite()
-             && (app.Environment.IsDevelopment() || app.Environment.IsEnvironment("Testing")))
+    else if (db.Database.IsSqlite() && app.Environment.IsDevelopment())
     {
-        await db.Database.EnsureCreatedAsync();
+        // P10.1 (#31): SQLite-embedded mode (docker-compose.embedded.yml
+        // sets ASPNETCORE_ENVIRONMENT=Development) must apply
+        // migrations, not EnsureCreated. EnsureCreated skips
+        // __EFMigrationsHistory and prevents in-place upgrade
+        // against an existing sqlite_data volume; a Conductor
+        // operator updating to a newer image would otherwise lose
+        // data on schema drift. Both providers share the same
+        // migration set; BundleMigrationTests (P8.1) already proves
+        // it applies cleanly on SQLite.
+        //
+        // The Testing environment is intentionally NOT included —
+        // integration test factories (PoliciesApiFactory, etc.)
+        // own schema initialisation via their own EnsureCreated /
+        // Migrate calls, and a startup-time Migrate here would
+        // collide with the factory's pre-built schema.
+        await db.Database.MigrateAsync();
     }
 }
 

--- a/tests/Andy.Policies.Tests.Integration/Embedded/SqliteBootTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Embedded/SqliteBootTests.cs
@@ -1,0 +1,219 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Tests.Integration.Controllers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Embedded;
+
+/// <summary>
+/// P10.1 (#31): boot smoke for the SQLite-embedded profile. Spins
+/// up <see cref="WebApplicationFactory{Program}"/> with
+/// <c>Database:Provider=Sqlite</c> + a fresh temp file, hits
+/// <c>/health</c>, lists policies, and asserts the boot-time stock
+/// seeder (P1.3 #73) populated the catalog with the six canonical
+/// drafts. Acceptance test for the embedded-mode happy path.
+/// </summary>
+public class SqliteBootTests : IAsyncLifetime
+{
+    private readonly string _dbPath;
+    private EmbeddedFactory _factory = null!;
+
+    public SqliteBootTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(),
+            $"andy-policies-embedded-{Guid.NewGuid():N}.db");
+    }
+
+    public Task InitializeAsync()
+    {
+        _factory = new EmbeddedFactory(_dbPath);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _factory.Dispose();
+        if (File.Exists(_dbPath)) File.Delete(_dbPath);
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Health_AfterBoot_Returns200()
+    {
+        using var client = _factory.CreateClient();
+
+        var resp = await client.GetAsync("/health");
+
+        resp.StatusCode.Should().Be(
+            HttpStatusCode.OK,
+            "embedded mode boot must reach the health endpoint within the test " +
+            "factory's default startup window — Conductor's compose healthcheck " +
+            "depends on this");
+    }
+
+    [Fact]
+    public async Task ListPolicies_AfterBoot_ReturnsSeededStockCatalog()
+    {
+        using var client = _factory.CreateClient();
+        // The list endpoint is gated by the bundle pinning gate
+        // (P8.4 #84) when pinning is required. The embedded factory
+        // stubs IPinningPolicy with required=false (matching the
+        // standard test factory's posture) so the live list path
+        // returns the seeded catalog directly.
+
+        var resp = await client.GetAsync("/api/policies");
+
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadAsStringAsync();
+        var rows = JsonDocument.Parse(body).RootElement.EnumerateArray().ToList();
+        rows.Should().NotBeEmpty(
+            "the boot-time stock-policy seeder (P1.3) populated the catalog; " +
+            "GET /api/policies must surface those rows on a fresh embedded " +
+            "boot — that's the P10.1 smoke contract.");
+        rows.Should().HaveCountGreaterThanOrEqualTo(
+            6,
+            "there are six canonical stock policies; the seeder must land them " +
+            "all on a fresh database. A short read points at a partial seed.");
+    }
+
+    [Fact]
+    public async Task SecondBoot_AgainstSamePersistentDb_DoesNotReseed()
+    {
+        // Boot once to seed.
+        using (var firstClient = _factory.CreateClient())
+        {
+            (await firstClient.GetAsync("/health")).EnsureSuccessStatusCode();
+        }
+        var initialCount = await CountPoliciesAsync();
+
+        // Tear down + boot a second factory pointing at the same
+        // physical SQLite file. Idempotent seeding means no
+        // duplicates land — operators restarting a Conductor
+        // container would see double-seeded rows otherwise.
+        _factory.Dispose();
+        using var secondFactory = new EmbeddedFactory(_dbPath);
+        using (var secondClient = secondFactory.CreateClient())
+        {
+            (await secondClient.GetAsync("/health")).EnsureSuccessStatusCode();
+        }
+
+        var afterCount = await CountPoliciesAsync(secondFactory);
+        afterCount.Should().Be(
+            initialCount,
+            "PolicySeeder uses presence-of-any-row as the idempotency probe " +
+            "(see PolicySeeder.SeedStockPoliciesAsync); restart booting the " +
+            "embedded image must NOT re-seed.");
+    }
+
+    private async Task<int> CountPoliciesAsync(EmbeddedFactory? factory = null)
+    {
+        factory ??= _factory;
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        return await db.Policies.AsNoTracking().CountAsync();
+    }
+
+    /// <summary>
+    /// Boot the API exactly the way docker-compose.embedded.yml does:
+    /// <c>Database:Provider=Sqlite</c> + a connection string pointing
+    /// at a real file on disk (so subsequent boots see persisted
+    /// state). Mirrors the relevant bits of <see cref="PoliciesApiFactory"/>
+    /// — auth handler stubbed, RBAC stubbed allow-all, pinning gate
+    /// stubbed off — but uses Production-style migrations
+    /// (<c>db.Database.Migrate()</c>) instead of <c>EnsureCreated</c>
+    /// so the boot path matches what Conductor operators get.
+    /// </summary>
+    private sealed class EmbeddedFactory : WebApplicationFactory<Program>
+    {
+        private readonly string _dbPath;
+
+        public EmbeddedFactory(string dbPath)
+        {
+            _dbPath = dbPath;
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            // Development env so Program.cs's MigrateAsync block runs
+            // (P10.1 — the embedded-mode boot path).
+            builder.UseEnvironment("Development");
+
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Database:Provider"] = "Sqlite",
+                    ["ConnectionStrings:DefaultConnection"] = $"Data Source={_dbPath}",
+                    ["AndyAuth:Authority"] = "https://test-auth.invalid",
+                    ["AndySettings:ApiBaseUrl"] = "https://test-settings.invalid",
+                    ["AndyRbac:BaseUrl"] = "https://test-rbac.invalid",
+                });
+            });
+
+            builder.ConfigureServices(services =>
+            {
+                // The default AddAppDatabase(...) registration ran
+                // before our ConfigureAppConfiguration override took
+                // effect (it reads Database:Provider from
+                // builder.Configuration during Program.cs ordering).
+                // Strip it and re-register against our temp file —
+                // same posture as PoliciesApiFactory.
+                var ctxDescriptor = services.SingleOrDefault(d =>
+                    d.ServiceType == typeof(DbContextOptions<AppDbContext>));
+                if (ctxDescriptor is not null) services.Remove(ctxDescriptor);
+                services.AddDbContext<AppDbContext>(opts =>
+                    opts.UseSqlite($"Data Source={_dbPath}"));
+
+                services.AddAuthentication(TestAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                        TestAuthHandler.SchemeName, _ => { });
+                services.PostConfigure<AuthorizationOptions>(opts =>
+                {
+                    opts.DefaultPolicy = new AuthorizationPolicyBuilder(TestAuthHandler.SchemeName)
+                        .RequireAuthenticatedUser()
+                        .Build();
+                });
+
+                // Stub the RBAC checker to allow everything — embedded
+                // mode boots without a live andy-rbac in this test.
+                var rbacDescriptors = services
+                    .Where(d => d.ServiceType == typeof(Andy.Policies.Application.Interfaces.IRbacChecker))
+                    .ToList();
+                foreach (var d in rbacDescriptors) services.Remove(d);
+                services.AddSingleton<Andy.Policies.Application.Interfaces.IRbacChecker, AllowAllRbacChecker>();
+
+                // Stub the pinning gate off so /api/policies returns
+                // live state without ?bundleId= (matches the standard
+                // test factory's posture from P8.4).
+                var pinDescriptors = services
+                    .Where(d => d.ServiceType == typeof(Andy.Policies.Application.Interfaces.IPinningPolicy))
+                    .ToList();
+                foreach (var d in pinDescriptors) services.Remove(d);
+                services.AddSingleton<Andy.Policies.Application.Interfaces.IPinningPolicy>(
+                    new PoliciesApiFactory.StaticPinningPolicy(required: false));
+            });
+        }
+
+        private sealed class AllowAllRbacChecker : Andy.Policies.Application.Interfaces.IRbacChecker
+        {
+            public Task<Andy.Policies.Application.Interfaces.RbacDecision> CheckAsync(
+                string subjectId, string permissionCode, IReadOnlyList<string> groups,
+                string? resourceInstanceId, CancellationToken ct)
+                => Task.FromResult(new Andy.Policies.Application.Interfaces.RbacDecision(true, "embedded-test"));
+        }
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Embedded/SqliteMigrationApplyTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Embedded/SqliteMigrationApplyTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Infrastructure.Data;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Embedded;
+
+/// <summary>
+/// P10.1 (#31): every committed EF migration must apply cleanly
+/// against an in-memory SQLite connection via
+/// <see cref="DatabaseFacade.MigrateAsync"/>. This is the
+/// embedded-mode (Conductor bundled deployment) boot contract: the
+/// shared migration set survives the round-trip through the SQLite
+/// provider, populates <c>__EFMigrationsHistory</c>, and
+/// <see cref="DatabaseFacade.GetAppliedMigrationsAsync"/> returns
+/// the full ordered set after apply.
+/// </summary>
+public class SqliteMigrationApplyTests
+{
+    [Fact]
+    public async Task EveryMigration_AppliesCleanly_OnSqlite()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        await using var db = new AppDbContext(options);
+
+        await db.Database.MigrateAsync();
+
+        var applied = (await db.Database.GetAppliedMigrationsAsync()).ToList();
+        var defined = db.Database.GetMigrations().ToList();
+
+        applied.Should().BeEquivalentTo(
+            defined,
+            "every migration in the source tree must apply on SQLite; an " +
+            "embedded-mode boot reads the same migration set and would fail " +
+            "if any migration carried Postgres-only DDL. The set we apply " +
+            "must equal the set we know about — no skipped, no extras.");
+    }
+
+    [Fact]
+    public async Task MigrationApply_IsIdempotent_OnSecondRun()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        await using var db = new AppDbContext(options);
+
+        await db.Database.MigrateAsync();
+        var firstCount = (await db.Database.GetAppliedMigrationsAsync()).Count();
+
+        // Second migrate against the same connection should be a
+        // no-op — Conductor operators restart containers; without
+        // idempotency they'd hit "table X already exists" on every
+        // restart against an existing sqlite_data volume.
+        await db.Database.MigrateAsync();
+        var secondCount = (await db.Database.GetAppliedMigrationsAsync()).Count();
+
+        secondCount.Should().Be(firstCount,
+            "MigrateAsync must be safe to call on every boot — it's the " +
+            "default startup path for embedded mode now (P10.1)");
+    }
+
+    [Fact]
+    public async Task MigrationsHistoryTable_IsPopulated_AfterApply()
+    {
+        // EnsureCreated would skip the history table; MigrateAsync
+        // populates it. A history table is the precondition for
+        // upgrade-in-place against an existing sqlite_data volume.
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        await using var db = new AppDbContext(options);
+
+        await db.Database.MigrateAsync();
+
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText =
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='__EFMigrationsHistory'";
+        var historyTable = (string?)await cmd.ExecuteScalarAsync();
+        historyTable.Should().Be(
+            "__EFMigrationsHistory",
+            "the history table is the difference between MigrateAsync (allows " +
+            "upgrade) and EnsureCreated (one-shot init); operators upgrading " +
+            "the embedded image to a newer release require this table to exist");
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Infrastructure/SqliteModelCompatibilityTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Infrastructure/SqliteModelCompatibilityTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Infrastructure.Data;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Infrastructure;
+
+/// <summary>
+/// P10.1 (#31): pin the SQLite-portability invariant on
+/// <see cref="AppDbContext.OnModelCreating"/>. When the context is
+/// built with <c>UseSqlite</c>, no entity column may carry a
+/// Postgres-only type literal (<c>jsonb</c>, <c>timestamptz</c>,
+/// <c>uuid</c>, etc.) — embedded mode (Conductor's bundled
+/// deployment) reads the same model and the same migrations against
+/// SQLite, so a Postgres-only column type would fail at boot.
+/// </summary>
+/// <remarks>
+/// The test mirrors what an embedded-mode boot would do at startup:
+/// build the model with the SQLite provider and walk every entity's
+/// columns. A failure here means an <c>AppDbContext</c> change
+/// introduced an unguarded <c>HasColumnType("jsonb")</c> (or similar)
+/// without an <c>isNpgsql</c> branch — the existing pattern in
+/// <c>OnModelCreating</c> for jsonb / text[] columns is the
+/// reference.
+/// </remarks>
+public class SqliteModelCompatibilityTests
+{
+    /// <summary>
+    /// Postgres-only column type literals that must not appear when
+    /// the model is built with SQLite. Excludes <c>uuid</c> on
+    /// purpose — EF Core's SQLite provider transparently maps GUIDs
+    /// to <c>BLOB</c>, but the model annotations may carry the
+    /// literal as a hint without harm. The other three are hard
+    /// failures at migration time.
+    /// </summary>
+    private static readonly string[] ForbiddenColumnTypes = new[]
+    {
+        "jsonb",
+        "timestamptz",
+        "timestamp with time zone",
+        "text[]",
+    };
+
+    [Fact]
+    public void NoEntityColumn_DeclaresPostgresOnlyType_WhenContextUsesSqlite()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        using var db = new AppDbContext(options);
+
+        var offending = new List<string>();
+        foreach (var entity in db.Model.GetEntityTypes())
+        {
+            foreach (var prop in entity.GetProperties())
+            {
+                var columnType = prop.GetColumnType();
+                if (string.IsNullOrEmpty(columnType)) continue;
+                if (ForbiddenColumnTypes.Any(forbidden =>
+                    columnType.Contains(forbidden, StringComparison.OrdinalIgnoreCase)))
+                {
+                    offending.Add($"{entity.Name}.{prop.Name} = '{columnType}'");
+                }
+            }
+        }
+
+        offending.Should().BeEmpty(
+            "embedded mode (P10.1 #31) reads the same model against SQLite. A " +
+            "Postgres-only column type without an isNpgsql() branch in " +
+            "OnModelCreating would fail at boot for Conductor operators. " +
+            "Use the existing isNpgsql conditional pattern (see PolicyVersion." +
+            "RulesJson, AuditEvent.FieldDiffJson) to fork the type per provider.");
+    }
+
+    [Fact]
+    public void EveryEntityType_IsBuildable_AgainstSqliteProvider()
+    {
+        // Sanity: a model that throws on Build means we'd never even
+        // reach migration. Defensive against future entity changes
+        // that misuse provider-specific configuration.
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        using var db = new AppDbContext(options);
+
+        var entityCount = db.Model.GetEntityTypes().Count();
+        entityCount.Should().BeGreaterThan(0,
+            "AppDbContext must register at least one entity under SQLite; " +
+            "an empty model means OnModelCreating shorted out somewhere");
+    }
+}


### PR DESCRIPTION
## Summary

Switches the embedded mode boot path (Conductor bundled deployment) from `EnsureCreatedAsync` to `MigrateAsync` so operators upgrading against an existing `sqlite_data` volume don't lose data on schema drift.

- **`Program.cs` SQLite branch (Development env)**: `MigrateAsync` replaces `EnsureCreatedAsync`. The migration set is provider-shared with Postgres; `BundleMigrationTests` (P8.1) already proves it applies cleanly on SQLite. The `Testing` environment is intentionally excluded so test factories own schema initialisation without collision.
- **`scripts/export-openapi.sh`**: `ASPNETCORE_ENVIRONMENT` switches from `Testing` to `Development` so Program.cs's `MigrateAsync` block runs against the empty temp SQLite — the boot-time seeder needs a schema to land into.

Closes #31. **Starts Epic P10 (#10).**

## Test plan

- [x] `dotnet build` clean (zero warnings under `TreatWarningsAsErrors`)
- [x] `dotnet test` — Unit 520/520 (+2 new), Integration 598/598 (+6 new), E2E 6/6
- [x] `SqliteModelCompatibilityTests` (2 unit): model walk against `UseSqlite` asserts no Postgres-only column type literal (`jsonb`, `timestamptz`, `text[]`) escapes the `isNpgsql()` branch in `OnModelCreating`
- [x] `SqliteMigrationApplyTests` (3 integration): every committed migration applies cleanly on in-memory SQLite; `MigrateAsync` is idempotent on second call; `__EFMigrationsHistory` is populated
- [x] `SqliteBootTests` (3 integration): end-to-end boot against a fresh SQLite file via `WebApplicationFactory<Program>` with Development env; `/health` returns 200; `/api/policies` surfaces the seeded stock policies; second boot against the same persistent file does NOT re-seed
- [x] `./scripts/export-openapi.sh` still produces a clean diff under the new Development env

🤖 Generated with [Claude Code](https://claude.com/claude-code)