### PR TITLE
Implement P10.4 — cross-service embedded smoke (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,10 @@ docker compose -f docker-compose.e2e.yml down -v
 First build is slow (8 images: 4 services × build + 4 Postgres pulls).
 Subsequent rebuilds are incremental.
 
+### Cross-service embedded smoke (P10.4, [#39](https://github.com/rivoli-ai/andy-policies/issues/39))
+
+The `EmbeddedCrossServiceSmokeTests` class in the same project drives the full catalog lifecycle (create → publish → bind → bundle → resolve → audit → verify) against the live REST surface. Used by [Conductor Epic AO](https://github.com/rivoli-ai/conductor/issues/669) via the `ANDY_POLICIES_E2E_NO_COMPOSE=1` flag so the harness owns compose; locally the fixture brings up `docker-compose.e2e.yml` itself. Every URL / credential is configurable via env var — see [`docs/embedded/cross-service-smoke.md`](docs/embedded/cross-service-smoke.md) for the full table and the harness-integration recipe.
+
 ## Docker modes
 
 ```bash

--- a/docs/embedded/cross-service-smoke.md
+++ b/docs/embedded/cross-service-smoke.md
@@ -1,0 +1,88 @@
+# Cross-service embedded smoke (P10.4)
+
+This is the andy-policies side of the [Conductor Epic AO](https://github.com/rivoli-ai/conductor/issues/669) cross-service integration suite. It boots the full ecosystem (andy-auth + andy-rbac + andy-settings + andy-policies), drives a complete catalog lifecycle through the live REST surface, and verifies the audit hash chain.
+
+The fixture lives in [`tests/Andy.Policies.Tests.E2E/EmbeddedSmoke/`](../../tests/Andy.Policies.Tests.E2E/EmbeddedSmoke/) — the `EmbeddedCrossServiceSmokeTests` class is the one Conductor's harness invokes.
+
+## What it proves
+
+`FullLifecycle_DraftPublishBindBundleResolveAuditVerify` walks seven HTTP calls in order:
+
+1. `POST /api/policies` — create stable policy + first draft version (P1).
+2. `POST /api/policies/{id}/versions/{vId}/publish` — promote to `Active` (P2).
+3. `POST /api/bindings` — bind the active version to a synthetic `repo:` target (P3).
+4. `POST /api/bundles` — snapshot the catalog (required because the manifest default for `andy.policies.bundleVersionPinning` is `true`; without a pinned bundle, resolve 400s — P8.4 gate).
+5. `GET /api/bindings/resolve?targetType=Repo&targetRef=…&bundleId={bid}` — Conductor-style read (P3.4 + P8.3).
+6. `GET /api/audit?pageSize=200` — pull the audit page; client-side `AuditChainVerifier.Verify` checks **link integrity** (no seq gaps, every `prevHash` matches the prior row's `hash`, genesis row has the 64-zero sentinel).
+7. `GET /api/audit/verify` — server-side **hash integrity** (recomputes SHA-256 over canonical-JSON payload bytes; the algorithm authority).
+
+`ResolveOnUnboundTarget_Returns404OrEmpty` proves the resolve path doesn't accidentally match-all on miss.
+
+`AuditChainVerifier_DetectsTamperedLink` is the negative-tamper assertion required by the acceptance criteria — it constructs a chain whose second event's `prevHash` is corrupted and proves the verifier rejects it.
+
+## Run recipe (local)
+
+```bash
+# 1. From the andy-policies repo root, boot the full stack.
+docker compose -f docker-compose.e2e.yml up -d --build
+
+# 2. Wait for andy-policies (compose's --wait already gates on healthcheck;
+#    this is just defensive).
+curl --retry 30 --retry-delay 2 -fsk http://localhost:7113/health
+
+# 3. Run the smoke (skipped silently without E2E_ENABLED=1).
+E2E_ENABLED=1 dotnet test tests/Andy.Policies.Tests.E2E \
+  --filter "FullyQualifiedName~EmbeddedCrossServiceSmoke"
+
+# 4. Teardown.
+docker compose -f docker-compose.e2e.yml down -v
+```
+
+The fixture itself can also drive `docker compose up`/`down` if you'd rather not orchestrate it manually — leave the stack down and just run step 3. The fixture invokes `docker compose -f $(ANDY_POLICIES_E2E_COMPOSE_FILE) up -d --wait` on `InitializeAsync` and `down -v` on disposal.
+
+## Conductor Epic AO harness contract
+
+The Conductor harness manages its own compose stack (a single combined compose for the full ecosystem behind a `:9100` reverse proxy). It points the smoke at that stack via env vars — **no andy-policies code change**:
+
+```bash
+export E2E_ENABLED=1
+export ANDY_POLICIES_E2E_NO_COMPOSE=1                              # harness owns compose
+export ANDY_POLICIES_E2E_POLICIES_BASE_URL=http://localhost:9100/policies/
+export ANDY_POLICIES_E2E_AUTH_BASE_URL=http://localhost:9100/auth/
+export ANDY_POLICIES_E2E_API_CLIENT_SECRET=<from harness's vault>
+
+dotnet test tests/Andy.Policies.Tests.E2E \
+  --filter "FullyQualifiedName~EmbeddedCrossServiceSmoke"
+```
+
+The fixture honors `ANDY_POLICIES_E2E_NO_COMPOSE=1` by skipping both compose `up` and `down` — Conductor manages the stack lifecycle.
+
+## Configurable env vars
+
+Defined in [`EmbeddedTestEnvironment.cs`](../../tests/Andy.Policies.Tests.E2E/EmbeddedSmoke/EmbeddedTestEnvironment.cs). All optional; defaults track `docker-compose.e2e.yml`'s exposed ports.
+
+| Var | Default | Purpose |
+|---|---|---|
+| `E2E_ENABLED` | unset | Master gate. Must be `1` or the suite skips silently. |
+| `ANDY_POLICIES_E2E_NO_COMPOSE` | unset | When `1`, fixture skips `docker compose up`/`down`. |
+| `ANDY_POLICIES_E2E_POLICIES_BASE_URL` | `http://localhost:7113/` | Policies REST root. |
+| `ANDY_POLICIES_E2E_AUTH_BASE_URL` | `http://localhost:7002/` | andy-auth root for the token endpoint. |
+| `ANDY_POLICIES_E2E_API_CLIENT_ID` | `andy-policies-api` | OAuth client id for `client_credentials`. |
+| `ANDY_POLICIES_E2E_API_CLIENT_SECRET` | `e2e-test-secret-not-for-production` | Dev-only default; production overrides via vault. |
+| `ANDY_POLICIES_E2E_AUDIENCE` | `urn:andy-policies-api` | Resource scope on the issued JWT. |
+| `ANDY_POLICIES_E2E_COMPOSE_FILE` | `docker-compose.e2e.yml` | Compose file the fixture brings up. |
+| `ANDY_POLICIES_E2E_COMPOSE_WAIT_SECONDS` | `90` | Health-probe deadline after `compose up`. |
+
+URLs without trailing slashes are normalised — `http://example/policies` becomes `http://example/policies/` so `Uri` composition with relative paths (`health`, `api/policies`) lands correctly.
+
+## Why a synthetic repo target?
+
+The smoke uses `repo:rivoli-ai/smoke-{guid}` as the binding target instead of one of the seeded scope nodes. Two reasons:
+
+- Reruns against the same persistent volume don't collide — every run gets a fresh GUID-suffixed slug + target.
+- Avoids depending on stock-policy seeding ordering or scope-tree shape, both of which can shift epic-to-epic without breaking this story's contract.
+
+## Known gaps / follow-ups
+
+- **CI gate** — there's no `e2e-embedded-smoke` job in `ci.yml` yet. The pattern from `docker-compose.e2e.yml`'s existing usage applies; gate behind a `run-e2e` PR label or `workflow_dispatch` so it doesn't slow day-to-day CI. Tracked as a P10.4 follow-up.
+- **Conductor :9100 proxy** — `docker-compose.e2e.yml` exposes services directly on host ports; the embedded `:9100` reverse proxy is owned by Conductor and is not booted here. The smoke targets the direct ports locally and is overridable for harness use.

--- a/tests/Andy.Policies.Tests.E2E/Andy.Policies.Tests.E2E.csproj
+++ b/tests/Andy.Policies.Tests.E2E/Andy.Policies.Tests.E2E.csproj
@@ -11,6 +11,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- P10.4 (#39): the cross-service smoke fixtures + AuditChainVerifier
+         carry internal seams (env-reader injection, process-starter
+         injection) that Tests.Unit pokes at to prove the no-hard-code
+         contract without standing up a real stack. -->
+    <InternalsVisibleTo Include="Andy.Policies.Tests.Unit" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/tests/Andy.Policies.Tests.E2E/EmbeddedSmoke/AuditChainVerifier.cs
+++ b/tests/Andy.Policies.Tests.E2E/EmbeddedSmoke/AuditChainVerifier.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+
+namespace Andy.Policies.Tests.E2E.EmbeddedSmoke;
+
+/// <summary>
+/// Client-side hash-chain link verifier for the audit surface. Used by
+/// the cross-service smoke test (P10.4, story
+/// rivoli-ai/andy-policies#39) to assert chain integrity over a list
+/// of <see cref="AuditEventDto"/>s pulled from
+/// <c>GET /api/audit</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>What it verifies.</b> Sequence monotonicity (no gaps, strict +1
+/// step) and chain linkage — every event's <c>PrevHashHex</c> must
+/// equal the previous event's <c>HashHex</c>, and the very first
+/// event's <c>PrevHashHex</c> must be the genesis sentinel
+/// (64 zero chars).
+/// </para>
+/// <para>
+/// <b>What it does NOT verify.</b> The actual SHA-256 over canonical
+/// payload bytes — that's the server's responsibility via
+/// <c>GET /api/audit/verify</c>, which holds the canonical-JSON
+/// algorithm and the source-of-truth payload. Recomputing on the
+/// client would (a) require importing the Shared canonicaliser and
+/// (b) drift silently if either side changes the algorithm. The smoke
+/// test calls both — this verifier catches reordering / pagination
+/// bugs / severed prevHash links; the server endpoint catches payload
+/// tampering.
+/// </para>
+/// </remarks>
+public static class AuditChainVerifier
+{
+    /// <summary>The 64-zero-char sentinel used as <c>PrevHashHex</c> for the genesis row.</summary>
+    public const string GenesisPrevHash = "0000000000000000000000000000000000000000000000000000000000000000";
+
+    /// <summary>
+    /// Verifies the chain link integrity of <paramref name="events"/>.
+    /// Returns <c>(true, null)</c> when valid; otherwise
+    /// <c>(false, reason)</c> describing the first fault.
+    /// </summary>
+    /// <param name="events">Events ordered ascending by
+    /// <see cref="AuditEventDto.Seq"/>. The verifier does not re-sort
+    /// — that's intentional, so a server that returns out-of-order
+    /// pages is detected.</param>
+    /// <param name="expectFromGenesis">When true (default for full-
+    /// catalog scans), the first event must be seq=1 with the genesis
+    /// prevHash. When false (sub-range checks), only adjacency is
+    /// enforced.</param>
+    public static (bool Valid, string? Reason) Verify(
+        IReadOnlyList<AuditEventDto> events,
+        bool expectFromGenesis = false)
+    {
+        if (events.Count == 0)
+        {
+            return (false, "audit chain is empty — no events to verify.");
+        }
+
+        for (var i = 0; i < events.Count; i++)
+        {
+            var current = events[i];
+            if (i == 0)
+            {
+                if (expectFromGenesis)
+                {
+                    if (current.Seq != 1)
+                        return (false, $"expected seq=1 at chain start, got seq={current.Seq}.");
+                    if (!string.Equals(current.PrevHashHex, GenesisPrevHash, StringComparison.OrdinalIgnoreCase))
+                        return (false, $"genesis row prevHash must be 64 zero chars, got '{current.PrevHashHex}'.");
+                }
+                continue;
+            }
+
+            var previous = events[i - 1];
+            if (current.Seq != previous.Seq + 1)
+            {
+                return (false,
+                    $"seq gap between events: previous seq={previous.Seq}, current seq={current.Seq} (expected {previous.Seq + 1}).");
+            }
+            if (!string.Equals(current.PrevHashHex, previous.HashHex, StringComparison.OrdinalIgnoreCase))
+            {
+                return (false,
+                    $"chain link broken at seq={current.Seq}: prevHash='{current.PrevHashHex}' does not match previous hash='{previous.HashHex}'.");
+            }
+        }
+
+        return (true, null);
+    }
+}

--- a/tests/Andy.Policies.Tests.E2E/EmbeddedSmoke/DockerComposeHelper.cs
+++ b/tests/Andy.Policies.Tests.E2E/EmbeddedSmoke/DockerComposeHelper.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Diagnostics;
+
+namespace Andy.Policies.Tests.E2E.EmbeddedSmoke;
+
+/// <summary>
+/// Wraps <c>docker compose up -d --wait</c> / <c>down -v</c> for the
+/// cross-service smoke fixture. Honors
+/// <see cref="EmbeddedTestEnvironment.NoComposeFlag"/> — when set, both
+/// <see cref="UpAsync"/> and <see cref="DownAsync"/> are no-ops, which
+/// is the contract Conductor Epic AO's harness relies on (the harness
+/// owns its own compose stack).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why shell out instead of using a Docker SDK?</b> The fixture has
+/// to match what an operator would run by hand. Shelling guarantees
+/// the same compose engine resolves images, networks, and `additional_contexts`
+/// the same way locally and on CI. Adding a Docker SDK dependency would
+/// also pull native bindings into our test stack for marginal benefit.
+/// </para>
+/// <para>
+/// <b>--wait.</b> Compose's built-in healthcheck wait (since v2) blocks
+/// until each service's healthcheck passes. The fixture still runs an
+/// HTTP-level health probe afterwards as belt-and-braces, but
+/// <c>--wait</c> means we don't see "connection refused" on the first
+/// few requests after up.
+/// </para>
+/// </remarks>
+public sealed class DockerComposeHelper
+{
+    private readonly EmbeddedTestEnvironment _env;
+    private readonly string _workingDirectory;
+    private readonly Func<ProcessStartInfo, Process?> _startProcess;
+
+    public DockerComposeHelper(EmbeddedTestEnvironment env, string workingDirectory)
+        : this(env, workingDirectory, Process.Start)
+    {
+    }
+
+    /// <summary>Test seam — substitute the process starter for unit tests.</summary>
+    internal DockerComposeHelper(
+        EmbeddedTestEnvironment env,
+        string workingDirectory,
+        Func<ProcessStartInfo, Process?> startProcess)
+    {
+        _env = env;
+        _workingDirectory = workingDirectory;
+        _startProcess = startProcess;
+    }
+
+    public bool DidStartCompose { get; private set; }
+
+    public async Task UpAsync(CancellationToken ct)
+    {
+        if (_env.SkipCompose) return;
+
+        await RunAsync(
+            new[] { "compose", "-f", _env.ComposeFile, "up", "-d", "--wait" },
+            timeoutSeconds: Math.Max(_env.ComposeWaitSeconds, 120),
+            ct);
+        DidStartCompose = true;
+    }
+
+    public async Task DownAsync(CancellationToken ct)
+    {
+        if (_env.SkipCompose) return;
+        if (!DidStartCompose) return;
+
+        await RunAsync(
+            new[] { "compose", "-f", _env.ComposeFile, "down", "-v" },
+            timeoutSeconds: 60,
+            ct);
+        DidStartCompose = false;
+    }
+
+    private async Task RunAsync(string[] args, int timeoutSeconds, CancellationToken ct)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "docker",
+            WorkingDirectory = _workingDirectory,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+
+        var process = _startProcess(psi)
+            ?? throw new InvalidOperationException(
+                $"Failed to start `docker {string.Join(' ', args)}` — is Docker installed?");
+
+        using var combined = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        combined.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
+
+        try
+        {
+            await process.WaitForExitAsync(combined.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            throw new TimeoutException(
+                $"`docker {string.Join(' ', args)}` exceeded {timeoutSeconds}s.");
+        }
+
+        if (process.ExitCode != 0)
+        {
+            var stdout = await process.StandardOutput.ReadToEndAsync(ct).ConfigureAwait(false);
+            var stderr = await process.StandardError.ReadToEndAsync(ct).ConfigureAwait(false);
+            throw new InvalidOperationException(
+                $"`docker {string.Join(' ', args)}` exited {process.ExitCode}.\nstdout: {stdout}\nstderr: {stderr}");
+        }
+    }
+}

--- a/tests/Andy.Policies.Tests.E2E/EmbeddedSmoke/EmbeddedCrossServiceSmokeTests.cs
+++ b/tests/Andy.Policies.Tests.E2E/EmbeddedSmoke/EmbeddedCrossServiceSmokeTests.cs
@@ -1,0 +1,240 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Enums;
+using Xunit;
+
+namespace Andy.Policies.Tests.E2E.EmbeddedSmoke;
+
+/// <summary>
+/// P10.4 (rivoli-ai/andy-policies#39) — cross-service embedded smoke.
+/// Drives the full lifecycle through the live REST surface against a
+/// running stack (default: <c>docker-compose.e2e.yml</c>; overridable
+/// via env vars per <see cref="EmbeddedTestEnvironment"/>):
+/// <list type="number">
+///   <item><c>POST /api/policies</c> — create + first draft version.</item>
+///   <item><c>POST /api/policies/{id}/versions/{vId}/publish</c> — Active.</item>
+///   <item><c>POST /api/bindings</c> — bind Active version to a synthetic repo target.</item>
+///   <item><c>POST /api/bundles</c> — snapshot the catalog (required for resolve under bundle pinning).</item>
+///   <item><c>GET /api/bindings/resolve?bundleId=...</c> — Conductor-style read.</item>
+///   <item><c>GET /api/audit</c> + chain link verification on the client.</item>
+///   <item><c>GET /api/audit/verify</c> — server-side hash chain verification.</item>
+/// </list>
+/// Plus a negative test that proves <see cref="AuditChainVerifier"/>
+/// detects a deliberately-tampered chain (link severance) — the
+/// acceptance criterion's tamper assertion.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Skip when E2E_ENABLED is not 1.</b> Mirrors
+/// <c>EndToEndAuthSmokeTest</c> so dev-machine <c>dotnet test</c> runs
+/// without Docker stay green. CI gates this behind a label or workflow
+/// dispatch (deferred to a follow-up); Conductor Epic AO sets the flag
+/// + <c>ANDY_POLICIES_E2E_NO_COMPOSE=1</c> so it manages compose itself.
+/// </para>
+/// <para>
+/// <b>Why a synthetic Repo target?</b> Avoids depending on seeded scope
+/// nodes or stock policies — the smoke creates everything it needs and
+/// keys on a fresh GUID-suffixed repo ref so reruns against the same
+/// volume don't collide.
+/// </para>
+/// </remarks>
+public sealed class EmbeddedCrossServiceSmokeTests : IClassFixture<EmbeddedSmokeFixture>
+{
+    private readonly EmbeddedSmokeFixture _fx;
+
+    public EmbeddedCrossServiceSmokeTests(EmbeddedSmokeFixture fx)
+    {
+        _fx = fx;
+    }
+
+    [Fact]
+    [Trait("Category", "E2E")]
+    public async Task FullLifecycle_DraftPublishBindBundleResolveAuditVerify()
+    {
+        if (!_fx.IsEnabled || _fx.PoliciesClient is null) return;
+
+        var http = _fx.PoliciesClient;
+        var slug = $"e2e-smoke-{Guid.NewGuid():N}".Substring(0, 24);
+        var targetRef = $"repo:rivoli-ai/smoke-{Guid.NewGuid():N}";
+
+        // 1. Create policy + first draft version.
+        var createReq = new CreatePolicyRequest(
+            Name: slug,
+            Description: "P10.4 cross-service smoke",
+            Summary: "smoke",
+            Enforcement: "Must",
+            Severity: "Critical",
+            Scopes: new[] { "prod" },
+            RulesJson: "{}");
+        var createResp = await http.PostAsJsonAsync("api/policies", createReq);
+        Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
+        var draft = await ReadJsonAsync<PolicyVersionDto>(createResp);
+        Assert.Equal("Draft", draft.State);
+        Assert.Equal(1, draft.Version);
+
+        // 2. Publish the draft.
+        var publishResp = await http.PostAsJsonAsync(
+            $"api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
+            new LifecycleTransitionRequest(Rationale: "smoke publish"));
+        Assert.Equal(HttpStatusCode.OK, publishResp.StatusCode);
+        var active = await ReadJsonAsync<PolicyVersionDto>(publishResp);
+        Assert.Equal("Active", active.State);
+        Assert.Equal(draft.Id, active.Id);
+
+        // 3. Bind the active version to a synthetic repo target.
+        var bindReq = new CreateBindingRequest(
+            PolicyVersionId: active.Id,
+            TargetType: BindingTargetType.Repo,
+            TargetRef: targetRef,
+            BindStrength: BindStrength.Mandatory);
+        var bindResp = await http.PostAsJsonAsync("api/bindings", bindReq);
+        Assert.Equal(HttpStatusCode.Created, bindResp.StatusCode);
+        var binding = await ReadJsonAsync<BindingDto>(bindResp);
+        Assert.Equal(active.Id, binding.PolicyVersionId);
+
+        // 4. Bundle the catalog so the pinning gate (default ON) lets
+        //    resolve through.
+        var bundleReq = new CreateBundleRequest(
+            Name: $"smoke-bundle-{Guid.NewGuid():N}".Substring(0, 24),
+            Description: "P10.4 smoke",
+            Rationale: "smoke bundle");
+        var bundleResp = await http.PostAsJsonAsync("api/bundles", bundleReq);
+        Assert.Equal(HttpStatusCode.Created, bundleResp.StatusCode);
+        var bundle = await ReadJsonAsync<BundleDto>(bundleResp);
+
+        // 5. Resolve the binding through the Conductor-style read path.
+        var resolveResp = await http.GetAsync(
+            $"api/bindings/resolve?targetType={BindingTargetType.Repo}&targetRef={Uri.EscapeDataString(targetRef)}&bundleId={bundle.Id}");
+        Assert.Equal(HttpStatusCode.OK, resolveResp.StatusCode);
+        var resolved = await ReadJsonAsync<ResolveBindingsResponse>(resolveResp);
+        Assert.Equal(targetRef, resolved.TargetRef);
+        Assert.Contains(resolved.Bindings, b => b.PolicyVersionId == active.Id);
+
+        // 6. Audit page — must include events for our slug.
+        var auditResp = await http.GetAsync("api/audit?pageSize=200");
+        Assert.Equal(HttpStatusCode.OK, auditResp.StatusCode);
+        var page = await ReadJsonAsync<AuditPageDto>(auditResp);
+        Assert.NotEmpty(page.Items);
+
+        var ourPolicyEvents = page.Items
+            .Where(e => e.EntityId == active.PolicyId.ToString()
+                        || e.EntityId == active.Id.ToString())
+            .ToList();
+        Assert.NotEmpty(ourPolicyEvents);
+
+        // Client-side chain link integrity over the page (server returns
+        // descending by seq; we sort ascending for the verifier).
+        var ascending = page.Items.OrderBy(e => e.Seq).ToList();
+        var (linkValid, linkReason) = AuditChainVerifier.Verify(ascending,
+            expectFromGenesis: ascending[0].Seq == 1);
+        Assert.True(linkValid, linkReason);
+
+        // 7. Server-side chain hash verification — the canonical assertion.
+        var verifyResp = await http.GetAsync("api/audit/verify");
+        Assert.Equal(HttpStatusCode.OK, verifyResp.StatusCode);
+        var verification = await ReadJsonAsync<ChainVerificationDto>(verifyResp);
+        Assert.True(verification.Valid,
+            $"server audit chain reported invalid; firstDivergenceSeq={verification.FirstDivergenceSeq}");
+    }
+
+    [Fact]
+    [Trait("Category", "E2E")]
+    public async Task ResolveOnUnboundTarget_Returns404OrEmpty()
+    {
+        if (!_fx.IsEnabled || _fx.PoliciesClient is null) return;
+
+        // The pinning gate requires a bundle even for a miss — list
+        // the most recent live bundle (or create one if the catalog is
+        // empty of bundles, which is unlikely here since the happy
+        // path test creates one). Any 2xx body is acceptable as the
+        // pin source; we only care about resolve's behaviour for an
+        // unknown target.
+        var http = _fx.PoliciesClient;
+        var bundles = await http.GetFromJsonAsync<List<BundleDto>>("api/bundles?take=1");
+        Assert.NotNull(bundles);
+        if (bundles!.Count == 0)
+        {
+            // No prior bundle — make one so resolve has a pin target.
+            var bundleResp = await http.PostAsJsonAsync("api/bundles",
+                new CreateBundleRequest(
+                    Name: $"smoke-empty-{Guid.NewGuid():N}".Substring(0, 24),
+                    Description: null,
+                    Rationale: "smoke empty"));
+            bundleResp.EnsureSuccessStatusCode();
+            bundles.Add((await ReadJsonAsync<BundleDto>(bundleResp))!);
+        }
+        var pin = bundles[0];
+        var unknownRef = $"repo:rivoli-ai/no-such-{Guid.NewGuid():N}";
+
+        var resp = await http.GetAsync(
+            $"api/bindings/resolve?targetType={BindingTargetType.Repo}&targetRef={Uri.EscapeDataString(unknownRef)}&bundleId={pin.Id}");
+        // The resolver returns 200 with an empty list for misses (P3.4
+        // / P8.3 behaviour) — empty is the contract, not 404. We
+        // accept either to keep the test resilient against future
+        // tightening.
+        Assert.True(resp.StatusCode is HttpStatusCode.OK or HttpStatusCode.NotFound,
+            $"expected 200 or 404 for unbound target, got {(int)resp.StatusCode}");
+        if (resp.StatusCode == HttpStatusCode.OK)
+        {
+            var body = await ReadJsonAsync<ResolveBindingsResponse>(resp);
+            Assert.Empty(body.Bindings);
+        }
+    }
+
+    [Fact]
+    public void AuditChainVerifier_DetectsTamperedLink()
+    {
+        // Pure unit-style assertion — runs whether or not the live
+        // stack is up. Acceptance criterion: the verifier detects a
+        // deliberately-tampered event and fails the test.
+        var genesis = MakeEvent(seq: 1,
+            prevHash: AuditChainVerifier.GenesisPrevHash,
+            hash: "aaaa");
+        var legitChild = MakeEvent(seq: 2, prevHash: "aaaa", hash: "bbbb");
+        var tamperedChild = legitChild with { PrevHashHex = "deadbeef" };
+
+        var (validHappy, _) = AuditChainVerifier.Verify(
+            new[] { genesis, legitChild }, expectFromGenesis: true);
+        Assert.True(validHappy);
+
+        var (validTampered, reason) = AuditChainVerifier.Verify(
+            new[] { genesis, tamperedChild }, expectFromGenesis: true);
+        Assert.False(validTampered);
+        Assert.NotNull(reason);
+        Assert.Contains("chain link broken", reason);
+    }
+
+    private static async Task<T> ReadJsonAsync<T>(HttpResponseMessage resp)
+    {
+        var body = await resp.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<T>(body, JsonOpts)
+            ?? throw new InvalidOperationException(
+                $"deserialised null from {resp.RequestMessage?.RequestUri}: {body}");
+    }
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private static AuditEventDto MakeEvent(long seq, string prevHash, string hash)
+        => new(
+            Id: Guid.NewGuid(),
+            Seq: seq,
+            PrevHashHex: prevHash,
+            HashHex: hash,
+            Timestamp: DateTimeOffset.UtcNow,
+            ActorSubjectId: "smoke",
+            ActorRoles: Array.Empty<string>(),
+            Action: "smoke.test",
+            EntityType: "Smoke",
+            EntityId: Guid.Empty.ToString(),
+            FieldDiff: JsonDocument.Parse("[]").RootElement,
+            Rationale: null);
+}

--- a/tests/Andy.Policies.Tests.E2E/EmbeddedSmoke/EmbeddedSmokeFixture.cs
+++ b/tests/Andy.Policies.Tests.E2E/EmbeddedSmoke/EmbeddedSmokeFixture.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Xunit;
+
+namespace Andy.Policies.Tests.E2E.EmbeddedSmoke;
+
+/// <summary>
+/// xUnit class fixture for the cross-service embedded smoke (P10.4,
+/// rivoli-ai/andy-policies#39). On <see cref="InitializeAsync"/>:
+/// <list type="number">
+///   <item><c>docker compose up -d --wait</c> (unless
+///   <see cref="EmbeddedTestEnvironment.NoComposeFlag"/> is set) on
+///   the configured compose file.</item>
+///   <item>HTTP-level health probe on <c>{policies}/health</c>.</item>
+///   <item><c>client_credentials</c> token from <c>{auth}/connect/token</c>
+///   for the <c>andy-policies-api</c> client.</item>
+///   <item>Configures an <see cref="HttpClient"/> with the bearer token
+///   and the policies base URL set as <see cref="HttpClient.BaseAddress"/>.</item>
+/// </list>
+/// On <see cref="DisposeAsync"/>: <c>docker compose down -v</c> (unless
+/// the no-compose flag is set, or the fixture didn't start compose
+/// itself).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Skip semantics.</b> When <see cref="EmbeddedTestEnvironment.IsEnabled"/>
+/// is false, both the boot and the token acquisition are no-ops and
+/// <see cref="PoliciesClient"/> stays null. Tests gate on
+/// <see cref="IsEnabled"/> and return early, mirroring the existing
+/// <c>EndToEndAuthSmokeTest</c>. We could lift this to xUnit's Skip
+/// attribute via Xunit.SkippableFact but the pattern is already
+/// established and a return statement keeps the failure mode obvious
+/// when env isn't set up.
+/// </para>
+/// <para>
+/// <b>Working directory.</b> Compose is invoked from the repo root so
+/// <c>docker-compose.e2e.yml</c> resolves and its
+/// <c>additional_contexts</c> (e.g. <c>../andy-settings/artifacts</c>)
+/// resolve relative to the repo. The fixture walks parent directories
+/// from <see cref="AppContext.BaseDirectory"/> looking for
+/// <c>Andy.Policies.sln</c>.
+/// </para>
+/// </remarks>
+public sealed class EmbeddedSmokeFixture : IAsyncLifetime
+{
+    private readonly EmbeddedTestEnvironment _env = new();
+    private readonly HttpClient _bootstrapHttp = new();
+    private DockerComposeHelper? _compose;
+
+    public EmbeddedTestEnvironment Env => _env;
+    public bool IsEnabled => _env.IsEnabled;
+    public string AdminToken { get; private set; } = string.Empty;
+
+    /// <summary>HTTP client with bearer auth, base addressed at the policies surface. Null until <see cref="InitializeAsync"/> completes a successful boot.</summary>
+    public HttpClient? PoliciesClient { get; private set; }
+
+    public async Task InitializeAsync()
+    {
+        if (!_env.IsEnabled) return;
+
+        var repoRoot = FindRepoRoot();
+        _compose = new DockerComposeHelper(_env, repoRoot);
+        await _compose.UpAsync(CancellationToken.None).ConfigureAwait(false);
+
+        await WaitForHealthAsync(CancellationToken.None).ConfigureAwait(false);
+
+        AdminToken = await AcquireClientCredentialsTokenAsync(CancellationToken.None).ConfigureAwait(false);
+
+        PoliciesClient = new HttpClient { BaseAddress = _env.PoliciesBaseUrl };
+        PoliciesClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", AdminToken);
+    }
+
+    public async Task DisposeAsync()
+    {
+        PoliciesClient?.Dispose();
+        _bootstrapHttp.Dispose();
+        if (_compose is not null)
+        {
+            await _compose.DownAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    private async Task WaitForHealthAsync(CancellationToken ct)
+    {
+        var healthUrl = new Uri(_env.PoliciesBaseUrl, "health");
+        var deadline = DateTime.UtcNow.AddSeconds(_env.ComposeWaitSeconds);
+        Exception? last = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                var resp = await _bootstrapHttp.GetAsync(healthUrl, ct).ConfigureAwait(false);
+                if (resp.IsSuccessStatusCode) return;
+            }
+            catch (HttpRequestException ex) { last = ex; }
+            await Task.Delay(TimeSpan.FromSeconds(2), ct).ConfigureAwait(false);
+        }
+        throw new TimeoutException(
+            $"andy-policies /health did not respond 2xx within {_env.ComposeWaitSeconds}s at {healthUrl}. " +
+            $"Last error: {last?.Message ?? "(none)"}");
+    }
+
+    private async Task<string> AcquireClientCredentialsTokenAsync(CancellationToken ct)
+    {
+        var tokenUrl = new Uri(_env.AuthBaseUrl, "connect/token");
+        var form = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("grant_type", "client_credentials"),
+            new KeyValuePair<string, string>("client_id", _env.ApiClientId),
+            new KeyValuePair<string, string>("client_secret", _env.ApiClientSecret),
+            new KeyValuePair<string, string>("scope", _env.Audience),
+        });
+
+        var resp = await _bootstrapHttp.PostAsync(tokenUrl, form, ct).ConfigureAwait(false);
+        var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        if (!resp.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"andy-auth /connect/token returned {(int)resp.StatusCode} {resp.ReasonPhrase} for client {_env.ApiClientId}: {body}");
+        }
+
+        using var doc = JsonDocument.Parse(body);
+        return doc.RootElement.GetProperty("access_token").GetString()
+            ?? throw new InvalidOperationException("andy-auth returned no access_token in body.");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Andy.Policies.sln")))
+        {
+            dir = dir.Parent;
+        }
+        return dir?.FullName
+            ?? throw new InvalidOperationException(
+                $"Could not locate Andy.Policies.sln walking up from {AppContext.BaseDirectory}.");
+    }
+}

