### PR TITLE
Implement P9.4 — lifecycle transitions modal + policy detail (#69)

### DIFF
--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -34,6 +34,14 @@ export const routes: Routes = [
     canActivate: [authGuard],
   },
   {
+    path: 'policies/:id',
+    loadComponent: () =>
+      import('./features/policies/policy-detail.component').then(
+        (m) => m.PolicyDetailComponent
+      ),
+    canActivate: [authGuard],
+  },
+  {
     path: 'policies/:id/versions/:vId/edit',
     loadComponent: () =>
       import('./features/policies/policy-editor.component').then(

--- a/client/src/app/features/policies/lifecycle-diagram.component.spec.ts
+++ b/client/src/app/features/policies/lifecycle-diagram.component.spec.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LifecycleDiagramComponent } from './lifecycle-diagram.component';
+import { LifecycleState } from '../../shared/services/api.service';
+
+describe('LifecycleDiagramComponent (P9.4)', () => {
+  let fixture: ComponentFixture<LifecycleDiagramComponent>;
+
+  function build(current: LifecycleState): void {
+    fixture = TestBed.createComponent(LifecycleDiagramComponent);
+    fixture.componentRef.setInput('current', current);
+    fixture.detectChanges();
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LifecycleDiagramComponent],
+    }).compileComponents();
+  });
+
+  it('renders all four state nodes', () => {
+    build('Draft');
+    const nodes = fixture.nativeElement.querySelectorAll('.node');
+    expect(nodes.length).toBe(4);
+    expect(fixture.nativeElement.querySelector('[data-testid="node-Draft"]')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="node-Active"]')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="node-WindingDown"]')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="node-Retired"]')).toBeTruthy();
+  });
+
+  it('marks only the current state as active', () => {
+    build('Active');
+    const active = fixture.nativeElement.querySelector('[data-testid="node-Active"]');
+    expect(active.classList).toContain('active');
+    const draft = fixture.nativeElement.querySelector('[data-testid="node-Draft"]');
+    expect(draft.classList).not.toContain('active');
+  });
+
+  it('moves the active class when current changes', () => {
+    build('Draft');
+    expect(fixture.nativeElement.querySelector('[data-testid="node-Draft"]').classList).toContain('active');
+
+    fixture.componentRef.setInput('current', 'Retired');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="node-Draft"]').classList).not.toContain('active');
+    expect(fixture.nativeElement.querySelector('[data-testid="node-Retired"]').classList).toContain('active');
+  });
+});

