### PR TITLE
Implement P10.5 — embedded-mode docs + ADR 0010 (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,13 @@ curl -fsk https://localhost:5112/api/policies
 
 The migration / model invariants are pinned by `SqliteModelCompatibilityTests`, `SqliteMigrationApplyTests`, and `SqliteBootTests`. A change to `AppDbContext.OnModelCreating` that introduces a Postgres-only column type (`jsonb`, `timestamptz`, `text[]`) without an `IsNpgsql()` branch fails the model-compat test before merge.
 
+**Operator runbooks** (P10.5, [#40](https://github.com/rivoli-ai/andy-policies/issues/40)):
+
+- [Embedded operations](docs/embedded/operations.md) — boot, seed, backup the SQLite file, upgrade migration, env var matrix.
+- [Embedded troubleshooting](docs/embedded/troubleshooting.md) — 404 under the prefix, manifest fail-loud crashes, SQLite locks, OIDC redirect mismatches.
+- [Cross-service smoke](docs/embedded/cross-service-smoke.md) — local + Conductor harness recipe (P10.4).
+- [ADR 0010 — Embedded mode](docs/adr/0010-embedded-mode.md) — SQLite trade-offs, in-process pathbase, manifest-driven registration, fail-loud rationale.
+
 ### Registration manifest (P10.3, [#38](https://github.com/rivoli-ai/andy-policies/issues/38))
 
 Embedded mode is "batteries-included": on first boot, andy-policies POSTs the three blocks of [`config/registration.json`](config/registration.json) to the corresponding consumer:

--- a/docs/adr/0010-embedded-mode.md
+++ b/docs/adr/0010-embedded-mode.md
@@ -1,0 +1,115 @@
+# ADR 0010 — Embedded mode (Conductor bundled deployment)
+
+## Status
+
+**Accepted** — 2026-05-06. Drafted retroactively after the P10.1–P10.4 implementation stories landed (P10.1 #31, P10.2 #35, P10.3 #38, P10.4 #39 already merged on `main`). The decisions captured here describe the implementation as shipped; future divergence requires a follow-up ADR.
+
+Related: ADR 0007 edit-rbac (#56 — provides the per-resource permission codes the manifest registers), ADR 0008 bundle-pinning (#88 — the bundle pinning gate is the production read path that the cross-service smoke exercises).
+
+## Context
+
+Andy-policies must be consumable as a "batteries-included" component inside Conductor, not only as a standalone Mode 1 (`dotnet run`) or Mode 2 (`docker compose up`) service. The Conductor bundled deployment (Mode 3) targets a single host where one operator runs `docker compose -f docker-compose.embedded.yml up -d` and gets a self-contained governance catalog reachable through Conductor's `:9100/policies/` reverse proxy.
+
+Three embedded-mode constraints follow from that target:
+
+1. **No external database.** Mode 3 cannot expect a sibling Postgres container; bootstrap must work with a single-file backing store that lives in a named volume.
+2. **URL-prefix isolation.** Conductor hosts multiple services behind one proxy; andy-policies must mount its routes under `/policies/*` and have its outbound URLs (Swagger `servers`, OIDC `redirect_uri`, static asset links, `LinkGenerator` outputs) emit the prefix without operator intervention.
+3. **Self-describing registration.** The bundled deployment can't rely on operator-run SQL seeds for OAuth clients, RBAC roles, and settings definitions; andy-policies has to tell andy-auth, andy-rbac, and andy-settings what it needs on first boot.
+
+Epic P10 (rivoli-ai/andy-policies#10) ships the four functional changes that satisfy these constraints (P10.1 SQLite boot, P10.2 base-path, P10.3 manifest registration, P10.4 cross-service smoke). This ADR captures the four architectural commitments behind them and the three Non-goals that scope the work, so future contributors don't unknowingly relax them.
+
+## Decisions
+
+### 1. SQLite for Mode 3; Postgres remains the default for Mode 1/2
+
+`docker-compose.embedded.yml` configures `Database__Provider=Sqlite` against a single file in the `sqlite_data` named volume. The same EF migration set applies on both providers; `BundleMigrationTests` (P8.1) and `SqliteMigrationApplyTests` (P10.1) prove it.
+
+Trade-offs:
+
+- **Pro:** no sibling DB container; single-file backup/restore via `sqlite3 .backup`; trivial bootstrap; the entire catalog is one durable object.
+- **Con:** single-writer throughput (file lock); no logical replication; no Postgres-only column types (`jsonb` operators, `timestamptz`, `text[]`).
+- **Mitigation:** `SqliteModelCompatibilityTests` fails any change to `AppDbContext.OnModelCreating` that introduces a Postgres-only type without an `IsNpgsql()` branch. Postgres remains the production-throughput target for Mode 1/2; Mode 3 is for embedded deployments where one operator's policy edits are the only writer.
+
+Mode 3 is **single-tenant by design** (Non-goal #1, below). Multi-tenant scale-out remains a Postgres-only feature.
+
+### 2. `UsePathBase` in-process, not nginx-side rewriting
+
+When `ASPNETCORE_PATHBASE=/policies` is set, P10.2's `app.UsePathBase(pathBase)` strips the prefix from inbound requests before route matching and re-prepends it on outbound URL generation. This is **load-bearing for outbound URLs**: Swagger `servers`, OIDC `redirect_uri` rendered from the SPA's `<base href>`, and `LinkGenerator` outputs all need to know the prefix in-process. Nginx-side rewriting (strip on the way in, rewrite on the way out) would create asymmetric bugs — outbound URLs would still emit the bare path because the in-process pipeline never sees the prefix.
+
+Order is load-bearing: `UsePathBase` runs before `UseRouting`, before `UseAuthentication`/`UseAuthorization`, before any `Map*` call. Modes 1/2 leave `ASPNETCORE_PATHBASE` empty; the call no-ops and routes resolve at root. Pinned by `PathBaseTests` and `PathBaseUnsetTests` in `tests/Andy.Policies.Tests.Integration/Embedded/`.
+
+The proxy itself is **Conductor's job, not ours** (Non-goal #3) — we declare the prefix in `config/registration.json` (`embeddedProxyPrefix`) and expect Conductor's `:9100` proxy to honor it.
+
+### 3. Manifest-driven registration, not operator-run SQL seeds
+
+`config/registration.json` is the single source of truth for the OAuth client (`andy-policies-api` + `andy-policies-web`), the RBAC application (`andy-policies` + 7 resource types + 18 permissions + 5 roles), and the settings definitions (5 keys). On first boot under embedded mode, P10.3's `ManifestRegistrationHostedService` POSTs the three blocks to:
+
+- `AndyAuth__ManifestEndpoint` — andy-auth ingests the OAuth client with scopes + redirect URIs (idempotent, keyed on `clientId`; never rotates persisted client secrets).
+- `AndyRbac__ManifestEndpoint` — andy-rbac upserts the application + roles + permissions (idempotent, keyed on `applicationCode` + `role.code` + `permission.code`; preserves subject assignments).
+- `AndySettings__ManifestEndpoint` — andy-settings upserts the setting definitions (idempotent, keyed on `key`; preserves operator-set values).
+
+Order is auth → rbac → settings — the auth-issued S2S token (P10.4 `client_credentials`) authenticates the rbac and settings calls, so a stack with auth-down can't even attempt rbac/settings registration. Replay is safe by design (each consumer owns idempotent upsert).
+
+The mode 1/2 `auth-seed.sql` + `config/rbac-seed.json` + andy-settings boostrap continues to work for local dev, where an operator typically wants explicit control. `Registration__AutoRegister` defaults to `false` in those modes; embedded mode flips it on.
+
+### 4. Fail-loud on registration failure
+
+If any of the three POSTs returns non-2xx — or the consumer is unreachable, or the response body is unparseable — `ManifestRegistrationException` propagates from `StartAsync` and the host crashes before Kestrel binds. No partial-success state.
+
+This is deliberate, and follows andy-rbac ADR-0001's posture (fail-loud on misconfiguration). A half-registered andy-policies fails confusingly at runtime (403 from rbac on every gated endpoint, missing settings defaults silently flipping behaviour, OIDC callbacks rejected as `invalid_client`); we'd rather see the operator hit a hard boot failure with a clear log line naming the failing block. P10.3's hosted service logs `Manifest registration failed for block {Block}: aborting startup.` at `Critical` precisely so this is grep-able.
+
+The local-dev escape hatch is `Registration__AutoRegister=false`, which skips dispatch entirely — appropriate for working on an isolated andy-policies branch without a live ecosystem stack, never appropriate for production.
+
+## Consequences
+
+### Positive
+
+- **Self-contained boot.** `docker compose -f docker-compose.embedded.yml up -d` is the entire deployment story for Conductor operators; no sibling DB, no manual SQL seed run, no out-of-band OAuth client registration.
+- **File-level backup/restore.** `sqlite3 .backup` is a one-liner; the catalog is one durable artifact ([operations.md](../embedded/operations.md) covers the recipe).
+- **Reproducible across environments.** The same `config/registration.json` drives auth/rbac/settings across all three modes — a Mode 3 catalog and a Mode 1/2 catalog have identical RBAC and settings shape.
+- **Cross-service smoke contract.** P10.4's `EmbeddedCrossServiceSmokeTests` exercises the full create→publish→bind→bundle→resolve→audit→verify lifecycle; Conductor Epic AO (rivoli-ai/conductor#669) consumes it via the `ANDY_POLICIES_E2E_NO_COMPOSE=1` flag.
+
+### Negative / accepted trade-offs
+
+- **Single-writer throughput.** SQLite serializes writers; Mode 3 is not the deployment to use if you expect dozens of concurrent policy authors. The bundle pinning gate (ADR 0008) means most reads bypass the live writer anyway, so the practical bottleneck is publish/transition rate, not lookup rate.
+- **All-or-nothing boot dependency on the ecosystem stack.** Fail-loud means andy-policies refuses to start when any of auth/rbac/settings is unreachable. Operators upgrading the bundle must bring up auth → rbac → settings → policies in order, or accept the boot crash and restart once dependencies are healthy.
+- **Mode switching requires a manual export.** A deployment is Mode 1 *or* 2 *or* 3 at boot — switching requires `dotnet ef migrations script` + `sqlite3 .dump` + targeted import (Non-goal #2). The catalog can move between modes; it cannot move *live*.
+- **No SQLite replication / HA.** A single-file store has no native replication. Operators wanting HA in Mode 3 must run their own filesystem-level replication (e.g. Litestream) outside this repo's scope.
+
+## Considered alternatives
+
+### Postgres in embedded mode
+
+A sibling Postgres container could remove the single-writer constraint and let the same migration set apply unmodified. Rejected because:
+
+- It defeats the "single durable artifact" property — operators now need to back up two volumes and reason about their consistency.
+- Conductor's headline framing is *"one container, one bind"*; adding a second persistent service contradicts the bundled-deployment value proposition.
+- Mode 1/2 already give operators Postgres if they want it.
+
+### Operator-driven seed scripts in Mode 3
+
+Continue using `auth-seed.sql` + `rbac-seed.json` + andy-settings bootstrap in Mode 3, run by the operator before booting andy-policies. Rejected because:
+
+- It pushes ecosystem coordination onto every operator — they'd have to know which seed runs against which service in which order.
+- Idempotent manifest endpoints (P10.3) collapse the same outcome to a single boot-time API call, which is how Conductor's bundled deployment is supposed to feel.
+
+### Silent fallback on manifest failure
+
+Log and continue when a consumer rejects the manifest POST, on the theory that a partially-registered andy-policies is better than no andy-policies. **Explicitly rejected** per andy-rbac ADR-0001 — partial registration causes 403 cascades and missing-setting drift that surface days later in production, far from the actual root cause.
+
+### Conductor-managed proxy implementation in andy-policies
+
+Bind `:9100` ourselves and route `/policies/*` internally. Rejected because the proxy is shared infrastructure across the entire Conductor bundle; baking it into one service would couple all the bundled services to andy-policies' deployment cadence (Non-goal #3).
+
+### Multi-tenant SQLite
+
+Run multiple Conductor tenants behind one andy-policies process via per-tenant SQLite files or a tenant column in the schema. Rejected as a Mode 3 Non-goal (#1) — scale-out is a Postgres-only deployment shape; Mode 3 stays single-tenant for the conceptual simplicity that justifies SQLite in the first place.
+
+## Non-goals from epic P10 (recorded for posterity)
+
+The epic explicitly scopes out four expansions; restating them here so a future change that re-considers them has a clear baseline to argue against:
+
+1. **No multi-tenant SQLite.** One file, one tenant. Multi-tenant is Postgres-only.
+2. **No live mode-switching.** A deployment is Mode 1 / 2 / 3 at boot; switching is an export/import operation.
+3. **No in-proc proxy.** The reverse proxy on `:9100` is Conductor's responsibility; we declare the prefix and expect it honored.
+4. **No backup automation.** Operators back up the SQLite file on whatever cadence their environment demands; we document the recipe in [`operations.md`](../embedded/operations.md).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -77,3 +77,12 @@ export Database__Provider=Sqlite
 export ConnectionStrings__DefaultConnection="Data Source=andy_policies.db"
 dotnet run --project src/Andy.Policies.Api
 ```
+
+### Embedded mode (Mode 3) operator docs
+
+Mode 3 is the bundled-with-Conductor deployment shape. The operator-facing runbooks live under `embedded/`:
+
+- [Operations](embedded/operations.md) — boot, seed, backup, upgrade, full env var matrix.
+- [Troubleshooting](embedded/troubleshooting.md) — 404 under the prefix, manifest fail-loud, SQLite locks, OIDC redirect mismatches.
+- [Cross-service smoke](embedded/cross-service-smoke.md) — local recipe + Conductor harness contract.
+- [ADR 0010 — Embedded mode](adr/0010-embedded-mode.md) — architectural decisions (SQLite trade-offs, in-process pathbase, manifest-driven registration, fail-loud rationale).

--- a/docs/embedded/cross-service-smoke.md
+++ b/docs/embedded/cross-service-smoke.md
@@ -2,7 +2,7 @@
 
 This is the andy-policies side of the [Conductor Epic AO](https://github.com/rivoli-ai/conductor/issues/669) cross-service integration suite. It boots the full ecosystem (andy-auth + andy-rbac + andy-settings + andy-policies), drives a complete catalog lifecycle through the live REST surface, and verifies the audit hash chain.
 
-The fixture lives in [`tests/Andy.Policies.Tests.E2E/EmbeddedSmoke/`](../../tests/Andy.Policies.Tests.E2E/EmbeddedSmoke/) — the `EmbeddedCrossServiceSmokeTests` class is the one Conductor's harness invokes.
+The fixture lives in [`tests/Andy.Policies.Tests.E2E/EmbeddedSmoke/`](https://github.com/rivoli-ai/andy-policies/tree/main/tests/Andy.Policies.Tests.E2E/EmbeddedSmoke) — the `EmbeddedCrossServiceSmokeTests` class is the one Conductor's harness invokes.
 
 ## What it proves
 
@@ -59,7 +59,7 @@ The fixture honors `ANDY_POLICIES_E2E_NO_COMPOSE=1` by skipping both compose `up
 
 ## Configurable env vars
 
-Defined in [`EmbeddedTestEnvironment.cs`](../../tests/Andy.Policies.Tests.E2E/EmbeddedSmoke/EmbeddedTestEnvironment.cs). All optional; defaults track `docker-compose.e2e.yml`'s exposed ports.
+Defined in [`EmbeddedTestEnvironment.cs`](https://github.com/rivoli-ai/andy-policies/blob/main/tests/Andy.Policies.Tests.E2E/EmbeddedSmoke/EmbeddedTestEnvironment.cs). All optional; defaults track `docker-compose.e2e.yml`'s exposed ports.
 
 | Var | Default | Purpose |
 |---|---|---|

--- a/docs/embedded/operations.md
+++ b/docs/embedded/operations.md
@@ -1,0 +1,104 @@
+# Embedded mode operations
+
+Mode 3 (Conductor embedded) runs andy-policies as a single container with a SQLite-backed catalog, behind Conductor's reverse proxy on `:9100/policies/`. This page is the operator runbook — how to boot, seed, back up, and upgrade the embedded deployment. The architectural decisions behind these mechanics are captured in [ADR 0010 — Embedded mode](../adr/0010-embedded-mode.md); the cross-service smoke that proves the contract end-to-end is in [`cross-service-smoke.md`](cross-service-smoke.md).
+
+## Prerequisites
+
+The embedded compose only starts andy-policies. It expects the rest of the ecosystem to be reachable from the container — by default at `host.docker.internal:5001` (auth), `:5003` (rbac), `:5300` (settings). For the cross-service smoke + manifest registration to work, those services must be up.
+
+## Boot
+
+```bash
+# From the andy-policies repo root.
+docker compose -f docker-compose.embedded.yml up -d
+
+# Wait for healthcheck (compose's own probe + an HTTP probe through the prefix).
+curl --retry 30 --retry-delay 2 -fsk https://localhost:5112/policies/health
+```
+
+On first boot the API:
+
+1. Applies EF migrations (P10.1 — `Database.MigrateAsync`, idempotent against an existing volume).
+2. Seeds the six stock policies via `PolicySeeder` (P1.3, idempotent — presence-of-any-row probe; restart-booting against a populated volume preserves operator edits).
+3. POSTs `config/registration.json`'s three blocks to andy-auth / andy-rbac / andy-settings if `Registration__AutoRegister=true` (P10.3, fail-loud on any consumer error).
+
+The `/policies` URL prefix on every route comes from `ASPNETCORE_PATHBASE=/policies` (P10.2 — see [`docker-compose.embedded.yml`](https://github.com/rivoli-ai/andy-policies/blob/main/docker-compose.embedded.yml) for the canonical environment block).
+
+## Seed
+
+The boot-time seeder lands the catalog with six stock policies (`read-only`, `write-branch`, `sandboxed`, `draft-only`, `no-prod`, `high-risk`). It is **idempotent**: a restart against the same SQLite file does **not** re-seed and does **not** clobber operator-edited rows. Verified by `SqliteBootTests.SecondBoot_AgainstSamePersistentDb_DoesNotReseed`.
+
+To **reseed from scratch** (drops all operator edits — destructive):
+
+```bash
+docker compose -f docker-compose.embedded.yml down -v
+docker compose -f docker-compose.embedded.yml up -d
+```
+
+`-v` tears down the `sqlite_data` named volume; the next `up` boots against an empty database, which triggers seeding.
+
+## Backup
+
+The catalog lives in a single file: `/data/andy_policies.db` inside the container, backed by the `sqlite_data` named volume. SQLite's built-in `.backup` command takes a consistent copy under a write-ahead snapshot — safe with concurrent reads:
+
+```bash
+# 1. Take a consistent copy inside the container.
+docker compose -f docker-compose.embedded.yml exec -T api \
+  sqlite3 /data/andy_policies.db ".backup /data/andy_policies.db.bak"
+
+# 2. Pull it onto the host.
+mkdir -p ./backups
+docker cp andy-policies-embedded:/data/andy_policies.db.bak \
+  "./backups/andy_policies-$(date -u +%Y%m%dT%H%M%SZ).db"
+
+# 3. (optional) Verify integrity of the copy.
+sqlite3 "./backups/andy_policies-…​.db" "PRAGMA integrity_check;"
+```
+
+`PRAGMA integrity_check` should print `ok`. Anything else means the backup is corrupt — re-run the `.backup` command.
+
+For automated backups, run the steps above on a cron from the host (the container's filesystem is ephemeral; only the named volume is durable).
+
+## Upgrade
+
+EF migrations apply on every boot (P10.1), so an upgrade is image-level:
+
+```bash
+# 1. Back up first (above).
+
+# 2. Pull the new image and recreate. Compose drains the old container,
+#    runs migrations on boot, and restarts only after healthcheck passes.
+docker compose -f docker-compose.embedded.yml pull
+docker compose -f docker-compose.embedded.yml up -d
+
+# 3. Verify.
+curl -fsk https://localhost:5112/policies/health
+docker compose -f docker-compose.embedded.yml logs api | tail -50
+```
+
+**Rollback** is a file-level restore: stop the container, replace `andy_policies.db` in the volume with a known-good backup, start the container. EF will not "down-migrate" — if you've moved past a schema version that the older image expects, the older image will refuse to boot. Plan rollbacks against a backup taken **before** the upgrade.
+
+## Environment variables
+
+The canonical set lives in [`docker-compose.embedded.yml`](https://github.com/rivoli-ai/andy-policies/blob/main/docker-compose.embedded.yml). The table below is the operator-facing summary.
+
+| Variable | Default in compose | Required? | Purpose |
+|---|---|---|---|
+| `ASPNETCORE_ENVIRONMENT` | `Development` | yes | Enables auto-migrate + seed (P10.1). |
+| `ASPNETCORE_URLS` | `https://+:8443;http://+:8080` | yes | Kestrel binding. |
+| `ASPNETCORE_PATHBASE` | `/policies` | embedded only | URL prefix (P10.2). Empty in Modes 1/2. |
+| `Database__Provider` | `Sqlite` | yes | Switches the DbContext to the SQLite provider. |
+| `ConnectionStrings__DefaultConnection` | `Data Source=/data/andy_policies.db` | yes | SQLite file path (volume-backed). |
+| `AndyAuth__Authority` | `https://host.docker.internal:5001` | yes | OAuth2/OIDC issuer (no bypass — see #103). |
+| `AndyAuth__Audience` | `urn:andy-policies-api` | yes | JWT audience claim. |
+| `AndyRbac__BaseUrl` | `https://host.docker.internal:5003` | yes | andy-rbac check endpoint. |
+| `AndySettings__ApiBaseUrl` | `https://host.docker.internal:5300` | yes | andy-settings client base URL. |
+| `Registration__AutoRegister` | `true` | embedded only | Enables the manifest hosted service (P10.3). |
+| `AndyAuth__ManifestEndpoint` | `…/api/manifest` | when AutoRegister=true | andy-auth manifest ingest. |
+| `AndyRbac__ManifestEndpoint` | `…/api/manifest` | when AutoRegister=true | andy-rbac manifest ingest. |
+| `AndySettings__ManifestEndpoint` | `…/api/manifest` | when AutoRegister=true | andy-settings manifest ingest. |
+| `ANDY_POLICIES_API_SECRET` | `_dev_only_not_production_` | yes in production | Confidential client secret for the api OAuth client (used by Conductor's S2S smoke per P10.4). Override via secret store; do not commit. |
+
+## Troubleshooting
+
+See [`troubleshooting.md`](troubleshooting.md) for common failure modes (404 under the prefix, manifest fail-loud, SQLite lock, OIDC redirect mismatch).

--- a/docs/embedded/troubleshooting.md
+++ b/docs/embedded/troubleshooting.md
@@ -1,0 +1,107 @@
+# Embedded mode troubleshooting
+
+Symptoms you're likely to see when something goes wrong in Mode 3, with concrete diagnosis commands and the underlying root cause. Companion to [`operations.md`](operations.md) and [ADR 0010](../adr/0010-embedded-mode.md).
+
+## `GET /policies/api/...` returns 404
+
+**Most likely cause:** `ASPNETCORE_PATHBASE` is unset or wrong, so the API serves at root and the `/policies` prefix is not stripped before route matching.
+
+**Diagnosis:**
+
+```bash
+# Confirm the env var landed in the container.
+docker compose -f docker-compose.embedded.yml exec api \
+  printenv ASPNETCORE_PATHBASE
+
+# Bypass the prefix — if this works, the prefix wiring is the bug.
+docker compose -f docker-compose.embedded.yml exec api \
+  curl -fsk http://localhost:8080/health
+```
+
+**Fix:** Ensure the compose file sets `ASPNETCORE_PATHBASE=/policies` (P10.2). If a reverse proxy ahead of us (Conductor's `:9100`) is also rewriting the path, you may be **double-stripping** — the proxy strips `/policies` from `/policies/api/foo`, then `UsePathBase` strips a second `/policies` that isn't there. Disable the proxy-side rewrite and let `UsePathBase` handle it in-process. Pinned by `PathBaseTests` in `tests/Andy.Policies.Tests.Integration/Embedded/`.
+
+## Startup crashes with `ManifestRegistrationException`
+
+**Most likely cause:** A consumer (andy-auth, andy-rbac, or andy-settings) is unreachable, returned non-2xx to the manifest POST, or rejected the payload. P10.3 is **fail-loud by design** — a half-registered embedded deployment fails confusingly at runtime, so we crash on boot instead.
+
+**Diagnosis:**
+
+```bash
+# Logs name the failing block (auth / rbac / settings).
+docker compose -f docker-compose.embedded.yml logs api \
+  | grep -i 'manifest registration failed for block'
+
+# Probe the manifest endpoints directly.
+curl -fsk -X POST https://host.docker.internal:5001/api/manifest \
+  -H 'Content-Type: application/json' -d '{}'
+# Repeat for :5003 and :5300.
+```
+
+**Fix:**
+
+- If a consumer is genuinely down, bring it up before andy-policies. The boot order in a Conductor-managed stack is auth → rbac → settings → policies; same order applies in dev.
+- If a consumer is up but rejecting the payload, look at its logs for the parse error — the manifest POST ships `config/registration.json`'s `auth`/`rbac`/`settings` block verbatim.
+- **Local-dev-only escape hatch:** set `Registration__AutoRegister=false`. This skips dispatch entirely and falls back to the Mode 1/2 seed-script path. **Do not use in production** — the embedded deployment is then non-self-describing.
+
+## SQLite "database is locked"
+
+**Most likely cause:** A second writer is attached to `/data/andy_policies.db`. SQLite's embedded mode is **single-writer**; concurrent writers serialise on a file lock.
+
+**Diagnosis:**
+
+```bash
+# Anyone holding the volume?
+docker ps --filter volume=sqlite_data
+
+# Any host-side sqlite3 attached?
+lsof | grep andy_policies.db
+```
+
+**Fix:**
+
+- Detach any host-side `sqlite3` shell.
+- Ensure only one container mounts the `sqlite_data` volume — running two replicas of andy-policies against the same volume is unsupported (epic Non-goal, see ADR 0010).
+- The `.backup` command from [operations.md](operations.md) takes a consistent copy without holding the write lock — it should not produce this symptom; if it does, you have a true concurrent writer somewhere.
+
+## OIDC callback fails with `invalid_redirect_uri`
+
+**Most likely cause:** The redirect URI the browser hit isn't in the registered list for `andy-policies-web`. The canonical list is in [`config/registration.json`](https://github.com/rivoli-ai/andy-policies/blob/main/config/registration.json) and includes `http://localhost:9100/policies/callback` for the embedded proxy.
+
+**Diagnosis:**
+
+```bash
+# Pull the registered URIs from andy-auth.
+curl -fsk https://host.docker.internal:5001/api/clients/andy-policies-web \
+  | jq '.redirectUris'
+```
+
+**Fix:**
+
+- If Conductor's proxy is bound to a non-default port (not `:9100`), update `auth.webClient.redirectUris` in `config/registration.json` and re-run the manifest registration: restart andy-policies (idempotent — re-POSTs and andy-auth upserts on `clientId`).
+- If you're testing through a tunnel (`ngrok`, `cloudflared`), add the tunnel hostname to the redirect URI list before booting; runtime additions need a re-register.
+
+## Health probe times out on first boot
+
+**Most likely cause:** Cold start under embedded mode runs migrate + seed + manifest registration before Kestrel accepts traffic. On a slow disk, this can take 30–60 s.
+
+**Diagnosis:**
+
+```bash
+# Watch boot progress; "Now listening on" comes after migrate+seed+register.
+docker compose -f docker-compose.embedded.yml logs -f api
+```
+
+**Fix:** Increase the compose `start_period` (currently `15s`) if your environment is consistently slow. The cross-service smoke uses `ANDY_POLICIES_E2E_COMPOSE_WAIT_SECONDS` (default 90) for the same reason — see [`cross-service-smoke.md`](cross-service-smoke.md).
+
+## Backup file is 0 bytes / corrupt
+
+**Most likely cause:** `sqlite3 .backup` was interrupted, or the destination filesystem ran out of space.
+
+**Diagnosis:**
+
+```bash
+sqlite3 ./backups/andy_policies-<ts>.db "PRAGMA integrity_check;"
+# Expect 'ok'. Anything else = corrupt.
+```
+
+**Fix:** Re-run the backup command from [operations.md](operations.md). If the disk is full, free space first; do not partial-restore a corrupt copy.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,10 @@ nav:
     - Override approver: runbooks/override-approver.md
     - Override operator: runbooks/override-operator.md
     - Audit compliance: runbooks/audit-compliance.md
+  - Embedded mode:
+    - Operations: embedded/operations.md
+    - Troubleshooting: embedded/troubleshooting.md
+    - Cross-service smoke: embedded/cross-service-smoke.md
   - ADRs:
     - 0001 Policy versioning: adr/0001-policy-versioning.md
     - 0002 Lifecycle states: adr/0002-lifecycle-states.md
@@ -44,3 +48,4 @@ nav:
     - 0006 Audit hash chain: adr/0006-audit-hash-chain.md
     - 0007 Edit RBAC: adr/0007-edit-rbac.md
     - 0008 Bundle pinning: adr/0008-bundle-pinning.md
+    - 0010 Embedded mode: adr/0010-embedded-mode.md


### PR DESCRIPTION
## Summary

Closes out **epic P10**. Adds the operator-facing documentation layer for Mode 3 (Conductor embedded) so the four functional changes from P10.1–P10.4 are actually adoptable.

- `docs/embedded/operations.md` — boot, seed, backup (`sqlite3 .backup`), upgrade migration, full env-var matrix.
- `docs/embedded/troubleshooting.md` — six failure modes (404 under prefix, manifest fail-loud crash, SQLite lock, OIDC redirect mismatch, slow-disk timeout, corrupt backup) with diagnosis commands.
- `docs/adr/0010-embedded-mode.md` — house-style ADR (Status / Context / numbered Decisions / Consequences / Alternatives). Covers SQLite trade-offs, in-process `UsePathBase`, manifest-driven registration, fail-loud rationale. Records the four epic Non-goals.
- mkdocs.yml + README.md + docs/deployment.md cross-links so the new pages are discoverable from every entry point.

## Side fix

Switched the relative `../../tests/...` links in P10.4's `cross-service-smoke.md` to GitHub URLs so `mkdocs build --strict` resolves them. Followed the existing house convention from `docs/audit-envelope.md` and `docs/guides/consumer-integration-bundles.md` (those use `https://github.com/rivoli-ai/andy-policies/blob/main/...`).

## Test plan

- [x] `mkdocs build --strict` — passes with new pages in nav, no broken references.
- [x] `dotnet build` — green (docs-only PR; sanity check that nothing leaked).
- [x] Manual review of internal links — every `[text](path)` resolves to an existing file.

## Scope notes

- ADR was numbered 0010 to match the epic ID `P10` (skipping 0009 for P9 Admin UI, which is wave 7 / not on the critical path; future P9 ADR can take 0009).
- P10's deferred follow-up — the `e2e-embedded-smoke` CI workflow gate (label-gated / `workflow_dispatch`) — is captured in `docs/embedded/cross-service-smoke.md` § Known gaps, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)