### PR TITLE
Implement P10.2 — reverse-proxy pathbase support (#35)

### DIFF
--- a/docker-compose.embedded.yml
+++ b/docker-compose.embedded.yml
@@ -17,6 +17,13 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=https://+:8443;http://+:8080
+      # P10.2 (#35): Conductor's embedded reverse proxy on :9100
+      # routes /policies/* here. UsePathBase strips the prefix
+      # before routing matches and re-prepends on outbound URL
+      # generation (Swagger servers, OIDC redirect_uri via the
+      # SPA's <base href>). Empty in Modes 1/2 — only set when
+      # the API is actually running behind the embedded proxy.
+      - ASPNETCORE_PATHBASE=/policies
       - Database__Provider=Sqlite
       - ConnectionStrings__DefaultConnection=Data Source=/data/andy_policies.db
       - AndyAuth__Authority=https://host.docker.internal:5001
@@ -33,7 +40,11 @@ services:
       - sqlite_data:/data
       - dpkeys:/app/.aspnet/DataProtection-Keys
     healthcheck:
-      test: ["CMD", "curl", "-fk", "https://localhost:8443/health"]
+      # P10.2 (#35): probe the prefixed path so the healthcheck
+      # exercises the same route Conductor's proxy reaches.
+      # UsePathBase is non-enforcing, so /health would also work
+      # — but using the prefix keeps the smoke contract honest.
+      test: ["CMD", "curl", "-fk", "https://localhost:8443/policies/health"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -418,6 +418,35 @@ builder.Services
 
 var app = builder.Build();
 
+// --- Reverse-proxy pathbase (P10.2, #35) ---
+// In Conductor's embedded mode (Mode 3), a single reverse proxy on
+// :9100 routes by URL prefix — `/policies/*` is forwarded here.
+// `UsePathBase` strips the prefix off inbound requests before
+// routing matches and re-prepends it on outbound URL generation
+// (Swagger `servers`, OIDC redirect_uri via the SPA's <base href>,
+// LinkGenerator). Order is load-bearing: this MUST run before any
+// endpoint-mapping middleware, before UseRouting / UseAuthentication
+// / UseAuthorization, and before MapFallbackToFile so the SPA
+// mounts under the prefix too.
+//
+// Modes 1 + 2 leave ASPNETCORE_PATHBASE empty; the call no-ops and
+// routes resolve at the root. The `embeddedProxyPrefix` from
+// config/registration.json is the canonical source for the value
+// (`/policies` today).
+var pathBase = builder.Configuration["AspNetCore:PathBase"]
+    ?? Environment.GetEnvironmentVariable("ASPNETCORE_PATHBASE")
+    ?? string.Empty;
+if (!string.IsNullOrEmpty(pathBase))
+{
+    app.UsePathBase(pathBase);
+}
+// Explicit UseRouting after UsePathBase so the implicit insertion
+// from Map* calls below doesn't position routing before pathbase
+// (would route on the prefixed path against un-prefixed registered
+// routes → 404). With pathbase empty, this is equivalent to the
+// implicit behavior anyway.
+app.UseRouting();
+
 // --- Middleware ---
 // Swagger document + UI are exposed in Development and the integration-test
 // "Testing" environment. The OpenAPI document drives the committed

--- a/tests/Andy.Policies.Tests.Integration/Embedded/PathBaseTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Embedded/PathBaseTests.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using Andy.Policies.Tests.Integration.Controllers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Embedded;
+
+/// <summary>
+/// P10.2 (#35): with <c>AspNetCore:PathBase=/policies</c> set,
+/// every API and SPA route mounts under <c>/policies/*</c>.
+/// Conductor's embedded reverse proxy strips the prefix before
+/// forwarding here; if pathbase wiring is wrong, every route
+/// 404s either inbound (prefix not stripped) or outbound
+/// (Swagger / OIDC redirects use the wrong base).
+/// </summary>
+public class PathBaseTests : IClassFixture<PoliciesApiFactory>, IDisposable
+{
+    private const string Prefix = "/policies";
+
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public PathBaseTests(PoliciesApiFactory baseFactory)
+    {
+        // Set the env var BEFORE the factory's host is built so
+        // Program.cs's `Environment.GetEnvironmentVariable("ASPNETCORE_PATHBASE")`
+        // observation picks it up. Reset on Dispose so the var
+        // doesn't bleed across test classes within the xUnit
+        // collection (process-wide state — racy without cleanup).
+        Environment.SetEnvironmentVariable("ASPNETCORE_PATHBASE", Prefix);
+        _factory = baseFactory.WithWebHostBuilder(_ => { });
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("ASPNETCORE_PATHBASE", null);
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task ApiRoute_UnderPrefix_Returns200()
+    {
+        using var client = _factory.CreateClient();
+
+        var resp = await client.GetAsync($"{Prefix}/api/policies");
+
+        resp.StatusCode.Should().Be(
+            HttpStatusCode.OK,
+            "with pathbase set, /policies/api/policies is the canonical " +
+            "route — Conductor's proxy forwards inbound /policies/* and " +
+            "UsePathBase strips the prefix before routing.");
+    }
+
+    [Fact]
+    public async Task ApiRoute_WithoutPrefix_StillRoutes()
+    {
+        // Documents the actual UsePathBase behaviour: it STRIPS the
+        // prefix when the request matches it, but does NOT enforce
+        // prefix usage. Un-prefixed requests pass through and routing
+        // matches them against the canonical un-prefixed routes.
+        // Production prefix enforcement is the reverse proxy's job,
+        // not the API's — Conductor's :9100 proxy only forwards
+        // /policies/* to here, so consumers can never reach this
+        // service through any other path.
+        using var client = _factory.CreateClient();
+
+        var resp = await client.GetAsync("/api/policies");
+
+        resp.StatusCode.Should().Be(
+            HttpStatusCode.OK,
+            "UsePathBase is non-enforcing by design; the proxy gates the " +
+            "prefix at the network edge");
+    }
+
+    [Fact]
+    public async Task Health_UnderPrefix_Returns200()
+    {
+        using var client = _factory.CreateClient();
+
+        var resp = await client.GetAsync($"{Prefix}/health");
+
+        resp.StatusCode.Should().Be(
+            HttpStatusCode.OK,
+            "the docker-compose.embedded.yml healthcheck targets " +
+            "/policies/health; if this fails the container restarts in a " +
+            "loop and Conductor never sees a healthy embedded service");
+    }
+
+    [Fact]
+    public async Task Health_WithoutPrefix_StillRoutes()
+    {
+        // Same backwards-compat story as the API route test above —
+        // un-prefixed health probes still resolve, the proxy enforces
+        // prefixed-only access at the network edge.
+        using var client = _factory.CreateClient();
+
+        var resp = await client.GetAsync("/health");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Swagger_UnderPrefix_ReturnsOpenApiDocument()
+    {
+        using var client = _factory.CreateClient();
+
+        var resp = await client.GetAsync($"{Prefix}/swagger/v1/swagger.json");
+
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadAsStringAsync();
+        body.Should().Contain("openapi",
+            "Swagger UI sits behind the same prefix as the API; consumers " +
+            "browsing /policies/swagger expect a valid OpenAPI doc");
+    }
+
+}

--- a/tests/Andy.Policies.Tests.Integration/Embedded/PathBaseUnsetTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Embedded/PathBaseUnsetTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using Andy.Policies.Tests.Integration.Controllers;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Embedded;
+
+/// <summary>
+/// P10.2 (#35) backwards compatibility: Mode 1 (<c>dotnet run</c>)
+/// and Mode 2 (<c>docker compose up</c>) leave
+/// <c>ASPNETCORE_PATHBASE</c> empty. The pathbase block in
+/// Program.cs no-ops in that case, and every route resolves at the
+/// root. Pinned here against the standard <see cref="PoliciesApiFactory"/>
+/// (which doesn't set the env var) so a future refactor that
+/// makes pathbase mandatory would fail this test before merging.
+/// </summary>
+public class PathBaseUnsetTests : IClassFixture<PoliciesApiFactory>
+{
+    private readonly PoliciesApiFactory _factory;
+
+    public PathBaseUnsetTests(PoliciesApiFactory factory)
+    {
+        // Defensive: ensure the env var leaked from PathBaseTests in
+        // the same xUnit collection isn't sticking around. The two
+        // class fixtures may run in interleaved orders depending on
+        // xunit's default parallel scheduler.
+        Environment.SetEnvironmentVariable("ASPNETCORE_PATHBASE", null);
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Health_AtRoot_Returns200()
+    {
+        using var client = _factory.CreateClient();
+
+        var resp = await client.GetAsync("/health");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK,
+            "Mode 1/2 boots without ASPNETCORE_PATHBASE; routes must remain at " +
+            "the root, otherwise existing dotnet-run / docker-compose deployments " +
+            "regress on the day P10.2 ships.");
+    }
+
+    [Fact]
+    public async Task ApiPolicies_AtRoot_Returns200()
+    {
+        using var client = _factory.CreateClient();
+
+        var resp = await client.GetAsync("/api/policies");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}


### PR DESCRIPTION
## Summary

Conductor's embedded mode (Mode 3) routes `/policies/*` through a single proxy on `:9100`. Without `UsePathBase`, every API call beneath the prefix would 404 because routing matches the prefixed path against un-prefixed registered routes. This PR adds the pathbase wiring so the API resolves cleanly behind any prefix-forwarding proxy while staying transparent in Modes 1 (`dotnet run`) and 2 (`docker compose up`).

- **`Program.cs`**: read pathbase from `AspNetCore:PathBase` config / `ASPNETCORE_PATHBASE` env var; when non-empty, call `app.UsePathBase(pathBase)` immediately after `Build()`. Then call `app.UseRouting()` explicitly so the implicit insertion triggered by the first `Map*` call doesn't position routing before pathbase — without this, routing matches the prefixed path against un-prefixed routes and every request 404s. Empty pathbase is a no-op; Mode 1/2 are unaffected.
- **`docker-compose.embedded.yml`**: set `ASPNETCORE_PATHBASE=/policies` (matches `embeddedProxyPrefix` from `config/registration.json`). Update healthcheck target to `/policies/health` so the smoke contract exercises the same route the proxy reaches.

Closes #35.

## Test plan

- [x] `dotnet build` clean (zero warnings under `TreatWarningsAsErrors`)
- [x] `dotnet test` — Unit 520/520, Integration 604/605 (the 1 flake is the pre-existing `ScopeWalkPerfTests.ResolveForScopeAsync_p99_StaysUnderBudget`, observed flaky across recent PRs), E2E 6/6
- [x] `PathBaseTests` (5 integration): factory boots with `ASPNETCORE_PATHBASE=/policies`; `/policies/api/policies` → 200; `/policies/health` → 200; `/policies/swagger/v1/swagger.json` → valid OpenAPI doc; un-prefixed `/api/policies` + `/health` still resolve (UsePathBase strips when present but is non-enforcing — proxy gates the prefix at the network edge)
- [x] `PathBaseUnsetTests` (2 integration): explicitly clears `ASPNETCORE_PATHBASE`; `/health` and `/api/policies` both return 200 against the standard `PoliciesApiFactory`. Pinned so a future refactor that makes pathbase mandatory regresses Mode 1/2 with a visible test failure.

## Scope reductions vs. spec

- **Angular SPA build configurations** (`angular.json` `embedded` configuration + `environment.embedded.ts` + `Dockerfile` `BUILD_MODE` arg) are deferred to a follow-up. The API-side pathbase wiring + tests cover the reproducible regression surface; the SPA build path is a separate cross-cut that would touch `client/angular.json` + the multi-stage `Dockerfile` and risks breaking Mode 2 builds. The OIDC redirect URIs in `config/registration.json` already include the prefix-aware callback paths, so the SPA can be wired in a focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)