--- a/tests/Andy.Policies.Tests.E2E/EmbeddedSmoke/EmbeddedTestEnvironment.cs
+++ b/tests/Andy.Policies.Tests.E2E/EmbeddedSmoke/EmbeddedTestEnvironment.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Tests.E2E.EmbeddedSmoke;
+
+/// <summary>
+/// P10.4 (rivoli-ai/andy-policies#39) — environment-driven config for
+/// the cross-service embedded smoke. Every endpoint, credential, and
+/// orchestration flag comes from an env var so the same suite can run
+/// (a) locally against <c>docker-compose.e2e.yml</c>, (b) under
+/// Conductor Epic AO's harness against a <c>:9100/policies</c> proxy,
+/// or (c) on CI against any other equivalent stack — without code
+/// changes.
+/// </summary>
+/// <remarks>
+/// Defaults track <c>docker-compose.e2e.yml</c>'s exposed ports so a
+/// fresh local boot picks up sensible values. Every default is
+/// overridable; tests must never bake URLs in.
+/// </remarks>
+public sealed class EmbeddedTestEnvironment
+{
+    public const string EnabledFlag = "E2E_ENABLED";
+    public const string NoComposeFlag = "ANDY_POLICIES_E2E_NO_COMPOSE";
+
+    public const string PoliciesBaseUrlVar = "ANDY_POLICIES_E2E_POLICIES_BASE_URL";
+    public const string AuthBaseUrlVar = "ANDY_POLICIES_E2E_AUTH_BASE_URL";
+    public const string ApiClientIdVar = "ANDY_POLICIES_E2E_API_CLIENT_ID";
+    public const string ApiClientSecretVar = "ANDY_POLICIES_E2E_API_CLIENT_SECRET";
+    public const string AudienceVar = "ANDY_POLICIES_E2E_AUDIENCE";
+    public const string ComposeFileVar = "ANDY_POLICIES_E2E_COMPOSE_FILE";
+    public const string ComposeWaitSecondsVar = "ANDY_POLICIES_E2E_COMPOSE_WAIT_SECONDS";
+
+    private readonly Func<string, string?> _read;
+
+    public EmbeddedTestEnvironment()
+        : this(Environment.GetEnvironmentVariable)
+    {
+    }
+
+    /// <summary>Test seam — pass a custom env reader for unit tests.</summary>
+    internal EmbeddedTestEnvironment(Func<string, string?> read)
+    {
+        _read = read;
+    }
+
+    /// <summary>
+    /// Whether the suite is enabled at all. Mirrors the
+    /// <c>EndToEndAuthSmokeTest</c> gate so dev-machine
+    /// <c>dotnet test</c> runs (no Docker) skip silently.
+    /// </summary>
+    public bool IsEnabled =>
+        string.Equals(_read(EnabledFlag), "1", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Skip <c>docker compose up</c>/<c>down</c> from the fixture —
+    /// stack is managed externally (Conductor Epic AO harness pattern).
+    /// </summary>
+    public bool SkipCompose =>
+        string.Equals(_read(NoComposeFlag), "1", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Base URL for andy-policies (path-prefix included if any).
+    /// Defaults to the e2e compose's exposed andy-policies port.
+    /// Conductor harness overrides to <c>http://localhost:9100/policies/</c>.
+    /// </summary>
+    public Uri PoliciesBaseUrl => ParseUri(PoliciesBaseUrlVar, "http://localhost:7113/");
+
+    /// <summary>
+    /// Base URL for andy-auth. Defaults to the e2e compose port.
+    /// Conductor harness overrides to <c>http://localhost:9100/auth/</c>.
+    /// </summary>
+    public Uri AuthBaseUrl => ParseUri(AuthBaseUrlVar, "http://localhost:7002/");
+
+    public string ApiClientId =>
+        _read(ApiClientIdVar) ?? "andy-policies-api";
+
+    public string ApiClientSecret =>
+        _read(ApiClientSecretVar) ?? "e2e-test-secret-not-for-production";
+
+    public string Audience =>
+        _read(AudienceVar) ?? "urn:andy-policies-api";
+
+    /// <summary>Compose file the fixture starts when <see cref="SkipCompose"/> is false.</summary>
+    public string ComposeFile =>
+        _read(ComposeFileVar) ?? "docker-compose.e2e.yml";
+
+    /// <summary>
+    /// Seconds to wait for the andy-policies <c>/health</c> endpoint
+    /// to come up after <c>docker compose up</c>. Defaults to 90 —
+    /// the e2e build (4 services, .NET + Node) can be slow on first
+    /// run, especially in CI.
+    /// </summary>
+    public int ComposeWaitSeconds =>
+        int.TryParse(_read(ComposeWaitSecondsVar), out var n) && n > 0
+            ? n
+            : 90;
+
+    private Uri ParseUri(string var, string fallback)
+    {
+        var raw = _read(var);
+        var s = string.IsNullOrWhiteSpace(raw) ? fallback : raw;
+        return s.EndsWith('/') ? new Uri(s) : new Uri(s + "/");
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Andy.Policies.Tests.Unit.csproj
+++ b/tests/Andy.Policies.Tests.Unit/Andy.Policies.Tests.Unit.csproj
@@ -12,6 +12,12 @@
     <!-- P7.7 (#65): RbacDocsGeneratorTests pin the generator's parsing,
          idempotency, and admin "*" rendering. -->
     <ProjectReference Include="..\..\tools\GenerateRbacDocs\GenerateRbacDocs.csproj" />
+    <!-- P10.4 (#39): unit tests for the cross-service smoke helpers
+         (AuditChainVerifier, EmbeddedTestEnvironment, DockerComposeHelper)
+         — they live in Tests.E2E so the smoke + helpers ship together,
+         but their pure logic is asserted from Tests.Unit so it exercises
+         on every dotnet test (no E2E_ENABLED gate, no Docker). -->
+    <ProjectReference Include="..\Andy.Policies.Tests.E2E\Andy.Policies.Tests.E2E.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Andy.Policies.Tests.Unit/E2E/AuditChainVerifierTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/E2E/AuditChainVerifierTests.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Tests.E2E.EmbeddedSmoke;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.E2E;
+
+/// <summary>
+/// P10.4 (#39): exercises <see cref="AuditChainVerifier"/> in
+/// isolation. Lives in Tests.Unit so the rules don't depend on a
+/// running stack — synthetic <see cref="AuditEventDto"/>s are enough
+/// to assert link integrity, seq monotonicity, genesis prevHash, and
+/// the negative-tamper acceptance path.
+/// </summary>
+public class AuditChainVerifierTests
+{
+    [Fact]
+    public void EmptyChain_FailsWithEmptyReason()
+    {
+        var (valid, reason) = AuditChainVerifier.Verify(Array.Empty<AuditEventDto>());
+
+        valid.Should().BeFalse();
+        reason.Should().Contain("empty");
+    }
+
+    [Fact]
+    public void Genesis_With64ZeroPrevHash_IsAccepted()
+    {
+        var only = MakeEvent(seq: 1, prev: AuditChainVerifier.GenesisPrevHash, hash: "abc1");
+
+        var (valid, _) = AuditChainVerifier.Verify(new[] { only }, expectFromGenesis: true);
+
+        valid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Genesis_WithNonZeroPrevHash_IsRejected()
+    {
+        var bogus = MakeEvent(seq: 1, prev: "deadbeef", hash: "abc1");
+
+        var (valid, reason) = AuditChainVerifier.Verify(new[] { bogus }, expectFromGenesis: true);
+
+        valid.Should().BeFalse();
+        reason.Should().Contain("genesis");
+    }
+
+    [Fact]
+    public void HappyPath_TwoLinkedEvents_IsAccepted()
+    {
+        var a = MakeEvent(seq: 1, prev: AuditChainVerifier.GenesisPrevHash, hash: "AAAA");
+        var b = MakeEvent(seq: 2, prev: "AAAA", hash: "BBBB");
+
+        var (valid, reason) = AuditChainVerifier.Verify(new[] { a, b }, expectFromGenesis: true);
+
+        valid.Should().BeTrue(reason);
+    }
+
+    [Fact]
+    public void TamperedPrevHash_BetweenLinks_IsRejected()
+    {
+        var a = MakeEvent(seq: 1, prev: AuditChainVerifier.GenesisPrevHash, hash: "AAAA");
+        var b = MakeEvent(seq: 2, prev: "deadbeef", hash: "BBBB"); // wrong prev
+
+        var (valid, reason) = AuditChainVerifier.Verify(new[] { a, b }, expectFromGenesis: true);
+
+        valid.Should().BeFalse();
+        reason.Should().Contain("chain link broken").And.Contain("seq=2");
+    }
+
+    [Fact]
+    public void SeqGap_IsRejected()
+    {
+        var a = MakeEvent(seq: 1, prev: AuditChainVerifier.GenesisPrevHash, hash: "AAAA");
+        var c = MakeEvent(seq: 3, prev: "AAAA", hash: "CCCC"); // skips seq=2
+
+        var (valid, reason) = AuditChainVerifier.Verify(new[] { a, c }, expectFromGenesis: true);
+
+        valid.Should().BeFalse();
+        reason.Should().Contain("seq gap");
+    }
+
+    [Fact]
+    public void SubRange_NoGenesisExpectation_LinksOnlyChecked()
+    {
+        // Same as the happy path but starts at seq=42 — the verifier
+        // must not insist on seq=1 / genesis prevHash when called for
+        // a sub-range page.
+        var a = MakeEvent(seq: 42, prev: "f00d", hash: "AAAA");
+        var b = MakeEvent(seq: 43, prev: "AAAA", hash: "BBBB");
+
+        var (valid, reason) = AuditChainVerifier.Verify(new[] { a, b }, expectFromGenesis: false);
+
+        valid.Should().BeTrue(reason);
+    }
+
+    [Fact]
+    public void HashCaseInsensitive_Match_IsAccepted()
+    {
+        // Hex hashes from the API are documented as lowercase, but
+        // OrdinalIgnoreCase compare keeps the verifier robust against
+        // a JSON serializer flip.
+        var a = MakeEvent(seq: 1, prev: AuditChainVerifier.GenesisPrevHash, hash: "aabb");
+        var b = MakeEvent(seq: 2, prev: "AABB", hash: "ccdd");
+
+        var (valid, _) = AuditChainVerifier.Verify(new[] { a, b }, expectFromGenesis: true);
+
+        valid.Should().BeTrue();
+    }
+
+    private static AuditEventDto MakeEvent(long seq, string prev, string hash)
+        => new(
+            Id: Guid.NewGuid(),
+            Seq: seq,
+            PrevHashHex: prev,
+            HashHex: hash,
+            Timestamp: DateTimeOffset.UtcNow,
+            ActorSubjectId: "u",
+            ActorRoles: Array.Empty<string>(),
+            Action: "x",
+            EntityType: "X",
+            EntityId: "id",
+            FieldDiff: JsonDocument.Parse("[]").RootElement,
+            Rationale: null);
+}

--- a/tests/Andy.Policies.Tests.Unit/E2E/DockerComposeHelperTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/E2E/DockerComposeHelperTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Diagnostics;
+using Andy.Policies.Tests.E2E.EmbeddedSmoke;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.E2E;
+
+/// <summary>
+/// P10.4 (#39): proves the no-compose flag is wired so the Conductor
+/// Epic AO harness — which manages its own compose stack — never
+/// accidentally races the fixture for control.
+/// </summary>
+public class DockerComposeHelperTests
+{
+    [Fact]
+    public async Task NoComposeFlag_Up_IsNoop()
+    {
+        var env = new EmbeddedTestEnvironment(
+            k => k == EmbeddedTestEnvironment.NoComposeFlag ? "1" : null);
+        var startCount = 0;
+        var helper = new DockerComposeHelper(env, workingDirectory: "/tmp",
+            startProcess: _ => { startCount++; return null; });
+
+        await helper.UpAsync(CancellationToken.None);
+
+        startCount.Should().Be(0, "no docker invocation when NO_COMPOSE=1");
+        helper.DidStartCompose.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task NoComposeFlag_Down_IsNoop()
+    {
+        var env = new EmbeddedTestEnvironment(
+            k => k == EmbeddedTestEnvironment.NoComposeFlag ? "1" : null);
+        var startCount = 0;
+        var helper = new DockerComposeHelper(env, workingDirectory: "/tmp",
+            startProcess: _ => { startCount++; return null; });
+
+        await helper.DownAsync(CancellationToken.None);
+
+        startCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task DownAsync_WhenUpNeverRan_DoesNotInvokeDocker()
+    {
+        // Defensive: an exception during InitializeAsync between
+        // skip-compose check and `up` would otherwise leave Down
+        // trying to take down a stack we never started.
+        var env = new EmbeddedTestEnvironment(_ => null);
+        var startCount = 0;
+        var helper = new DockerComposeHelper(env, workingDirectory: "/tmp",
+            startProcess: _ => { startCount++; return null; });
+
+        await helper.DownAsync(CancellationToken.None);
+
+        startCount.Should().Be(0);
+        helper.DidStartCompose.Should().BeFalse();
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/E2E/EmbeddedTestEnvironmentTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/E2E/EmbeddedTestEnvironmentTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Tests.E2E.EmbeddedSmoke;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.E2E;
+
+/// <summary>
+/// P10.4 (#39): pin <see cref="EmbeddedTestEnvironment"/>'s env-var
+/// reads. The whole point of this helper is to keep URLs out of
+/// source — the unit tests prove fallbacks and overrides land where
+/// expected so a Conductor harness override can't silently miss.
+/// </summary>
+public class EmbeddedTestEnvironmentTests
+{
+    [Fact]
+    public void Defaults_WhenAllVarsUnset_TrackComposeFile()
+    {
+        var env = MakeEnv(_ => null);
+
+        env.IsEnabled.Should().BeFalse();
+        env.SkipCompose.Should().BeFalse();
+        env.PoliciesBaseUrl.AbsoluteUri.Should().Be("http://localhost:7113/");
+        env.AuthBaseUrl.AbsoluteUri.Should().Be("http://localhost:7002/");
+        env.ApiClientId.Should().Be("andy-policies-api");
+        env.Audience.Should().Be("urn:andy-policies-api");
+        env.ComposeFile.Should().Be("docker-compose.e2e.yml");
+        env.ComposeWaitSeconds.Should().Be(90);
+    }
+
+    [Fact]
+    public void E2EEnabled_OnlyWhenLiteralOne()
+    {
+        MakeEnv(k => k == EmbeddedTestEnvironment.EnabledFlag ? "1" : null)
+            .IsEnabled.Should().BeTrue();
+        MakeEnv(k => k == EmbeddedTestEnvironment.EnabledFlag ? "true" : null)
+            .IsEnabled.Should().BeFalse("only the literal '1' enables — keeps the gate explicit");
+        MakeEnv(k => k == EmbeddedTestEnvironment.EnabledFlag ? "0" : null)
+            .IsEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void NoCompose_OnlyWhenLiteralOne()
+    {
+        MakeEnv(k => k == EmbeddedTestEnvironment.NoComposeFlag ? "1" : null)
+            .SkipCompose.Should().BeTrue();
+        MakeEnv(k => k == EmbeddedTestEnvironment.NoComposeFlag ? "true" : null)
+            .SkipCompose.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ConductorHarness_OverridesPointAtProxy()
+    {
+        // Mirrors how Conductor Epic AO will wire the smoke against
+        // the embedded :9100 proxy — every URL configurable, no code
+        // change needed on the andy-policies side.
+        var overrides = new Dictionary<string, string?>
+        {
+            [EmbeddedTestEnvironment.PoliciesBaseUrlVar] = "http://localhost:9100/policies",
+            [EmbeddedTestEnvironment.AuthBaseUrlVar] = "http://localhost:9100/auth",
+            [EmbeddedTestEnvironment.NoComposeFlag] = "1",
+            [EmbeddedTestEnvironment.EnabledFlag] = "1",
+        };
+        var env = MakeEnv(k => overrides.GetValueOrDefault(k));
+
+        env.IsEnabled.Should().BeTrue();
+        env.SkipCompose.Should().BeTrue();
+        env.PoliciesBaseUrl.AbsoluteUri.Should().Be("http://localhost:9100/policies/");
+        env.AuthBaseUrl.AbsoluteUri.Should().Be("http://localhost:9100/auth/");
+    }
+
+    [Fact]
+    public void BaseUrls_WithoutTrailingSlash_AreNormalised()
+    {
+        // Uri composition with relative paths breaks if the base URL
+        // doesn't end in '/'. The helper must coerce.
+        var env = MakeEnv(k => k == EmbeddedTestEnvironment.PoliciesBaseUrlVar
+            ? "http://example.invalid/policies"
+            : null);
+
+        env.PoliciesBaseUrl.AbsoluteUri.Should().Be("http://example.invalid/policies/");
+        new Uri(env.PoliciesBaseUrl, "health").AbsoluteUri
+            .Should().Be("http://example.invalid/policies/health");
+    }
+
+    [Fact]
+    public void ComposeWaitSeconds_NonIntegerValue_FallsBackToDefault()
+    {
+        var env = MakeEnv(k => k == EmbeddedTestEnvironment.ComposeWaitSecondsVar ? "abc" : null);
+
+        env.ComposeWaitSeconds.Should().Be(90);
+    }
+
+    [Fact]
+    public void ComposeWaitSeconds_NegativeValue_FallsBackToDefault()
+    {
+        var env = MakeEnv(k => k == EmbeddedTestEnvironment.ComposeWaitSecondsVar ? "-1" : null);
+
+        env.ComposeWaitSeconds.Should().Be(90);
+    }
+
+    private static EmbeddedTestEnvironment MakeEnv(Func<string, string?> reader)
+    {
+        // Internal test seam — Tests.E2E InternalsVisibleTo doesn't
+        // currently allow Tests.Unit, so we use reflection through
+        // the public-by-arity ctor only when the seam is internal.
+        // (As of P10.4 the seam IS internal, but Tests.E2E grants
+        // access to Tests.Unit via an InternalsVisibleTo we add now.)
+        return new EmbeddedTestEnvironment(reader);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `EmbeddedCrossServiceSmokeTests` to the existing `Tests.E2E` project (extending instead of forking a sibling project per discussion). Drives the full lifecycle through the live REST surface: create policy + draft → publish → bind → bundle → resolve via bundle → audit page (client-side link verifier) → server-side hash verify.
- Negative-tamper assertion: `AuditChainVerifier_DetectsTamperedLink` runs as a pure xUnit fact (no E2E gate) and proves the client verifier rejects a severed prevHash link.
- Every URL, credential, and orchestration flag is configurable via env var (`EmbeddedTestEnvironment`). No hard-coded URLs in any new code — Conductor Epic AO can repoint the same suite at its `:9100/policies` proxy without a code change.
- Honors `ANDY_POLICIES_E2E_NO_COMPOSE=1` so the harness can own compose; locally the fixture brings up `docker-compose.e2e.yml` itself.

## Test plan

- [x] `dotnet test tests/Andy.Policies.Tests.Unit --filter "FullyQualifiedName~E2E"` — 18 new unit tests pass (verifier, env-var matrix, no-compose helper).
- [x] `dotnet test tests/Andy.Policies.Tests.E2E` — 9 tests pass (existing 6 + new 3, smoke flow skips without `E2E_ENABLED=1`).
- [x] Full `dotnet test` — only failure is a known-flaky integration perf test (`PathBaseTests.Swagger_UnderPrefix_ReturnsOpenApiDocument` under full-suite parallelism; passes in isolation, same family as the other documented flakes).
- [ ] **Manual smoke against live stack** (deferred to follow-up — same posture as the existing `EndToEndAuthSmokeTest`):
      `docker compose -f docker-compose.e2e.yml up -d --build && E2E_ENABLED=1 dotnet test tests/Andy.Policies.Tests.E2E --filter "FullyQualifiedName~EmbeddedCrossService"`.

## Deferred to follow-up

- `ci.yml` `e2e-embedded-smoke` job (label-gated / `workflow_dispatch`). Tracked in [`docs/embedded/cross-service-smoke.md` § Known gaps](docs/embedded/cross-service-smoke.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)