--- a/client/src/app/features/policies/lifecycle-diagram.component.ts
+++ b/client/src/app/features/policies/lifecycle-diagram.component.ts
@@ -1,0 +1,85 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { LifecycleState } from '../../shared/services/api.service';
+
+/**
+ * P9.4 (rivoli-ai/andy-policies#69) — tiny static SVG of the four-state
+ * lifecycle graph. The `current` state gets `.active` styling; the rest are
+ * dimmed. No dynamic graph library — the shape is fixed in P2 and only
+ * changes via a coordinated server+client release.
+ */
+@Component({
+  selector: 'app-lifecycle-diagram',
+  standalone: true,
+  imports: [CommonModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <svg
+      viewBox="0 0 360 110"
+      class="diagram"
+      role="img"
+      [attr.aria-label]="'Lifecycle state diagram, current state ' + current">
+      <defs>
+        <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10 z" />
+        </marker>
+      </defs>
+
+      <g class="node" [class.active]="current === 'Draft'" data-testid="node-Draft">
+        <circle cx="40" cy="40" r="26"></circle>
+        <text x="40" y="44" text-anchor="middle">Draft</text>
+      </g>
+      <g class="node" [class.active]="current === 'Active'" data-testid="node-Active">
+        <circle cx="140" cy="40" r="26"></circle>
+        <text x="140" y="44" text-anchor="middle">Active</text>
+      </g>
+      <g class="node" [class.active]="current === 'WindingDown'" data-testid="node-WindingDown">
+        <circle cx="240" cy="40" r="28"></circle>
+        <text x="240" y="38" text-anchor="middle">Wind</text>
+        <text x="240" y="50" text-anchor="middle">Down</text>
+      </g>
+      <g class="node" [class.active]="current === 'Retired'" data-testid="node-Retired">
+        <circle cx="330" cy="40" r="22"></circle>
+        <text x="330" y="44" text-anchor="middle">Retired</text>
+      </g>
+
+      <path d="M66,40 L114,40" class="arrow" marker-end="url(#arrow)"></path>
+      <path d="M168,40 L210,40" class="arrow" marker-end="url(#arrow)"></path>
+      <path d="M270,40 L308,40" class="arrow" marker-end="url(#arrow)"></path>
+      <path d="M155,66 C200,100 280,100 320,62" class="arrow" fill="none" marker-end="url(#arrow)"></path>
+    </svg>
+  `,
+  styles: [`
+    :host { display: block; }
+    .diagram { width: 100%; max-width: 380px; height: auto; }
+    .node circle {
+      fill: var(--surface);
+      stroke: var(--border);
+      stroke-width: 1.5;
+    }
+    .node text {
+      fill: var(--text-secondary);
+      font-size: 11px;
+      font-weight: 500;
+      font-family: ui-sans-serif, system-ui, sans-serif;
+    }
+    .node.active circle {
+      fill: var(--primary);
+      stroke: var(--primary);
+    }
+    .node.active text {
+      fill: white;
+    }
+    .arrow {
+      stroke: var(--border);
+      stroke-width: 1.5;
+      fill: none;
+    }
+    #arrow path { fill: var(--border); }
+  `],
+})
+export class LifecycleDiagramComponent {
+  @Input({ required: true }) current!: LifecycleState;
+}

--- a/client/src/app/features/policies/lifecycle-graph.ts
+++ b/client/src/app/features/policies/lifecycle-graph.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { LifecycleState } from '../../shared/services/api.service';
+
+/**
+ * P9.4 (rivoli-ai/andy-policies#69) — client-side mirror of the server-side
+ * lifecycle state machine. Reflects the transitions exposed by
+ * `PolicyVersionsLifecycleController` (P2.3): Draft → Active (publish),
+ * Active → WindingDown (winding-down), Active → Retired (retire),
+ * WindingDown → Retired (retire). Retired is terminal.
+ *
+ * The server is the authoritative gate — illegal transitions return 409
+ * regardless of what this map says. This client-side copy lets the UI
+ * render the dropdown without a round-trip; if the graph changes server-side,
+ * the worst case is the UI offers a transition that 409s on submit.
+ */
+export const LIFECYCLE_GRAPH: Record<LifecycleState, LifecycleState[]> = {
+  Draft: ['Active'],
+  Active: ['WindingDown', 'Retired'],
+  WindingDown: ['Retired'],
+  Retired: [],
+};
+
+/** Maps a target lifecycle state to the action-shaped endpoint segment used
+ *  by `PolicyVersionsLifecycleController`. */
+export const TRANSITION_PATH_SEGMENT: Record<LifecycleState, string | null> = {
+  Active: 'publish',
+  WindingDown: 'winding-down',
+  Retired: 'retire',
+  Draft: null, // not a transition target
+};
+
+/** User-facing labels (matches simulator visual baseline). */
+export const LIFECYCLE_LABEL: Record<LifecycleState, string> = {
+  Draft: 'Draft',
+  Active: 'Active',
+  WindingDown: 'Winding down',
+  Retired: 'Retired',
+};
+
+/** Short copy describing the implication of moving INTO each state — surfaces
+ *  in the dropdown so authors don't accidentally retire an active policy. */
+export const TRANSITION_HINT: Record<LifecycleState, string> = {
+  Active: 'Publish — auto-supersedes the previous Active version.',
+  WindingDown: 'Mark for sunset — reads still resolve until retired.',
+  Retired: 'Tombstone — no further transitions are possible.',
+  Draft: '',
+};

--- a/client/src/app/features/policies/lifecycle-transition-modal.component.html
+++ b/client/src/app/features/policies/lifecycle-transition-modal.component.html
@@ -1,0 +1,66 @@
+<!-- Copyright (c) Rivoli AI 2026. All rights reserved. -->
+<div class="overlay" (click)="cancel()" data-testid="overlay">
+  <div
+    class="modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="lifecycle-modal-title"
+    (click)="$event.stopPropagation()">
+    <header class="modal-header">
+      <h2 id="lifecycle-modal-title">Transition lifecycle</h2>
+      <p class="subtitle">
+        Currently <strong>{{ LIFECYCLE_LABEL[version.state] }}</strong> ·
+        v{{ version.version }}
+      </p>
+    </header>
+
+    <app-lifecycle-diagram [current]="version.state"></app-lifecycle-diagram>
+
+    <form [formGroup]="form" (ngSubmit)="submit()" class="form" data-testid="form">
+      <div *ngIf="hasNoTargets()" class="banner-info" data-testid="terminal">
+        No further transitions available — version is in <strong>{{ LIFECYCLE_LABEL[version.state] }}</strong>.
+      </div>
+
+      <label *ngIf="!hasNoTargets()" class="field">
+        <span>Target state</span>
+        <select formControlName="targetState" class="input" data-testid="target">
+          <option *ngFor="let s of legalTargets()" [value]="s">
+            {{ LIFECYCLE_LABEL[s] }} — {{ TRANSITION_HINT[s] }}
+          </option>
+        </select>
+      </label>
+
+      <label *ngIf="!hasNoTargets()" class="field">
+        <span>
+          Rationale
+          <em>(required, min 10 chars — recorded in the audit chain)</em>
+        </span>
+        <textarea
+          formControlName="rationale"
+          class="input rationale"
+          rows="3"
+          data-testid="rationale"
+          placeholder="Why is this transition happening?"></textarea>
+      </label>
+
+      <div *ngIf="errorMessage()" class="banner-error" role="alert" data-testid="banner">
+        {{ errorMessage() }}
+      </div>
+
+      <footer class="modal-footer">
+        <button type="button" class="btn-secondary" (click)="cancel()" [disabled]="submitting()">
+          Cancel
+        </button>
+        <button
+          type="submit"
+          class="btn-primary"
+          *ngIf="!hasNoTargets()"
+          [disabled]="form.invalid || submitting()"
+          data-testid="submit">
+          <span *ngIf="!submitting()">Confirm transition</span>
+          <span *ngIf="submitting()">Submitting…</span>
+        </button>
+      </footer>
+    </form>
+  </div>
+</div>

--- a/client/src/app/features/policies/lifecycle-transition-modal.component.scss
+++ b/client/src/app/features/policies/lifecycle-transition-modal.component.scss
@@ -1,0 +1,114 @@
+/* Copyright (c) Rivoli AI 2026. All rights reserved. */
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 16px;
+}
+
+.modal {
+  background: var(--surface);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  padding: 20px 24px;
+  width: 100%;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
+}
+
+.modal-header h2 {
+  margin: 0 0 4px;
+  font-size: 18px;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.form { display: flex; flex-direction: column; gap: 12px; }
+
+.field { display: flex; flex-direction: column; gap: 4px; font-size: 14px; }
+.field > span {
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  em { color: var(--text-secondary); font-style: normal; font-weight: 400; }
+}
+
+.input {
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: inherit;
+  font-size: 14px;
+  width: 100%;
+}
+
+.input:focus { outline: 2px solid var(--primary); outline-offset: 1px; }
+
+.rationale {
+  resize: vertical;
+  min-height: 70px;
+  font-family: inherit;
+}
+
+.banner-info,
+.banner-error {
+  padding: 10px 14px;
+  border-radius: 6px;
+  font-size: 13px;
+}
+
+.banner-info {
+  background: var(--background);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+
+.banner-error {
+  background: #fce8e6;
+  border: 1px solid #f0a99a;
+  color: var(--error);
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.btn-primary,
+.btn-secondary {
+  padding: 8px 16px;
+  font-size: 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 1px solid var(--border);
+}
+
+.btn-primary {
+  background: var(--primary);
+  color: white;
+  border-color: var(--primary);
+}
+
+.btn-primary[disabled] { opacity: 0.55; cursor: not-allowed; }
+
+.btn-secondary {
+  background: var(--surface);
+  color: inherit;
+}
+
+.btn-secondary:hover:not([disabled]) { background: var(--background); }

--- a/client/src/app/features/policies/lifecycle-transition-modal.component.spec.ts
+++ b/client/src/app/features/policies/lifecycle-transition-modal.component.spec.ts
@@ -1,0 +1,136 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+import {
+  ApiService,
+  LifecycleState,
+  PolicyVersionDto,
+} from '../../shared/services/api.service';
+import { LifecycleTransitionModalComponent } from './lifecycle-transition-modal.component';
+
+describe('LifecycleTransitionModalComponent (P9.4)', () => {
+  let fixture: ComponentFixture<LifecycleTransitionModalComponent>;
+  let component: LifecycleTransitionModalComponent;
+  let api: jasmine.SpyObj<ApiService>;
+
+  const draftVersion: PolicyVersionDto = {
+    id: 'vid-1',
+    policyId: 'pid-1',
+    version: 1,
+    state: 'Draft',
+    enforcement: 'MUST',
+    severity: 'critical',
+    scopes: ['prod'],
+    summary: 'init',
+    rulesJson: '{}',
+    createdAt: '2026-04-01T00:00:00Z',
+    createdBySubjectId: 'user:alice',
+    proposerSubjectId: 'user:alice',
+  };
+
+  function build(version: PolicyVersionDto): void {
+    // Each build() resets the TestBed so the same `it()` can rebuild with
+    // different `version` inputs (legalTargets coverage walks all 4 states).
+    TestBed.resetTestingModule();
+    api = jasmine.createSpyObj<ApiService>('ApiService', ['transitionPolicyVersion']);
+    TestBed.configureTestingModule({
+      imports: [LifecycleTransitionModalComponent],
+      providers: [{ provide: ApiService, useValue: api }],
+    });
+
+    fixture = TestBed.createComponent(LifecycleTransitionModalComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('version', version);
+    component.ngOnInit();
+    fixture.detectChanges();
+  }
+
+  it('legalTargets are computed from the current state', () => {
+    build(draftVersion);
+    expect(component.legalTargets()).toEqual(['Active']);
+
+    build({ ...draftVersion, state: 'Active' });
+    expect(component.legalTargets()).toEqual(['WindingDown', 'Retired']);
+
+    build({ ...draftVersion, state: 'WindingDown' });
+    expect(component.legalTargets()).toEqual(['Retired']);
+
+    build({ ...draftVersion, state: 'Retired' });
+    expect(component.legalTargets()).toEqual([]);
+    expect(component.hasNoTargets()).toBeTrue();
+  });
+
+  it('Submit is disabled until rationale.length >= 10', () => {
+    build(draftVersion);
+
+    component.form.controls.rationale.setValue('short');
+    expect(component.form.invalid).toBeTrue();
+
+    component.form.controls.rationale.setValue('exactly 10');
+    expect(component.form.valid).toBeTrue();
+  });
+
+  it('renders no submit button when version is terminal (Retired)', () => {
+    build({ ...draftVersion, state: 'Retired' });
+
+    const btn = fixture.nativeElement.querySelector('[data-testid="submit"]');
+    expect(btn).toBeNull();
+    const banner = fixture.nativeElement.querySelector('[data-testid="terminal"]');
+    expect(banner).toBeTruthy();
+  });
+
+  it('submit calls transitionPolicyVersion with target + rationale', () => {
+    build(draftVersion);
+    const updated: PolicyVersionDto = { ...draftVersion, state: 'Active' };
+    api.transitionPolicyVersion.and.returnValue(of(updated));
+
+    const captures: (PolicyVersionDto | null)[] = [];
+    component.closed.subscribe(v => captures.push(v));
+
+    component.form.controls.rationale.setValue('publishing the initial draft');
+    component.submit();
+
+    expect(api.transitionPolicyVersion).toHaveBeenCalledTimes(1);
+    const args = api.transitionPolicyVersion.calls.mostRecent().args;
+    expect(args[0]).toBe('pid-1');
+    expect(args[1]).toBe('vid-1');
+    expect(args[2]).toBe('Active');
+    expect(args[3]).toBe('publishing the initial draft');
+
+    expect(captures).toEqual([updated]);
+  });
+
+  it('on 409 keeps the modal open and surfaces problem-detail', () => {
+    build(draftVersion);
+    const conflict = new HttpErrorResponse({
+      status: 409,
+      error: { detail: 'Lifecycle transition Draft → Retired is not allowed.' },
+    });
+    api.transitionPolicyVersion.and.returnValue(throwError(() => conflict));
+
+    let emitCount = 0;
+    component.closed.subscribe(() => emitCount++);
+
+    component.form.controls.rationale.setValue('a valid rationale');
+    component.submit();
+    fixture.detectChanges();
+
+    expect(emitCount).toBe(0); // modal stayed open — no closed emit
+    expect(component.errorMessage()).toContain('Draft → Retired');
+    const banner = fixture.nativeElement.querySelector('[data-testid="banner"]');
+    expect(banner).toBeTruthy();
+  });
+
+  it('cancel emits null without calling the API', () => {
+    build(draftVersion);
+    const captures: (PolicyVersionDto | null)[] = [];
+    component.closed.subscribe(v => captures.push(v));
+
+    component.cancel();
+
+    expect(api.transitionPolicyVersion).not.toHaveBeenCalled();
+    expect(captures).toEqual([null]);
+  });
+});

--- a/client/src/app/features/policies/lifecycle-transition-modal.component.ts
+++ b/client/src/app/features/policies/lifecycle-transition-modal.component.ts
@@ -1,0 +1,138 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  EventEmitter,
+  Input,
+  Output,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  FormControl,
+  FormGroup,
+  NonNullableFormBuilder,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import {
+  ApiService,
+  LifecycleState,
+  PolicyVersionDto,
+} from '../../shared/services/api.service';
+import { LifecycleDiagramComponent } from './lifecycle-diagram.component';
+import {
+  LIFECYCLE_GRAPH,
+  LIFECYCLE_LABEL,
+  TRANSITION_HINT,
+} from './lifecycle-graph';
+
+interface TransitionForm {
+  targetState: FormControl<LifecycleState>;
+  rationale: FormControl<string>;
+}
+
+/**
+ * P9.4 (rivoli-ai/andy-policies#69) — modal that wraps a single lifecycle
+ * transition. Renders the diagram of the four-state graph, lets the user
+ * choose a legal target (computed from `version.state` against
+ * `LIFECYCLE_GRAPH`), and forwards a non-empty rationale to the server.
+ *
+ * Server is authoritative: illegal target → 409, missing rationale → 400.
+ * On 409 the modal stays open so the user can adjust rationale or cancel;
+ * on success the modal emits the updated DTO via `closed` so the host can
+ * refresh without a full page reload.
+ */
+@Component({
+  selector: 'app-lifecycle-transition-modal',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, LifecycleDiagramComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './lifecycle-transition-modal.component.html',
+  styleUrls: ['./lifecycle-transition-modal.component.scss'],
+})
+export class LifecycleTransitionModalComponent {
+  static readonly minRationaleLength = 10;
+
+  @Input({ required: true }) version!: PolicyVersionDto;
+  @Output() readonly closed = new EventEmitter<PolicyVersionDto | null>();
+
+  private readonly api = inject(ApiService);
+  private readonly fb = inject(NonNullableFormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly submitting = signal(false);
+  readonly errorMessage = signal<string | null>(null);
+
+  readonly LIFECYCLE_LABEL = LIFECYCLE_LABEL;
+  readonly TRANSITION_HINT = TRANSITION_HINT;
+
+  readonly form: FormGroup<TransitionForm> = this.fb.group<TransitionForm>({
+    targetState: this.fb.control<LifecycleState>('Active', Validators.required),
+    rationale: this.fb.control('', [
+      Validators.required,
+      Validators.minLength(LifecycleTransitionModalComponent.minRationaleLength),
+    ]),
+  });
+
+  readonly legalTargets = computed<LifecycleState[]>(() =>
+    LIFECYCLE_GRAPH[this.version?.state ?? 'Retired'] ?? [],
+  );
+
+  readonly hasNoTargets = computed(() => this.legalTargets().length === 0);
+
+  ngOnInit(): void {
+    const targets = this.legalTargets();
+    if (targets.length > 0) {
+      this.form.controls.targetState.setValue(targets[0]);
+    }
+  }
+
+  submit(): void {
+    if (this.form.invalid || this.submitting()) return;
+    const { targetState, rationale } = this.form.getRawValue();
+
+    this.submitting.set(true);
+    this.errorMessage.set(null);
+    this.api
+      .transitionPolicyVersion(this.version.policyId, this.version.id, targetState, rationale)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: updated => {
+          this.submitting.set(false);
+          this.closed.emit(updated);
+        },
+        error: (err: HttpErrorResponse) => {
+          this.submitting.set(false);
+          // 409 = illegal transition / concurrent change. Keep the modal
+          // open so the user can adjust or cancel.
+          if (err.status === 409) {
+            this.errorMessage.set(this.describeProblem(err)
+              ?? 'Transition rejected by the server. Refresh and try again.');
+            return;
+          }
+          this.errorMessage.set(this.describeProblem(err) ?? `Unexpected error (${err.status}).`);
+        },
+      });
+  }
+
+  cancel(): void {
+    this.closed.emit(null);
+  }
+
+  /** Pull `detail` out of an RFC 7807 ProblemDetails body, falling back to
+   *  `title` then a generic. */
+  private describeProblem(err: HttpErrorResponse): string | null {
+    const body = err.error;
+    if (!body) return null;
+    if (typeof body.detail === 'string' && body.detail) return body.detail;
+    if (typeof body.title === 'string' && body.title) return `${body.title} (${err.status}).`;
+    return null;
+  }
+}

--- a/client/src/app/features/policies/policies-list.component.html
+++ b/client/src/app/features/policies/policies-list.component.html
@@ -87,7 +87,11 @@
     </thead>
     <tbody>
       <tr *ngFor="let p of policies()">
-        <td><span class="name">{{ p.name }}</span></td>
+        <td>
+          <a class="name" [routerLink]="['/policies', p.id]" [attr.data-testid]="'detail-' + p.id">
+            {{ p.name }}
+          </a>
+        </td>
         <td>{{ p.description || '—' }}</td>
         <td class="numeric">{{ p.versionCount }}</td>
         <td>

--- a/client/src/app/features/policies/policies-list.component.scss
+++ b/client/src/app/features/policies/policies-list.component.scss
@@ -136,7 +136,10 @@
 
   .name {
     font-weight: 500;
+    color: var(--primary);
+    text-decoration: none;
   }
+  .name:hover { text-decoration: underline; }
 }
 
 .badge {

--- a/client/src/app/features/policies/policy-detail.component.html
+++ b/client/src/app/features/policies/policy-detail.component.html
@@ -1,0 +1,82 @@
+<!-- Copyright (c) Rivoli AI 2026. All rights reserved. -->
+<div class="page">
+  <p class="back"><a routerLink="/policies">← Back to policies</a></p>
+
+  <ng-container *ngIf="loading()">
+    <div class="loading" data-testid="loading">Loading…</div>
+  </ng-container>
+
+  <div *ngIf="errorMessage() && !loading()" class="banner-error" role="alert" data-testid="banner">
+    {{ errorMessage() }}
+  </div>
+
+  <ng-container *ngIf="policy() as p">
+    <header class="page-header">
+      <h1 class="title-row">
+        <span class="policy-name">{{ p.name }}</span>
+        <span *ngIf="activeVersion() as a" class="active-pill">
+          Active v{{ a.version }}
+        </span>
+        <span *ngIf="!activeVersion()" class="active-pill draft">
+          No active version
+        </span>
+      </h1>
+      <p *ngIf="p.description" class="subtitle">{{ p.description }}</p>
+    </header>
+
+    <section *ngIf="activeVersion() as a" class="card">
+      <h2>Lifecycle</h2>
+      <app-lifecycle-diagram [current]="a.state"></app-lifecycle-diagram>
+    </section>
+
+    <section class="card">
+      <h2>Versions</h2>
+      <table class="versions-table" data-testid="versions">
+        <thead>
+          <tr>
+            <th>Version</th>
+            <th>State</th>
+            <th>Summary</th>
+            <th>Enforcement</th>
+            <th>Severity</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let v of versions()">
+            <td class="numeric">v{{ v.version }}</td>
+            <td>
+              <span class="badge badge-{{ v.state }}">{{ LIFECYCLE_LABEL[v.state] }}</span>
+            </td>
+            <td>{{ v.summary }}</td>
+            <td>{{ v.enforcement }}</td>
+            <td>{{ v.severity }}</td>
+            <td class="actions">
+              <a
+                *ngIf="v.state === 'Draft'"
+                class="btn-link"
+                [routerLink]="['/policies', v.policyId, 'versions', v.id, 'edit']"
+                [attr.data-testid]="'edit-' + v.id">
+                Edit
+              </a>
+              <button
+                *ngIf="hasLegalTransitions(v)"
+                type="button"
+                class="btn-link"
+                (click)="openTransition(v)"
+                [attr.data-testid]="'transition-' + v.id">
+                Transition…
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </ng-container>
+
+  <app-lifecycle-transition-modal
+    *ngIf="transitioningVersion() as tv"
+    [version]="tv"
+    (closed)="onModalClosed($event)">
+  </app-lifecycle-transition-modal>
+</div>

--- a/client/src/app/features/policies/policy-detail.component.scss
+++ b/client/src/app/features/policies/policy-detail.component.scss
@@ -1,0 +1,137 @@
+/* Copyright (c) Rivoli AI 2026. All rights reserved. */
+
+.page { display: flex; flex-direction: column; gap: 16px; }
+
+.back a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 13px;
+}
+.back a:hover { color: var(--primary); }
+
+.page-header h1.title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin: 0 0 4px;
+}
+
+.policy-name { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+
+.active-pill {
+  font-size: 0.7em;
+  background: #e6f4ea;
+  color: var(--success);
+  border: 1px solid #b6e0c2;
+  border-radius: 12px;
+  padding: 2px 10px;
+  font-weight: 500;
+}
+
+.active-pill.draft {
+  background: var(--background);
+  color: var(--text-secondary);
+  border-color: var(--border);
+}
+
+.subtitle { margin: 0; color: var(--text-secondary); }
+
+.loading,
+.banner-error {
+  padding: 16px;
+  border-radius: 6px;
+  font-size: 14px;
+  text-align: center;
+}
+
+.loading {
+  background: var(--surface);
+  border: 1px dashed var(--border);
+  color: var(--text-secondary);
+}
+
+.banner-error {
+  background: #fce8e6;
+  border: 1px solid #f0a99a;
+  color: var(--error);
+  text-align: left;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.versions-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.versions-table th,
+.versions-table td {
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+
+.versions-table th {
+  background: var(--background);
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.versions-table tbody tr:last-child td { border-bottom: none; }
+
+.versions-table .numeric {
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+}
+
+.versions-table .actions {
+  display: flex;
+  gap: 8px;
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.badge-Draft { background: #fce8e6; color: var(--error); }
+.badge-Active { background: #e6f4ea; color: var(--success); }
+.badge-WindingDown { background: #fff4e5; color: #a85d00; }
+.badge-Retired { background: var(--background); color: var(--text-secondary); }
+
+.btn-link {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--primary);
+  font: inherit;
+  font-size: 13px;
+  text-decoration: none;
+}
+
+.btn-link:hover { text-decoration: underline; }

--- a/client/src/app/features/policies/policy-detail.component.spec.ts
+++ b/client/src/app/features/policies/policy-detail.component.spec.ts
@@ -1,0 +1,134 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+import {
+  ApiService,
+  PolicyDto,
+  PolicyVersionDto,
+} from '../../shared/services/api.service';
+import { PolicyDetailComponent } from './policy-detail.component';
+
+describe('PolicyDetailComponent (P9.4)', () => {
+  let fixture: ComponentFixture<PolicyDetailComponent>;
+  let component: PolicyDetailComponent;
+  let api: jasmine.SpyObj<ApiService>;
+
+  const samplePolicy: PolicyDto = {
+    id: 'pid-1',
+    name: 'no-prod',
+    description: 'No prod from drafts',
+    createdAt: '2026-04-01T00:00:00Z',
+    createdBySubjectId: 'user:alice',
+    versionCount: 2,
+    activeVersionId: 'vid-active',
+  };
+
+  const draftV2: PolicyVersionDto = {
+    id: 'vid-2',
+    policyId: 'pid-1',
+    version: 2,
+    state: 'Draft',
+    enforcement: 'SHOULD',
+    severity: 'moderate',
+    scopes: [],
+    summary: 'next iteration',
+    rulesJson: '{}',
+    createdAt: '2026-04-15T00:00:00Z',
+    createdBySubjectId: 'user:bob',
+    proposerSubjectId: 'user:bob',
+  };
+
+  const activeV1: PolicyVersionDto = {
+    ...draftV2,
+    id: 'vid-active',
+    version: 1,
+    state: 'Active',
+    summary: 'initial',
+  };
+
+  function build(): void {
+    api = jasmine.createSpyObj<ApiService>('ApiService', [
+      'getPolicy',
+      'listPolicyVersions',
+    ]);
+    api.getPolicy.and.returnValue(of(samplePolicy));
+    api.listPolicyVersions.and.returnValue(of([activeV1, draftV2]));
+
+    TestBed.configureTestingModule({
+      imports: [PolicyDetailComponent],
+      providers: [
+        provideRouter([]),
+        { provide: ApiService, useValue: api },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: convertToParamMap({ id: 'pid-1' }) } },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(PolicyDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  it('loads policy + versions on init and sorts versions descending', () => {
+    build();
+    expect(api.getPolicy).toHaveBeenCalledWith('pid-1');
+    expect(api.listPolicyVersions).toHaveBeenCalledWith('pid-1');
+    expect(component.versions().map(v => v.version)).toEqual([2, 1]);
+  });
+
+  it('activeVersion resolves from policy.activeVersionId', () => {
+    build();
+    expect(component.activeVersion()?.id).toBe('vid-active');
+  });
+
+  it('Edit link is shown only on Draft rows', () => {
+    build();
+    const editDraft = fixture.nativeElement.querySelector('[data-testid="edit-vid-2"]');
+    const editActive = fixture.nativeElement.querySelector('[data-testid="edit-vid-active"]');
+    expect(editDraft).toBeTruthy();
+    expect(editActive).toBeNull();
+  });
+
+  it('Transition button is shown only on rows with legal targets', () => {
+    build();
+    // Draft has [Active]; Active has [WindingDown, Retired]; both have legal targets.
+    expect(fixture.nativeElement.querySelector('[data-testid="transition-vid-2"]')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="transition-vid-active"]')).toBeTruthy();
+  });
+
+  it('openTransition sets the modal source version', () => {
+    build();
+    component.openTransition(draftV2);
+    expect(component.transitioningVersion()).toBe(draftV2);
+  });
+
+  it('onModalClosed(null) clears the modal without calling getPolicy', () => {
+    build();
+    component.openTransition(draftV2);
+    api.getPolicy.calls.reset();
+
+    component.onModalClosed(null);
+
+    expect(component.transitioningVersion()).toBeNull();
+    expect(api.getPolicy).not.toHaveBeenCalled();
+  });
+
+  it('onModalClosed(updated) replaces the version and refetches the policy', () => {
+    build();
+    const updated: PolicyVersionDto = { ...draftV2, state: 'Active' };
+
+    component.openTransition(draftV2);
+    api.getPolicy.calls.reset();
+    api.getPolicy.and.returnValue(of({ ...samplePolicy, activeVersionId: 'vid-2' }));
+
+    component.onModalClosed(updated);
+
+    expect(component.transitioningVersion()).toBeNull();
+    expect(component.versions().find(v => v.id === 'vid-2')!.state).toBe('Active');
+    expect(api.getPolicy).toHaveBeenCalledWith('pid-1');
+  });
+});

--- a/client/src/app/features/policies/policy-detail.component.ts
+++ b/client/src/app/features/policies/policy-detail.component.ts
@@ -1,0 +1,121 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { forkJoin } from 'rxjs';
+import {
+  ApiService,
+  PolicyDto,
+  PolicyVersionDto,
+} from '../../shared/services/api.service';
+import { LifecycleDiagramComponent } from './lifecycle-diagram.component';
+import { LifecycleTransitionModalComponent } from './lifecycle-transition-modal.component';
+import { LIFECYCLE_GRAPH, LIFECYCLE_LABEL } from './lifecycle-graph';
+
+/**
+ * P9.4 (rivoli-ai/andy-policies#69) — minimum viable policy detail page.
+ * Shows policy header, the version list, and a Transition button that
+ * opens `LifecycleTransitionModalComponent` for the selected version. Edit
+ * (P9.2) link surfaces only on Draft versions. Bindings/overrides/audit
+ * panels arrive in P9.5/P9.6/P9.7.
+ */
+@Component({
+  selector: 'app-policy-detail',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterLink,
+    LifecycleDiagramComponent,
+    LifecycleTransitionModalComponent,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './policy-detail.component.html',
+  styleUrls: ['./policy-detail.component.scss'],
+})
+export class PolicyDetailComponent {
+  private readonly api = inject(ApiService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly LIFECYCLE_LABEL = LIFECYCLE_LABEL;
+
+  readonly policy = signal<PolicyDto | null>(null);
+  readonly versions = signal<PolicyVersionDto[]>([]);
+  readonly loading = signal(true);
+  readonly errorMessage = signal<string | null>(null);
+
+  readonly transitioningVersion = signal<PolicyVersionDto | null>(null);
+
+  readonly activeVersion = computed<PolicyVersionDto | null>(() => {
+    const list = this.versions();
+    const p = this.policy();
+    if (!p?.activeVersionId) return null;
+    return list.find(v => v.id === p.activeVersionId) ?? null;
+  });
+
+  constructor() {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id) this.load(id);
+  }
+
+  hasLegalTransitions(version: PolicyVersionDto): boolean {
+    return (LIFECYCLE_GRAPH[version.state] ?? []).length > 0;
+  }
+
+  openTransition(version: PolicyVersionDto): void {
+    this.transitioningVersion.set(version);
+  }
+
+  onModalClosed(updated: PolicyVersionDto | null): void {
+    if (updated) {
+      // Replace the version in-place, then refetch the policy header so
+      // activeVersionId moves with the transition.
+      this.versions.update(vs =>
+        vs.map(v => (v.id === updated.id ? updated : v)),
+      );
+      const id = this.policy()?.id;
+      if (id) {
+        this.api
+          .getPolicy(id)
+          .pipe(takeUntilDestroyed(this.destroyRef))
+          .subscribe({
+            next: p => this.policy.set(p),
+            error: () => {/* non-critical */},
+          });
+      }
+    }
+    this.transitioningVersion.set(null);
+  }
+
+  private load(id: string): void {
+    this.loading.set(true);
+    this.errorMessage.set(null);
+    forkJoin({
+      policy: this.api.getPolicy(id),
+      versions: this.api.listPolicyVersions(id),
+    })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: ({ policy, versions }) => {
+          this.policy.set(policy);
+          // Sort by version desc so latest is first.
+          this.versions.set([...versions].sort((a, b) => b.version - a.version));
+          this.loading.set(false);
+        },
+        error: (err: HttpErrorResponse) => {
+          this.loading.set(false);
+          this.errorMessage.set(err.error?.title ?? `Failed to load policy (${err.status}).`);
+        },
+      });
+  }
+}

--- a/client/src/app/shared/services/api.service.ts
+++ b/client/src/app/shared/services/api.service.ts
@@ -62,6 +62,23 @@ export interface UpdatePolicyVersionRequest {
   rulesJson: string;
 }
 
+/** Body for the lifecycle transition endpoints (publish / winding-down / retire). */
+export interface LifecycleTransitionBody {
+  rationale: string;
+}
+
+/**
+ * Maps a target lifecycle state to the action-shaped path segment used by
+ * `PolicyVersionsLifecycleController`. `Draft` is intentionally null —
+ * versions are born Draft, never transitioned to it.
+ */
+const TRANSITION_PATH_SEGMENTS: Record<LifecycleState, string | null> = {
+  Active: 'publish',
+  WindingDown: 'winding-down',
+  Retired: 'retire',
+  Draft: null,
+};
+
 /** Filters accepted by `GET /api/policies`. The server has no full-text search;
  *  `namePrefix` does prefix matching only. No `state=` filter exists; per-row
  *  `activeVersionId == null` means "all versions are still draft" client-side. */
@@ -134,6 +151,36 @@ export class ApiService {
     return this.http.put<PolicyVersionDto>(
       `${this.baseUrl}/policies/${id}/versions/${versionId}`,
       request,
+    );
+  }
+
+  /** P9.4 (#69) — list all versions of a policy. */
+  listPolicyVersions(id: string): Observable<PolicyVersionDto[]> {
+    return this.http.get<PolicyVersionDto[]>(
+      `${this.baseUrl}/policies/${id}/versions`,
+    );
+  }
+
+  /**
+   * P9.4 (#69) — transition a version to a new lifecycle state.
+   * Routes to the action-shaped endpoint that the server exposes
+   * (`publish` / `winding-down` / `retire`). The server is the
+   * authoritative gate for legality — illegal transitions return 409
+   * regardless of what the client requested.
+   */
+  transitionPolicyVersion(
+    id: string,
+    versionId: string,
+    targetState: LifecycleState,
+    rationale: string,
+  ): Observable<PolicyVersionDto> {
+    const segment = TRANSITION_PATH_SEGMENTS[targetState];
+    if (!segment) {
+      throw new Error(`No endpoint exists for transition to '${targetState}'.`);
+    }
+    return this.http.post<PolicyVersionDto>(
+      `${this.baseUrl}/policies/${id}/versions/${versionId}/${segment}`,
+      { rationale },
     );
   }
 


### PR DESCRIPTION
## Summary

Adds the lifecycle transitions UX — modal with state diagram, target dropdown computed from the four-state graph (Draft → Active → WindingDown → Retired), rationale textarea (min 10 chars, audit-chain enforced server-side), and a minimal policy detail page at \`/policies/:id\` to host it. Policies list rows now link into the detail page.

The single \`ApiService.transitionPolicyVersion(id, vId, target, rationale)\` routes to the right action-shaped endpoint (\`publish\` / \`winding-down\` / \`retire\`); UI never has to know which URL maps to which target.

## Spec deltas worth flagging

- **Endpoints**: spec posited a unified \`POST /transition\`; server has three separate action endpoints. Behaviour matches; URL shape differs.
- **State names**: \`Active\`/\`WindingDown\` per ADR 0001 §6, not the spec's \`Published\`/\`Deprecated\`.
- **Concurrency token**: no \`expectedRevision\` (tracked as #194); transitions are last-write-wins.

## Test plan

- [x] \`npm test -- --watch=false --browsers=ChromeHeadless\` — **40/40 pass**:
  - 3 diagram cases (renders 4 nodes, marks current state active, moves on input change).
  - 6 modal cases (legal-target matrix Draft/Active/WindingDown/Retired, rationale gate at minlength 10, terminal state hides Submit, success emits updated DTO, 409 keeps modal open with detail surfaced, cancel emits null).
  - 7 detail cases (load + version sort, activeVersion compute, Edit-on-Draft visibility, Transition-on-legal visibility, modal open + close-null + close-with-update refetch).
  - 24 carried from P9.1/P9.2.
- [x] \`npm run build\` — prod bundle clean.
- [x] \`dotnet build\` — green.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)