### PR TITLE
Implement P9.5 — bindings manager (#70)

### DIFF
--- a/client/src/app/features/policies/bindings-manager.component.html
+++ b/client/src/app/features/policies/bindings-manager.component.html
@@ -1,0 +1,76 @@
+<!-- Copyright (c) Rivoli AI 2026. All rights reserved. -->
+<section class="card">
+  <header class="card-header">
+    <h2>Bindings</h2>
+    <button
+      type="button"
+      class="btn-primary btn-sm"
+      (click)="openCreate()"
+      [disabled]="loading() || versions.length === 0"
+      data-testid="create-binding">
+      + Add binding
+    </button>
+  </header>
+
+  <div *ngIf="loading()" class="loading" data-testid="loading">Loading bindings…</div>
+
+  <div *ngIf="errorMessage() && !loading()" class="banner-error" role="alert" data-testid="banner">
+    {{ errorMessage() }}
+  </div>
+
+  <p *ngIf="!loading() && !errorMessage() && !hasAnyBindings()" class="empty" data-testid="empty">
+    No bindings on any version of this policy yet.
+  </p>
+
+  <table
+    *ngIf="!loading() && hasAnyBindings()"
+    class="bindings-table"
+    data-testid="bindings-table">
+    <thead>
+      <tr>
+        <th>Version</th>
+        <th>Target type</th>
+        <th>Target ref</th>
+        <th>Strength</th>
+        <th>Created</th>
+        <th>Created by</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let b of bindings()">
+        <td class="numeric">v{{ b.versionNumber }}</td>
+        <td>{{ b.targetType }}</td>
+        <td><code class="ref">{{ b.targetRef }}</code></td>
+        <td>
+          <span class="badge" [class.mandatory]="b.bindStrength === 'Mandatory'">
+            {{ b.bindStrength }}
+          </span>
+        </td>
+        <td>{{ b.createdAt | date: 'short' }}</td>
+        <td class="subject">{{ b.createdBySubjectId }}</td>
+        <td>
+          <button
+            type="button"
+            class="btn-link danger"
+            (click)="openDelete(b)"
+            [attr.data-testid]="'delete-' + b.id">
+            Delete
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<app-create-binding-modal
+  *ngIf="showCreate()"
+  [versions]="versions"
+  (closed)="onCreateClosed($event)">
+</app-create-binding-modal>
+
+<app-delete-binding-modal
+  *ngIf="deleting() as b"
+  [binding]="b"
+  (closed)="onDeleteClosed($event)">
+</app-delete-binding-modal>

--- a/client/src/app/features/policies/bindings-manager.component.scss
+++ b/client/src/app/features/policies/bindings-manager.component.scss
@@ -1,0 +1,135 @@
+/* Copyright (c) Rivoli AI 2026. All rights reserved. */
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+
+  h2 {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+}
+
+.loading,
+.empty,
+.banner-error {
+  padding: 14px;
+  text-align: center;
+  font-size: 13px;
+  border-radius: 6px;
+}
+
+.loading,
+.empty {
+  background: var(--background);
+  color: var(--text-secondary);
+  border: 1px dashed var(--border);
+}
+
+.banner-error {
+  text-align: left;
+  background: #fce8e6;
+  border: 1px solid #f0a99a;
+  color: var(--error);
+}
+
+.bindings-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.bindings-table th,
+.bindings-table td {
+  padding: 8px 10px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  vertical-align: middle;
+}
+
+.bindings-table th {
+  background: var(--background);
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.bindings-table tbody tr:last-child td { border-bottom: none; }
+
+.bindings-table .numeric {
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+}
+
+.bindings-table .ref {
+  background: var(--background);
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 12px;
+}
+
+.bindings-table .subject {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 500;
+  background: var(--background);
+  color: var(--text-secondary);
+}
+
+.badge.mandatory {
+  background: #fce8e6;
+  color: var(--error);
+}
+
+.btn-primary {
+  background: var(--primary);
+  color: white;
+  border: 1px solid var(--primary);
+  padding: 8px 16px;
+  font-size: 14px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn-primary[disabled] { opacity: 0.55; cursor: not-allowed; }
+
+.btn-sm { padding: 6px 12px; font-size: 13px; }
+
+.btn-link {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--primary);
+  font: inherit;
+  font-size: 12px;
+}
+
+.btn-link:hover { text-decoration: underline; }
+.btn-link.danger { color: var(--error); }

--- a/client/src/app/features/policies/bindings-manager.component.spec.ts
+++ b/client/src/app/features/policies/bindings-manager.component.spec.ts
@@ -1,0 +1,142 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  ApiService,
+  BindingDto,
+  PolicyVersionDto,
+} from '../../shared/services/api.service';
+import { BindingsManagerComponent } from './bindings-manager.component';
+
+describe('BindingsManagerComponent (P9.5)', () => {
+  let fixture: ComponentFixture<BindingsManagerComponent>;
+  let component: BindingsManagerComponent;
+  let api: jasmine.SpyObj<ApiService>;
+
+  const v1Active: PolicyVersionDto = {
+    id: 'vid-1', policyId: 'pid-1', version: 1, state: 'Active',
+    enforcement: 'MUST', severity: 'critical', scopes: [],
+    summary: 'initial', rulesJson: '{}',
+    createdAt: '2026-04-01T00:00:00Z', createdBySubjectId: 'u', proposerSubjectId: 'u',
+  };
+  const v2Draft: PolicyVersionDto = { ...v1Active, id: 'vid-2', version: 2, state: 'Draft' };
+
+  const bindingA: BindingDto = {
+    id: 'bid-A', policyVersionId: 'vid-1',
+    targetType: 'Repo', targetRef: 'rivoli-ai/a',
+    bindStrength: 'Mandatory',
+    createdAt: '2026-04-02T00:00:00Z', createdBySubjectId: 'u',
+    deletedAt: null, deletedBySubjectId: null,
+  };
+  const bindingB: BindingDto = { ...bindingA, id: 'bid-B', policyVersionId: 'vid-2', targetRef: 'rivoli-ai/b' };
+  const bindingDeleted: BindingDto = { ...bindingA, id: 'bid-DEL', deletedAt: '2026-04-03T00:00:00Z' };
+
+  /** Helper signature carries the API stub eagerly so build() applies the
+   *  callFake BEFORE the component's ngOnChanges runs — otherwise the
+   *  spy is bare and the load loop hits an empty function. */
+  function build(opts: {
+    withVersions: boolean;
+    perVersion?: (versionId: string) => BindingDto[];
+    perVersionError?: (versionId: string) => HttpErrorResponse | null;
+  }): void {
+    TestBed.resetTestingModule();
+    api = jasmine.createSpyObj<ApiService>('ApiService', ['listVersionBindings']);
+    api.listVersionBindings.and.callFake((_, vId) => {
+      const err = opts.perVersionError?.(vId);
+      if (err) return throwError(() => err);
+      return of(opts.perVersion?.(vId) ?? []);
+    });
+
+    TestBed.configureTestingModule({
+      imports: [BindingsManagerComponent],
+      providers: [{ provide: ApiService, useValue: api }],
+    });
+
+    fixture = TestBed.createComponent(BindingsManagerComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('policyId', 'pid-1');
+    fixture.componentRef.setInput(
+      'versions',
+      opts.withVersions ? [v1Active, v2Draft] : [],
+    );
+    component.ngOnChanges();
+    fixture.detectChanges();
+  }
+
+  it('aggregates bindings across versions and sorts by version desc', () => {
+    build({
+      withVersions: true,
+      perVersion: vId => (vId === 'vid-1' ? [bindingA] : [bindingB]),
+    });
+
+    // listVersionBindings is called once per version per reload — the test
+    // helper triggers reload twice (manual ngOnChanges + auto on first
+    // detectChanges) so 2 versions × 2 reloads = 4. We only care that the
+    // component called the API at least once per version, hence assert ≥ 2.
+    expect(api.listVersionBindings.calls.count()).toBeGreaterThanOrEqual(2);
+    expect(component.bindings().length).toBe(2);
+    // v2 first (desc), v1 second.
+    expect(component.bindings().map(b => b.id)).toEqual(['bid-B', 'bid-A']);
+    expect(component.bindings()[0].versionNumber).toBe(2);
+  });
+
+  it('filters out soft-deleted bindings', () => {
+    build({
+      withVersions: true,
+      perVersion: () => [bindingA, bindingDeleted],
+    });
+
+    expect(component.bindings().length).toBe(2); // bindingA from each version, deleted dropped
+    expect(component.bindings().every(b => b.id !== 'bid-DEL')).toBeTrue();
+  });
+
+  it('renders empty state when no bindings on any version', () => {
+    build({ withVersions: true });
+
+    const empty = fixture.nativeElement.querySelector('[data-testid="empty"]');
+    expect(empty).toBeTruthy();
+  });
+
+  it('does not call API when versions is empty', () => {
+    build({ withVersions: false });
+    expect(api.listVersionBindings).not.toHaveBeenCalled();
+  });
+
+  it('survives a per-version error by returning empty rows for that version', () => {
+    build({
+      withVersions: true,
+      perVersionError: vId =>
+        vId === 'vid-1' ? new HttpErrorResponse({ status: 403 }) : null,
+      perVersion: vId => (vId === 'vid-2' ? [bindingB] : []),
+    });
+
+    expect(component.bindings().length).toBe(1);
+    expect(component.bindings()[0].id).toBe('bid-B');
+    expect(component.errorMessage()).toBeNull();
+  });
+
+  it('onCreateClosed appends + sorts the new row', () => {
+    build({ withVersions: true });
+
+    const created: BindingDto = { ...bindingA, id: 'bid-NEW', policyVersionId: 'vid-2' };
+    component.onCreateClosed(created);
+
+    expect(component.bindings()[0].id).toBe('bid-NEW');
+    expect(component.bindings()[0].versionNumber).toBe(2);
+  });
+
+  it('onDeleteClosed(deleted=true) removes the row from the list', () => {
+    build({
+      withVersions: true,
+      perVersion: vId => (vId === 'vid-1' ? [bindingA] : [bindingB]),
+    });
+    expect(component.bindings().length).toBe(2);
+
+    component.onDeleteClosed({ deleted: true, bindingId: 'bid-A' });
+
+    expect(component.bindings().length).toBe(1);
+    expect(component.bindings()[0].id).toBe('bid-B');
+  });
+});

--- a/client/src/app/features/policies/bindings-manager.component.ts
+++ b/client/src/app/features/policies/bindings-manager.component.ts
@@ -1,0 +1,160 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  Input,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { forkJoin, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import {
+  ApiService,
+  BindingDto,
+  PolicyVersionDto,
+} from '../../shared/services/api.service';
+import { CreateBindingModalComponent } from './create-binding-modal.component';
+import { DeleteBindingModalComponent } from './delete-binding-modal.component';
+
+interface BindingRow extends BindingDto {
+  versionNumber: number;
+  versionState: string;
+}
+
+/**
+ * P9.5 (rivoli-ai/andy-policies#70) — bindings manager mounted under
+ * the policy detail page. Aggregates bindings across every version of
+ * the policy via parallel `GET /api/policies/{id}/versions/{vId}/bindings`
+ * calls (the server has no per-policy list endpoint), and renders a
+ * single table with a Version column.
+ *
+ * Spec called for autocomplete on target-ref via a `/target-refs`
+ * endpoint that doesn't exist; target-ref is free-text here. Filed as
+ * a follow-up.
+ */
+@Component({
+  selector: 'app-bindings-manager',
+  standalone: true,
+  imports: [
+    CommonModule,
+    CreateBindingModalComponent,
+    DeleteBindingModalComponent,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './bindings-manager.component.html',
+  styleUrls: ['./bindings-manager.component.scss'],
+})
+export class BindingsManagerComponent {
+  @Input({ required: true }) policyId!: string;
+  @Input({ required: true }) versions: readonly PolicyVersionDto[] = [];
+
+  private readonly api = inject(ApiService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly bindings = signal<BindingRow[]>([]);
+  readonly loading = signal(false);
+  readonly errorMessage = signal<string | null>(null);
+
+  readonly showCreate = signal(false);
+  readonly deleting = signal<BindingDto | null>(null);
+
+  readonly hasAnyBindings = computed(() => this.bindings().length > 0);
+
+  ngOnChanges(): void {
+    // versions @Input arrives once the parent has loaded — refresh whenever it changes.
+    if (this.policyId && this.versions.length > 0) {
+      this.reload();
+    }
+  }
+
+  reload(): void {
+    if (this.versions.length === 0) {
+      this.bindings.set([]);
+      return;
+    }
+    this.loading.set(true);
+    this.errorMessage.set(null);
+
+    // forkJoin across versions — empty result on a 4xx for one version
+    // doesn't sink the whole page; the version-scoped 403 (e.g. the
+    // current user can't read a particular version) gets swallowed.
+    const calls = this.versions.map(v =>
+      this.api.listVersionBindings(this.policyId, v.id).pipe(
+        map(rows => ({ version: v, rows })),
+        catchError(() => of({ version: v, rows: [] as BindingDto[] })),
+      ),
+    );
+    forkJoin(calls)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: results => {
+          const rows: BindingRow[] = results.flatMap(({ version, rows }) =>
+            rows
+              .filter(r => r.deletedAt === null)
+              .map(r => ({
+                ...r,
+                versionNumber: version.version,
+                versionState: version.state,
+              })),
+          );
+          // Sort by version desc, then targetType, then targetRef so reads
+          // through the table are stable across reloads.
+          rows.sort((a, b) =>
+            b.versionNumber - a.versionNumber
+            || a.targetType.localeCompare(b.targetType)
+            || a.targetRef.localeCompare(b.targetRef),
+          );
+          this.bindings.set(rows);
+          this.loading.set(false);
+        },
+        error: (err: HttpErrorResponse) => {
+          this.loading.set(false);
+          this.errorMessage.set(err.error?.title ?? `Failed to load bindings (${err.status}).`);
+        },
+      });
+  }
+
+  openCreate(): void {
+    this.showCreate.set(true);
+  }
+
+  onCreateClosed(created: BindingDto | null): void {
+    this.showCreate.set(false);
+    if (created) {
+      // Locate the version this binding hit so we can decorate the row
+      // without a full reload.
+      const ver = this.versions.find(v => v.id === created.policyVersionId);
+      const row: BindingRow = {
+        ...created,
+        versionNumber: ver?.version ?? -1,
+        versionState: ver?.state ?? 'Unknown',
+      };
+      this.bindings.update(rows => {
+        const next = [row, ...rows];
+        next.sort((a, b) =>
+          b.versionNumber - a.versionNumber
+          || a.targetType.localeCompare(b.targetType)
+          || a.targetRef.localeCompare(b.targetRef),
+        );
+        return next;
+      });
+    }
+  }
+
+  openDelete(binding: BindingDto): void {
+    this.deleting.set(binding);
+  }
+
+  onDeleteClosed(result: { deleted: boolean; bindingId: string } | null): void {
+    if (result?.deleted) {
+      this.bindings.update(rows => rows.filter(r => r.id !== result.bindingId));
+    }
+    this.deleting.set(null);
+  }
+}

--- a/client/src/app/features/policies/create-binding-modal.component.html
+++ b/client/src/app/features/policies/create-binding-modal.component.html
@@ -1,0 +1,97 @@
+<!-- Copyright (c) Rivoli AI 2026. All rights reserved. -->
+<div class="overlay" (click)="cancel()" data-testid="overlay">
+  <div
+    class="modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="create-binding-title"
+    (click)="$event.stopPropagation()">
+    <header class="modal-header">
+      <h2 id="create-binding-title">New binding</h2>
+      <p class="subtitle">Bind a policy version to a target. Tighten-only rules apply.</p>
+    </header>
+
+    <div *ngIf="eligibleVersions().length === 0" class="banner-info" data-testid="no-versions">
+      No eligible versions on this policy. Bindings can only target Draft, Active,
+      or WindingDown versions — Retired versions reject new bindings.
+    </div>
+
+    <form
+      *ngIf="eligibleVersions().length > 0"
+      [formGroup]="form"
+      (ngSubmit)="submit()"
+      class="form"
+      data-testid="form">
+      <label class="field">
+        <span>Version</span>
+        <select formControlName="policyVersionId" class="input" data-testid="version">
+          <option *ngFor="let v of eligibleVersions()" [value]="v.id">
+            v{{ v.version }} · {{ v.state }} · {{ v.summary }}
+          </option>
+        </select>
+      </label>
+
+      <div class="row two-col">
+        <label class="field">
+          <span>Target type</span>
+          <select formControlName="targetType" class="input" data-testid="target-type">
+            <option *ngFor="let t of TARGET_TYPES" [value]="t">{{ t }}</option>
+          </select>
+        </label>
+
+        <label class="field">
+          <span>Bind strength</span>
+          <div class="strength-toggle" role="radiogroup" aria-label="Bind strength">
+            <label
+              class="strength-option"
+              [class.selected]="form.controls.bindStrength.value === 'Recommended'">
+              <input type="radio" value="Recommended" formControlName="bindStrength" data-testid="strength-Recommended" />
+              Recommended
+            </label>
+            <label
+              class="strength-option"
+              [class.selected]="form.controls.bindStrength.value === 'Mandatory'">
+              <input type="radio" value="Mandatory" formControlName="bindStrength" data-testid="strength-Mandatory" />
+              Mandatory
+            </label>
+          </div>
+        </label>
+      </div>
+
+      <label class="field">
+        <span>Target ref</span>
+        <input
+          formControlName="targetRef"
+          class="input"
+          autocomplete="off"
+          placeholder="e.g. rivoli-ai/andy-policies, scope:abc-123, template:guid"
+          data-testid="target-ref" />
+        <small class="hint">
+          Canonical formats per type: <code>repo:org/name</code>, <code>template:&lt;guid&gt;</code>, <code>scope:&lt;guid&gt;</code>, <code>tenant:&lt;guid&gt;</code>, <code>org:&lt;guid&gt;</code>.
+        </small>
+      </label>
+
+      <div *ngIf="errorMessage()" class="banner-error" role="alert" data-testid="banner">
+        {{ errorMessage() }}
+      </div>
+
+      <footer class="modal-footer">
+        <button
+          type="button"
+          class="btn-secondary"
+          (click)="cancel()"
+          [disabled]="submitting()">
+          Cancel
+        </button>
+        <button
+          type="submit"
+          class="btn-primary"
+          [disabled]="form.invalid || submitting()"
+          data-testid="submit">
+          <span *ngIf="!submitting()">Create binding</span>
+          <span *ngIf="submitting()">Creating…</span>
+        </button>
+      </footer>
+    </form>
+  </div>
+</div>

--- a/client/src/app/features/policies/create-binding-modal.component.scss
+++ b/client/src/app/features/policies/create-binding-modal.component.scss
@@ -1,0 +1,144 @@
+/* Copyright (c) Rivoli AI 2026. All rights reserved. */
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 16px;
+}
+
+.modal {
+  background: var(--surface);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  padding: 20px 24px;
+  width: 100%;
+  max-width: 540px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
+}
+
+.modal-header h2 { margin: 0 0 4px; font-size: 18px; }
+.subtitle { margin: 0; font-size: 13px; color: var(--text-secondary); }
+
+.form { display: flex; flex-direction: column; gap: 12px; }
+
+.row.two-col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.field { display: flex; flex-direction: column; gap: 4px; font-size: 14px; }
+.field > span {
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.input {
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: inherit;
+  font-size: 14px;
+  width: 100%;
+}
+
+.input:focus { outline: 2px solid var(--primary); outline-offset: 1px; }
+
+.hint {
+  margin-top: 2px;
+  font-size: 12px;
+  color: var(--text-secondary);
+
+  code {
+    background: var(--background);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 11px;
+  }
+}
+
+.strength-toggle {
+  display: flex;
+  gap: 6px;
+}
+
+.strength-option {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 7px 12px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--surface);
+  cursor: pointer;
+  font-size: 13px;
+
+  input { display: none; }
+}
+
+.strength-option.selected {
+  background: var(--primary);
+  color: white;
+  border-color: var(--primary);
+}
+
+.banner-info,
+.banner-error {
+  padding: 10px 14px;
+  border-radius: 6px;
+  font-size: 13px;
+}
+
+.banner-info {
+  background: var(--background);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+
+.banner-error {
+  background: #fce8e6;
+  border: 1px solid #f0a99a;
+  color: var(--error);
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.btn-primary,
+.btn-secondary {
+  padding: 8px 16px;
+  font-size: 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 1px solid var(--border);
+}
+
+.btn-primary {
+  background: var(--primary);
+  color: white;
+  border-color: var(--primary);
+}
+
+.btn-primary[disabled] { opacity: 0.55; cursor: not-allowed; }
+
+.btn-secondary {
+  background: var(--surface);
+  color: inherit;
+}
+
+.btn-secondary:hover:not([disabled]) { background: var(--background); }

--- a/client/src/app/features/policies/create-binding-modal.component.spec.ts
+++ b/client/src/app/features/policies/create-binding-modal.component.spec.ts
@@ -1,0 +1,127 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+import {
+  ApiService,
+  BindingDto,
+  CreateBindingRequest,
+  PolicyVersionDto,
+} from '../../shared/services/api.service';
+import { CreateBindingModalComponent } from './create-binding-modal.component';
+
+describe('CreateBindingModalComponent (P9.5)', () => {
+  let fixture: ComponentFixture<CreateBindingModalComponent>;
+  let component: CreateBindingModalComponent;
+  let api: jasmine.SpyObj<ApiService>;
+
+  const draft: PolicyVersionDto = {
+    id: 'vid-1', policyId: 'pid-1', version: 1, state: 'Draft',
+    enforcement: 'MUST', severity: 'critical', scopes: [],
+    summary: 'init', rulesJson: '{}',
+    createdAt: '2026-04-01T00:00:00Z', createdBySubjectId: 'u', proposerSubjectId: 'u',
+  };
+
+  const retired: PolicyVersionDto = { ...draft, id: 'vid-r', state: 'Retired' };
+
+  function build(versions: PolicyVersionDto[]): void {
+    TestBed.resetTestingModule();
+    api = jasmine.createSpyObj<ApiService>('ApiService', ['createBinding']);
+    TestBed.configureTestingModule({
+      imports: [CreateBindingModalComponent],
+      providers: [{ provide: ApiService, useValue: api }],
+    });
+
+    fixture = TestBed.createComponent(CreateBindingModalComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('versions', versions);
+    component.ngOnInit();
+    fixture.detectChanges();
+  }
+
+  it('filters Retired versions out of the dropdown', () => {
+    build([draft, retired]);
+    expect(component.eligibleVersions().map(v => v.id)).toEqual(['vid-1']);
+  });
+
+  it('shows the no-versions banner when only Retired versions exist', () => {
+    build([retired]);
+    const banner = fixture.nativeElement.querySelector('[data-testid="no-versions"]');
+    expect(banner).toBeTruthy();
+    const submit = fixture.nativeElement.querySelector('[data-testid="submit"]');
+    expect(submit).toBeNull();
+  });
+
+  it('seeds policyVersionId to the first eligible version', () => {
+    build([draft]);
+    expect(component.form.controls.policyVersionId.value).toBe('vid-1');
+  });
+
+  it('submit fires createBinding with the canonical body shape', () => {
+    build([draft]);
+    const created: BindingDto = {
+      id: 'bid-1', policyVersionId: 'vid-1',
+      targetType: 'Repo', targetRef: 'rivoli-ai/example',
+      bindStrength: 'Mandatory',
+      createdAt: '2026-05-07T00:00:00Z', createdBySubjectId: 'u',
+      deletedAt: null, deletedBySubjectId: null,
+    };
+    api.createBinding.and.returnValue(of(created));
+
+    const captures: (BindingDto | null)[] = [];
+    component.closed.subscribe(v => captures.push(v));
+
+    component.form.patchValue({
+      targetRef: '  rivoli-ai/example  ', // trims
+      bindStrength: 'Mandatory',
+    });
+    component.submit();
+
+    const req = api.createBinding.calls.mostRecent().args[0] as CreateBindingRequest;
+    expect(req).toEqual({
+      policyVersionId: 'vid-1',
+      targetType: 'Repo',
+      targetRef: 'rivoli-ai/example',
+      bindStrength: 'Mandatory',
+    });
+    expect(captures).toEqual([created]);
+  });
+
+  it('on 409 keeps the modal open and surfaces detail + offending scope inline', () => {
+    build([draft]);
+    const conflict = new HttpErrorResponse({
+      status: 409,
+      error: {
+        title: 'Tighten-only violation',
+        detail: 'Recommended binding loosens an ancestor Mandatory.',
+        offendingScopeDisplayName: 'Org/Tenant/Frontend',
+        errorCode: 'binding.tighten-only-violation',
+      },
+    });
+    api.createBinding.and.returnValue(throwError(() => conflict));
+    let emitCount = 0;
+    component.closed.subscribe(() => emitCount++);
+
+    component.form.patchValue({ targetRef: 'rivoli-ai/example' });
+    component.submit();
+    fixture.detectChanges();
+
+    expect(emitCount).toBe(0);
+    expect(component.errorMessage()).toContain('Recommended binding loosens');
+    expect(component.errorMessage()).toContain('Org/Tenant/Frontend');
+    const banner = fixture.nativeElement.querySelector('[data-testid="banner"]');
+    expect(banner).toBeTruthy();
+  });
+
+  it('cancel emits null without calling the API', () => {
+    build([draft]);
+    const captures: (BindingDto | null)[] = [];
+    component.closed.subscribe(v => captures.push(v));
+
+    component.cancel();
+
+    expect(api.createBinding).not.toHaveBeenCalled();
+    expect(captures).toEqual([null]);
+  });
+});

--- a/client/src/app/features/policies/create-binding-modal.component.ts
+++ b/client/src/app/features/policies/create-binding-modal.component.ts
@@ -1,0 +1,151 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  EventEmitter,
+  Input,
+  Output,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  FormControl,
+  FormGroup,
+  NonNullableFormBuilder,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import {
+  ApiService,
+  BINDING_TARGET_TYPES,
+  BindStrength,
+  BindingDto,
+  BindingTargetType,
+  CreateBindingRequest,
+  PolicyVersionDto,
+} from '../../shared/services/api.service';
+
+interface CreateBindingForm {
+  policyVersionId: FormControl<string>;
+  targetType: FormControl<BindingTargetType>;
+  targetRef: FormControl<string>;
+  bindStrength: FormControl<BindStrength>;
+}
+
+/**
+ * P9.5 (rivoli-ai/andy-policies#70) — modal for creating a binding.
+ * Bindings live on a specific PolicyVersion server-side, so the modal
+ * forces the user to pick the target version up front (filtered to
+ * non-Retired since the server rejects bindings on retired versions
+ * with `BindingRetiredVersionException`).
+ *
+ * Target type is a fixed enum (Template / Repo / ScopeNode / Tenant /
+ * Org); target ref is free-text. The autocomplete the spec called for
+ * isn't shipped — the server has no /target-refs endpoint to back it.
+ *
+ * Tighten-only violation (server-side) returns 409 with
+ * `errorCode: 'binding.tighten-only-violation'` and structured
+ * extensions. The modal stays open and renders the Detail inline so
+ * the user can adjust target / strength.
+ */
+@Component({
+  selector: 'app-create-binding-modal',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './create-binding-modal.component.html',
+  styleUrls: ['./create-binding-modal.component.scss'],
+})
+export class CreateBindingModalComponent {
+  @Input({ required: true }) versions!: readonly PolicyVersionDto[];
+  @Output() readonly closed = new EventEmitter<BindingDto | null>();
+
+  private readonly api = inject(ApiService);
+  private readonly fb = inject(NonNullableFormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly TARGET_TYPES = BINDING_TARGET_TYPES;
+  readonly submitting = signal(false);
+  readonly errorMessage = signal<string | null>(null);
+
+  readonly form: FormGroup<CreateBindingForm> = this.fb.group<CreateBindingForm>({
+    policyVersionId: this.fb.control('', Validators.required),
+    targetType: this.fb.control<BindingTargetType>('Repo', Validators.required),
+    targetRef: this.fb.control('', [Validators.required, Validators.minLength(1)]),
+    bindStrength: this.fb.control<BindStrength>('Recommended', Validators.required),
+  });
+
+  ngOnInit(): void {
+    const eligible = this.eligibleVersions();
+    if (eligible.length > 0) {
+      this.form.controls.policyVersionId.setValue(eligible[0].id);
+    }
+  }
+
+  /** Server rejects bindings on Retired versions; filter the dropdown. */
+  eligibleVersions(): readonly PolicyVersionDto[] {
+    return (this.versions ?? []).filter(v => v.state !== 'Retired');
+  }
+
+  submit(): void {
+    if (this.form.invalid || this.submitting()) return;
+
+    const v = this.form.getRawValue();
+    const req: CreateBindingRequest = {
+      policyVersionId: v.policyVersionId,
+      targetType: v.targetType,
+      targetRef: v.targetRef.trim(),
+      bindStrength: v.bindStrength,
+    };
+
+    this.submitting.set(true);
+    this.errorMessage.set(null);
+    this.api
+      .createBinding(req)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: created => {
+          this.submitting.set(false);
+          this.closed.emit(created);
+        },
+        error: (err: HttpErrorResponse) => {
+          this.submitting.set(false);
+          // 409 = tighten-only violation or other conflict; surface inline so
+          // the user can adjust target / strength without losing the form.
+          if (err.status === 409) {
+            this.errorMessage.set(this.describeProblem(err)
+              ?? 'Binding rejected by the tighten-only validator.');
+            return;
+          }
+          this.errorMessage.set(this.describeProblem(err)
+            ?? `Unexpected error (${err.status}).`);
+        },
+      });
+  }
+
+  cancel(): void {
+    this.closed.emit(null);
+  }
+
+  /** Combines `detail` and any structured extensions for the inline
+   *  banner. Tighten-only adds the offending scope id which is helpful
+   *  even though it's not human-friendly. */
+  private describeProblem(err: HttpErrorResponse): string | null {
+    const body = err.error;
+    if (!body) return null;
+    const parts: string[] = [];
+    if (typeof body.detail === 'string' && body.detail) parts.push(body.detail);
+    const ext = body.offendingScopeDisplayName ?? body['offendingScopeDisplayName'];
+    if (typeof ext === 'string' && ext) {
+      parts.push(`Offending scope: ${ext}`);
+    }
+    if (parts.length > 0) return parts.join(' ');
+    if (typeof body.title === 'string') return `${body.title} (${err.status}).`;
+    return null;
+  }
+}

--- a/client/src/app/features/policies/delete-binding-modal.component.spec.ts
+++ b/client/src/app/features/policies/delete-binding-modal.component.spec.ts
@@ -1,0 +1,83 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+import { ApiService, BindingDto } from '../../shared/services/api.service';
+import { DeleteBindingModalComponent } from './delete-binding-modal.component';
+
+describe('DeleteBindingModalComponent (P9.5)', () => {
+  let fixture: ComponentFixture<DeleteBindingModalComponent>;
+  let component: DeleteBindingModalComponent;
+  let api: jasmine.SpyObj<ApiService>;
+
+  const binding: BindingDto = {
+    id: 'bid-1', policyVersionId: 'vid-1',
+    targetType: 'Repo', targetRef: 'rivoli-ai/example',
+    bindStrength: 'Mandatory',
+    createdAt: '2026-04-01T00:00:00Z', createdBySubjectId: 'u',
+    deletedAt: null, deletedBySubjectId: null,
+  };
+
+  beforeEach(async () => {
+    api = jasmine.createSpyObj<ApiService>('ApiService', ['deleteBinding']);
+    await TestBed.configureTestingModule({
+      imports: [DeleteBindingModalComponent],
+      providers: [{ provide: ApiService, useValue: api }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DeleteBindingModalComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('binding', binding);
+    fixture.detectChanges();
+  });
+
+  it('confirm sends rationale to deleteBinding and emits deleted=true', () => {
+    api.deleteBinding.and.returnValue(of(undefined));
+    const captures: ({ deleted: boolean; bindingId: string } | null)[] = [];
+    component.closed.subscribe(v => captures.push(v));
+
+    component.rationale = 'no longer relevant';
+    component.confirm();
+
+    expect(api.deleteBinding).toHaveBeenCalledWith('bid-1', 'no longer relevant');
+    expect(captures).toEqual([{ deleted: true, bindingId: 'bid-1' }]);
+  });
+
+  it('confirm trims rationale before calling delete', () => {
+    api.deleteBinding.and.returnValue(of(undefined));
+
+    component.rationale = '   spaces around   ';
+    component.confirm();
+
+    expect(api.deleteBinding).toHaveBeenCalledWith('bid-1', 'spaces around');
+  });
+
+  it('on 409 keeps modal open and surfaces detail inline', () => {
+    const conflict = new HttpErrorResponse({
+      status: 409,
+      error: { detail: 'Cannot delete: relied on by template X.' },
+    });
+    api.deleteBinding.and.returnValue(throwError(() => conflict));
+    let emitCount = 0;
+    component.closed.subscribe(() => emitCount++);
+
+    component.confirm();
+    fixture.detectChanges();
+
+    expect(emitCount).toBe(0);
+    expect(component.errorMessage()).toContain('relied on by template X');
+    const banner = fixture.nativeElement.querySelector('[data-testid="banner"]');
+    expect(banner).toBeTruthy();
+  });
+
+  it('cancel emits null without calling delete', () => {
+    const captures: unknown[] = [];
+    component.closed.subscribe(v => captures.push(v));
+
+    component.cancel();
+
+    expect(api.deleteBinding).not.toHaveBeenCalled();
+    expect(captures).toEqual([null]);
+  });
+});

--- a/client/src/app/features/policies/delete-binding-modal.component.ts
+++ b/client/src/app/features/policies/delete-binding-modal.component.ts
@@ -1,0 +1,209 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  EventEmitter,
+  Input,
+  Output,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { ApiService, BindingDto } from '../../shared/services/api.service';
+
+/**
+ * P9.5 (rivoli-ai/andy-policies#70) — confirmation dialog for deleting a
+ * binding. Captures a rationale (recorded in the audit chain via the
+ * server's `?rationale=` query param) and surfaces 409 ProblemDetails
+ * inline so the user stays in context — the spec asked for inline
+ * (not a toast) and that's what we do.
+ *
+ * Server-side note: the tighten-only check fires on **create**, not
+ * delete; deletes are unconditional once the caller has
+ * `andy-policies:binding:manage`. The 409 path is therefore unlikely
+ * for delete in normal operation, but defensive coverage stays since
+ * any conflict (e.g. concurrent deletion) can still surface here.
+ */
+@Component({
+  selector: 'app-delete-binding-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="overlay" (click)="cancel()" data-testid="overlay">
+      <div
+        class="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="delete-binding-title"
+        (click)="$event.stopPropagation()">
+        <header class="modal-header">
+          <h2 id="delete-binding-title">Delete binding?</h2>
+          <p class="subtitle">
+            <strong>{{ binding.targetType }}</strong>
+            <code class="ref">{{ binding.targetRef }}</code>
+            ·
+            <span class="strength" [class.mandatory]="binding.bindStrength === 'Mandatory'">
+              {{ binding.bindStrength }}
+            </span>
+          </p>
+        </header>
+
+        <label class="field">
+          <span>
+            Rationale
+            <em>(optional, recorded in the audit chain)</em>
+          </span>
+          <textarea
+            class="input rationale"
+            rows="3"
+            [(ngModel)]="rationale"
+            data-testid="rationale"
+            placeholder="Why is this binding being removed?"></textarea>
+        </label>
+
+        <div *ngIf="errorMessage()" class="banner-error" role="alert" data-testid="banner">
+          {{ errorMessage() }}
+        </div>
+
+        <footer class="modal-footer">
+          <button type="button" class="btn-secondary" (click)="cancel()" [disabled]="submitting()">
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="btn-danger"
+            (click)="confirm()"
+            [disabled]="submitting()"
+            data-testid="confirm">
+            <span *ngIf="!submitting()">Delete</span>
+            <span *ngIf="submitting()">Deleting…</span>
+          </button>
+        </footer>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .overlay {
+      position: fixed; inset: 0;
+      background: rgba(0, 0, 0, 0.45);
+      display: flex; align-items: center; justify-content: center;
+      z-index: 1000; padding: 16px;
+    }
+    .modal {
+      background: var(--surface);
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      padding: 20px 24px;
+      width: 100%; max-width: 480px;
+      display: flex; flex-direction: column; gap: 14px;
+      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
+    }
+    .modal-header h2 { margin: 0 0 4px; font-size: 18px; }
+    .subtitle { margin: 0; font-size: 13px; color: var(--text-secondary); }
+    .ref {
+      background: var(--background);
+      padding: 1px 6px;
+      border-radius: 3px;
+      font-size: 12px;
+    }
+    .strength { padding: 1px 8px; border-radius: 12px; background: var(--background); font-size: 11px; }
+    .strength.mandatory { background: #fce8e6; color: var(--error); }
+    .field { display: flex; flex-direction: column; gap: 4px; font-size: 14px; }
+    .field > span {
+      color: var(--text-secondary);
+      font-size: 12px;
+      font-weight: 500;
+      em { font-weight: 400; font-style: normal; }
+    }
+    .input {
+      padding: 8px 12px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      background: var(--surface);
+      color: inherit;
+      font-size: 14px;
+      width: 100%;
+    }
+    .rationale { resize: vertical; min-height: 70px; font-family: inherit; }
+    .banner-error {
+      padding: 10px 14px;
+      border-radius: 6px;
+      font-size: 13px;
+      background: #fce8e6;
+      border: 1px solid #f0a99a;
+      color: var(--error);
+    }
+    .modal-footer {
+      display: flex; justify-content: flex-end; gap: 8px;
+      margin-top: 4px;
+    }
+    .btn-secondary, .btn-danger {
+      padding: 8px 16px; font-size: 14px; border-radius: 4px;
+      cursor: pointer; border: 1px solid var(--border);
+    }
+    .btn-secondary { background: var(--surface); color: inherit; }
+    .btn-secondary:hover:not([disabled]) { background: var(--background); }
+    .btn-danger {
+      background: var(--error);
+      color: white;
+      border-color: var(--error);
+    }
+    .btn-danger[disabled] { opacity: 0.55; cursor: not-allowed; }
+  `],
+})
+export class DeleteBindingModalComponent {
+  @Input({ required: true }) binding!: BindingDto;
+  @Output() readonly closed = new EventEmitter<{ deleted: boolean; bindingId: string } | null>();
+
+  private readonly api = inject(ApiService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  rationale = '';
+  readonly submitting = signal(false);
+  readonly errorMessage = signal<string | null>(null);
+
+  confirm(): void {
+    if (this.submitting()) return;
+
+    this.submitting.set(true);
+    this.errorMessage.set(null);
+    this.api
+      .deleteBinding(this.binding.id, this.rationale.trim())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.submitting.set(false);
+          this.closed.emit({ deleted: true, bindingId: this.binding.id });
+        },
+        error: (err: HttpErrorResponse) => {
+          this.submitting.set(false);
+          // Inline 409 — modal stays open per the epic spec.
+          if (err.status === 409) {
+            this.errorMessage.set(this.describeProblem(err)
+              ?? 'Deletion was rejected by the server.');
+            return;
+          }
+          this.errorMessage.set(this.describeProblem(err)
+            ?? `Unexpected error (${err.status}).`);
+        },
+      });
+  }
+
+  cancel(): void {
+    this.closed.emit(null);
+  }
+
+  private describeProblem(err: HttpErrorResponse): string | null {
+    const body = err.error;
+    if (!body) return null;
+    if (typeof body.detail === 'string' && body.detail) return body.detail;
+    if (typeof body.title === 'string') return `${body.title} (${err.status}).`;
+    return null;
+  }
+}

--- a/client/src/app/features/policies/policy-detail.component.html
+++ b/client/src/app/features/policies/policy-detail.component.html
@@ -74,6 +74,12 @@
     </section>
   </ng-container>
 
+  <app-bindings-manager
+    *ngIf="policy() as p"
+    [policyId]="p.id"
+    [versions]="versions()">
+  </app-bindings-manager>
+
   <app-lifecycle-transition-modal
     *ngIf="transitioningVersion() as tv"
     [version]="tv"

--- a/client/src/app/features/policies/policy-detail.component.spec.ts
+++ b/client/src/app/features/policies/policy-detail.component.spec.ts
@@ -52,9 +52,14 @@ describe('PolicyDetailComponent (P9.4)', () => {
     api = jasmine.createSpyObj<ApiService>('ApiService', [
       'getPolicy',
       'listPolicyVersions',
+      'listVersionBindings',
     ]);
     api.getPolicy.and.returnValue(of(samplePolicy));
     api.listPolicyVersions.and.returnValue(of([activeV1, draftV2]));
+    // BindingsManager mounts as a child and pulls bindings per version on
+    // ngOnChanges — stub to empty so the parent suite stays focused on
+    // detail-level behaviour (P9.5 has its own bindings-manager.spec).
+    api.listVersionBindings.and.returnValue(of([]));
 
     TestBed.configureTestingModule({
       imports: [PolicyDetailComponent],

--- a/client/src/app/features/policies/policy-detail.component.ts
+++ b/client/src/app/features/policies/policy-detail.component.ts
@@ -18,6 +18,7 @@ import {
   PolicyDto,
   PolicyVersionDto,
 } from '../../shared/services/api.service';
+import { BindingsManagerComponent } from './bindings-manager.component';
 import { LifecycleDiagramComponent } from './lifecycle-diagram.component';
 import { LifecycleTransitionModalComponent } from './lifecycle-transition-modal.component';
 import { LIFECYCLE_GRAPH, LIFECYCLE_LABEL } from './lifecycle-graph';
@@ -35,6 +36,7 @@ import { LIFECYCLE_GRAPH, LIFECYCLE_LABEL } from './lifecycle-graph';
   imports: [
     CommonModule,
     RouterLink,
+    BindingsManagerComponent,
     LifecycleDiagramComponent,
     LifecycleTransitionModalComponent,
   ],

--- a/client/src/app/shared/services/api.service.ts
+++ b/client/src/app/shared/services/api.service.ts
@@ -67,6 +67,50 @@ export interface LifecycleTransitionBody {
   rationale: string;
 }
 
+/** P9.5 (#70) — bind strength enum, matches `Andy.Policies.Domain.Enums.BindStrength`. */
+export type BindStrength = 'Mandatory' | 'Recommended';
+
+/**
+ * P9.5 (#70) — what kind of foreign target a `Binding` attaches to.
+ * Mirrors `Andy.Policies.Domain.Enums.BindingTargetType` (1..5).
+ */
+export type BindingTargetType =
+  | 'Template'
+  | 'Repo'
+  | 'ScopeNode'
+  | 'Tenant'
+  | 'Org';
+
+export const BINDING_TARGET_TYPES: BindingTargetType[] = [
+  'Template',
+  'Repo',
+  'ScopeNode',
+  'Tenant',
+  'Org',
+];
+
+/** Wire shape matching `BindingDto`. `DeletedAt` is non-null for soft-deleted rows. */
+export interface BindingDto {
+  id: string;
+  policyVersionId: string;
+  targetType: BindingTargetType;
+  targetRef: string;
+  bindStrength: BindStrength;
+  createdAt: string;
+  createdBySubjectId: string;
+  deletedAt: string | null;
+  deletedBySubjectId: string | null;
+}
+
+/** Body for `POST /api/bindings`. Server has no `Rationale` field on create
+ *  today — see follow-up issue. */
+export interface CreateBindingRequest {
+  policyVersionId: string;
+  targetType: BindingTargetType;
+  targetRef: string;
+  bindStrength: BindStrength;
+}
+
 /**
  * Maps a target lifecycle state to the action-shaped path segment used by
  * `PolicyVersionsLifecycleController`. `Draft` is intentionally null —
@@ -182,6 +226,26 @@ export class ApiService {
       `${this.baseUrl}/policies/${id}/versions/${versionId}/${segment}`,
       { rationale },
     );
+  }
+
+  // --- Bindings (P9.5, #70) ---
+
+  /** Lists every (non-soft-deleted) binding on a specific version. */
+  listVersionBindings(policyId: string, versionId: string): Observable<BindingDto[]> {
+    return this.http.get<BindingDto[]>(
+      `${this.baseUrl}/policies/${policyId}/versions/${versionId}/bindings`,
+    );
+  }
+
+  createBinding(request: CreateBindingRequest): Observable<BindingDto> {
+    return this.http.post<BindingDto>(`${this.baseUrl}/bindings`, request);
+  }
+
+  /** Server accepts rationale as a query param (not body) on DELETE. */
+  deleteBinding(bindingId: string, rationale: string): Observable<void> {
+    let params = new HttpParams();
+    if (rationale) params = params.set('rationale', rationale);
+    return this.http.delete<void>(`${this.baseUrl}/bindings/${bindingId}`, { params });
   }
 
   // --- Bundles (P8.3) ---


### PR DESCRIPTION
## Summary

Bindings manager mounted under the policy detail page. Aggregates bindings across every version (server has no per-policy list endpoint — bindings live per-version), renders one row per binding with a Version column, exposes create + delete via dedicated modals. Tighten-only 409 ProblemDetails surfaced inline on the create modal (with the offendingScopeDisplayName extension); delete uses the server's \`?rationale=\` query-param contract.

## Spec deltas worth flagging

| Spec | Reality |
|---|---|
| \`POST /api/policies/{id}/bindings\` | Doesn't exist — bindings are per-version, create is \`POST /api/bindings\` with \`PolicyVersionId\` in body |
| \`GET /api/policies/{id}/bindings\` | Doesn't exist — \`GET /api/policies/{id}/versions/{vId}/bindings\` per version |
| \`DELETE\` with body | Reality: \`?rationale=\` query param |
| \`/target-types\` + \`/target-refs\` autocomplete | Don't exist — fixed 5-value enum + free-text — filed as #198 |
| \`'Advisory' \| 'Required'\` strength | \`Mandatory\` / \`Recommended\` |
| Rationale on create body | No \`Rationale\` field — filed as #197 |
| 409 \`extensions.looseningReason\` | Reality: \`errorCode = 'binding.tighten-only-violation'\` + \`offendingScopeDisplayName\` etc. |

Aligned the UI to what's actually there. Filed two follow-ups for the missing backend pieces.

## Test plan

- [x] \`npm test\` — **57/57 pass**: 6 create-modal cases (eligible-versions filter, no-versions banner, body shape, 409 inline + offending-scope, cancel), 4 delete-modal (confirm + trim, 409, cancel), 7 manager (cross-version aggregation, sort, soft-delete filter, empty, no-call-when-empty, per-version error survival, optimistic add/remove), 40 carried from P9.1/P9.2/P9.4.
- [x] \`npm run build\` — prod bundle clean.
- [x] \`dotnet build\` — green.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)