### PR TITLE
Implement P9.6 — overrides manager (#88)

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -5,6 +5,7 @@
     <div class="nav-links">
       <a routerLink="/dashboard" routerLinkActive="active">Dashboard</a>
       <a routerLink="/policies" routerLinkActive="active">Policies</a>
+      <a routerLink="/overrides" routerLinkActive="active">Overrides</a>
       <a routerLink="/help" routerLinkActive="active">Help</a>
     </div>
     <div class="auth-section">

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -50,6 +50,14 @@ export const routes: Routes = [
     canActivate: [authGuard],
   },
   {
+    path: 'overrides',
+    loadComponent: () =>
+      import('./features/overrides/overrides-manager.component').then(
+        (m) => m.OverridesManagerComponent
+      ),
+    canActivate: [authGuard],
+  },
+  {
     path: 'help',
     loadComponent: () =>
       import('./features/help/help.component').then(

--- a/client/src/app/features/overrides/expiry-countdown.pipe.spec.ts
+++ b/client/src/app/features/overrides/expiry-countdown.pipe.spec.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { ExpiryCountdownPipe } from './expiry-countdown.pipe';
+
+describe('ExpiryCountdownPipe (P9.6)', () => {
+  let pipe: ExpiryCountdownPipe;
+  // Fixed reference instant so tests don't drift with wall clock.
+  const now = new Date('2026-05-07T12:00:00Z');
+
+  beforeEach(() => {
+    pipe = new ExpiryCountdownPipe();
+  });
+
+  it('returns "Expired" for a past timestamp', () => {
+    const past = new Date(now.getTime() - 60_000).toISOString();
+    expect(pipe.transform(past, now)).toBe('Expired');
+  });
+
+  it('returns "Expired" exactly at the boundary', () => {
+    expect(pipe.transform(now.toISOString(), now)).toBe('Expired');
+  });
+
+  it('formats sub-hour times in minutes', () => {
+    const future = new Date(now.getTime() + 5 * 60_000).toISOString();
+    expect(pipe.transform(future, now)).toBe('5m remaining');
+  });
+
+  it('shows <1m for the last sub-minute', () => {
+    const future = new Date(now.getTime() + 30_000).toISOString();
+    expect(pipe.transform(future, now)).toBe('<1m remaining');
+  });
+
+  it('formats hour-bucket times as "Xh Ym remaining"', () => {
+    const future = new Date(now.getTime() + (3 * 3600_000) + (15 * 60_000)).toISOString();
+    expect(pipe.transform(future, now)).toBe('3h 15m remaining');
+  });
+
+  it('formats multi-day times as "Xd Yh remaining"', () => {
+    // 2 days, 6 hours
+    const future = new Date(now.getTime() + ((2 * 24 + 6) * 3600_000)).toISOString();
+    expect(pipe.transform(future, now)).toBe('2d 6h remaining');
+  });
+
+  it('returns empty string for null/undefined/invalid input', () => {
+    expect(pipe.transform(null, now)).toBe('');
+    expect(pipe.transform(undefined, now)).toBe('');
+    expect(pipe.transform('not-a-date', now)).toBe('');
+  });
+
+  it('accepts a Date instance', () => {
+    expect(pipe.transform(new Date(now.getTime() + 90 * 60_000), now)).toBe('1h 30m remaining');
+  });
+});

--- a/client/src/app/features/overrides/expiry-countdown.pipe.ts
+++ b/client/src/app/features/overrides/expiry-countdown.pipe.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { Pipe, PipeTransform } from '@angular/core';
+
+/**
+ * P9.6 (rivoli-ai/andy-policies#88) — relative-time pipe for an override's
+ * `expiresAt`. Impure (`pure: false`) so it re-renders on every change-
+ * detection cycle; the parent component runs an interval that nudges CD
+ * every 60s so the value advances even when there's no other interaction.
+ *
+ * Output formats:
+ *   - "Expired" if the timestamp is in the past
+ *   - "Xd Yh remaining" for ≥ 24h
+ *   - "Xh Ym remaining" for ≥ 1h
+ *   - "Xm remaining" for < 1h
+ *   - "<1m remaining" inside the last 60 seconds
+ *
+ * Accepts an ISO-8601 string or a Date instance.
+ */
+@Pipe({ name: 'expiryCountdown', standalone: true, pure: false })
+export class ExpiryCountdownPipe implements PipeTransform {
+  transform(value: string | Date | null | undefined, now: Date = new Date()): string {
+    if (!value) return '';
+    const target = typeof value === 'string' ? new Date(value) : value;
+    if (Number.isNaN(target.getTime())) return '';
+
+    const ms = target.getTime() - now.getTime();
+    if (ms <= 0) return 'Expired';
+
+    const totalMinutes = Math.floor(ms / 60_000);
+    const days = Math.floor(totalMinutes / (60 * 24));
+    const hours = Math.floor((totalMinutes - days * 60 * 24) / 60);
+    const minutes = totalMinutes - days * 60 * 24 - hours * 60;
+
+    if (days > 0) return `${days}d ${hours}h remaining`;
+    if (hours > 0) return `${hours}h ${minutes}m remaining`;
+    if (minutes > 0) return `${minutes}m remaining`;
+    return '<1m remaining';
+  }
+}

--- a/client/src/app/features/overrides/overrides-manager.component.html
+++ b/client/src/app/features/overrides/overrides-manager.component.html
@@ -1,0 +1,146 @@
+<!-- Copyright (c) Rivoli AI 2026. All rights reserved. -->
+<div class="page">
+  <header class="page-header">
+    <h1>Overrides</h1>
+    <p class="page-subtitle">
+      Scoped, time-bounded exceptions to a policy. Writes are gated by
+      <code>andy.policies.experimentalOverridesEnabled</code> server-side.
+    </p>
+  </header>
+
+  <nav class="tabs" role="tablist" aria-label="Override states">
+    <button
+      *ngFor="let s of STATE_TABS"
+      type="button"
+      role="tab"
+      class="tab"
+      [class.active]="state() === s"
+      (click)="setState(s)"
+      [attr.aria-selected]="state() === s"
+      [attr.data-testid]="'tab-' + s">
+      {{ s }}
+    </button>
+  </nav>
+
+  <div *ngIf="errorMessage()" class="banner-error" role="alert" data-testid="banner">
+    <span>{{ errorMessage() }}</span>
+    <button type="button" class="btn-link" (click)="retry()">Retry</button>
+  </div>
+
+  <div *ngIf="approveError()" class="banner-error" role="alert" data-testid="approve-error">
+    {{ approveError() }}
+  </div>
+
+  <div *ngIf="loading() && currentRows().length === 0" class="loading" data-testid="loading">
+    Loading overrides…
+  </div>
+
+  <p
+    *ngIf="!loading() && !hasRows() && !errorMessage()"
+    class="empty"
+    data-testid="empty">
+    No overrides in <strong>{{ state() }}</strong> state.
+  </p>
+
+  <table
+    *ngIf="hasRows()"
+    class="overrides-table"
+    data-testid="overrides-table">
+    <thead>
+      <tr>
+        <th>Scope</th>
+        <th>Effect</th>
+        <th>Proposed by</th>
+        <th>Proposed</th>
+        <th>Expires</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <ng-container *ngFor="let o of currentRows()">
+        <tr
+          [class.expanded]="expandedId() === o.id"
+          [attr.data-testid]="'row-' + o.id">
+          <td>
+            <span class="scope-kind">{{ o.scopeKind }}</span>
+            <code class="ref">{{ o.scopeRef }}</code>
+          </td>
+          <td>
+            <span class="badge effect-{{ o.effect }}">{{ o.effect }}</span>
+          </td>
+          <td class="subject">{{ o.proposerSubjectId }}</td>
+          <td>{{ o.proposedAt | date: 'short' }}</td>
+          <td>
+            <!-- expiry pipe: tick() is read so OnPush re-evaluates the impure pipe. -->
+            <span [attr.data-tick]="tick()">{{ o.expiresAt | expiryCountdown }}</span>
+          </td>
+          <td class="actions">
+            <button
+              type="button"
+              class="btn-link"
+              (click)="toggleExpand(o.id)"
+              [attr.data-testid]="'expand-' + o.id">
+              {{ expandedId() === o.id ? 'Hide' : 'Details' }}
+            </button>
+            <button
+              *ngIf="o.state === 'Proposed'"
+              type="button"
+              class="btn-link primary"
+              (click)="approve(o)"
+              [attr.data-testid]="'approve-' + o.id">
+              Approve
+            </button>
+            <button
+              *ngIf="o.state === 'Proposed' || o.state === 'Approved'"
+              type="button"
+              class="btn-link danger"
+              (click)="openRevoke(o)"
+              [attr.data-testid]="'revoke-' + o.id">
+              Revoke
+            </button>
+          </td>
+        </tr>
+        <tr *ngIf="expandedId() === o.id" class="detail-row">
+          <td colspan="6">
+            <div class="detail" [attr.data-testid]="'detail-' + o.id">
+              <dl class="detail-grid">
+                <dt>PolicyVersion</dt>
+                <dd><code>{{ o.policyVersionId }}</code></dd>
+
+                <dt>Replacement version</dt>
+                <dd>
+                  <code *ngIf="o.replacementPolicyVersionId">{{ o.replacementPolicyVersionId }}</code>
+                  <span *ngIf="!o.replacementPolicyVersionId" class="muted">—</span>
+                </dd>
+
+                <dt>Approver</dt>
+                <dd>
+                  <code *ngIf="o.approverSubjectId">{{ o.approverSubjectId }}</code>
+                  <span *ngIf="!o.approverSubjectId" class="muted">—</span>
+                </dd>
+
+                <dt>Approved at</dt>
+                <dd>
+                  <span *ngIf="o.approvedAt">{{ o.approvedAt | date: 'medium' }}</span>
+                  <span *ngIf="!o.approvedAt" class="muted">—</span>
+                </dd>
+
+                <dt>Rationale</dt>
+                <dd>{{ o.rationale }}</dd>
+
+                <dt *ngIf="o.revocationReason">Revocation reason</dt>
+                <dd *ngIf="o.revocationReason">{{ o.revocationReason }}</dd>
+              </dl>
+            </div>
+          </td>
+        </tr>
+      </ng-container>
+    </tbody>
+  </table>
+</div>
+
+<app-revoke-override-modal
+  *ngIf="revoking() as r"
+  [override]="r"
+  (closed)="onRevokeClosed($event)">
+</app-revoke-override-modal>

--- a/client/src/app/features/overrides/overrides-manager.component.scss
+++ b/client/src/app/features/overrides/overrides-manager.component.scss
@@ -1,0 +1,193 @@
+/* Copyright (c) Rivoli AI 2026. All rights reserved. */
+
+.page { display: flex; flex-direction: column; gap: 16px; }
+
+.page-header h1 { margin: 0 0 4px; }
+.page-subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+
+  code {
+    background: var(--background);
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 12px;
+  }
+}
+
+.tabs {
+  display: flex;
+  gap: 6px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 6px;
+}
+
+.tab {
+  flex: 1;
+  background: transparent;
+  border: none;
+  padding: 8px 14px;
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  border-radius: 6px;
+}
+
+.tab.active {
+  background: var(--primary);
+  color: white;
+  font-weight: 500;
+}
+
+.tab:hover:not(.active) { background: var(--background); }
+
+.loading,
+.empty,
+.banner-error {
+  padding: 14px;
+  border-radius: 6px;
+  font-size: 14px;
+}
+
+.loading,
+.empty {
+  text-align: center;
+  background: var(--surface);
+  color: var(--text-secondary);
+  border: 1px dashed var(--border);
+}
+
+.banner-error {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: #fce8e6;
+  border: 1px solid #f0a99a;
+  color: var(--error);
+
+  span { flex: 1; }
+}
+
+.overrides-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.overrides-table th,
+.overrides-table td {
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  vertical-align: middle;
+}
+
+.overrides-table th {
+  background: var(--background);
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.overrides-table tbody tr:last-child td { border-bottom: none; }
+
+.overrides-table tr.expanded { background: var(--background); }
+
+.overrides-table .scope-kind {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 12px;
+  background: var(--background);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 500;
+  margin-right: 6px;
+}
+
+.overrides-table .ref {
+  background: var(--background);
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 12px;
+}
+
+.overrides-table .subject {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.badge.effect-Exempt { background: #fff4e5; color: #a85d00; }
+.badge.effect-Replace { background: #e6f0ff; color: #1750c8; }
+
+.detail-row td {
+  background: var(--background);
+  padding: 14px 18px;
+}
+
+.detail {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 6px 16px;
+  margin: 0;
+}
+
+.detail-grid dt {
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.detail-grid dd {
+  margin: 0;
+  font-size: 13px;
+  word-break: break-word;
+}
+
+.detail-grid dd .muted {
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+}
+
+.btn-link {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--primary);
+  font: inherit;
+  font-size: 12px;
+}
+
+.btn-link:hover { text-decoration: underline; }
+.btn-link.danger { color: var(--error); }
+.btn-link.primary { font-weight: 500; }

--- a/client/src/app/features/overrides/overrides-manager.component.spec.ts
+++ b/client/src/app/features/overrides/overrides-manager.component.spec.ts
@@ -1,0 +1,161 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+import {
+  ApiService,
+  OverrideDto,
+  OverrideListQuery,
+} from '../../shared/services/api.service';
+import { OverridesManagerComponent } from './overrides-manager.component';
+
+describe('OverridesManagerComponent (P9.6)', () => {
+  let fixture: ComponentFixture<OverridesManagerComponent>;
+  let component: OverridesManagerComponent;
+  let api: jasmine.SpyObj<ApiService>;
+
+  const proposed: OverrideDto = {
+    id: 'oid-1',
+    policyVersionId: 'vid-1',
+    scopeKind: 'Principal',
+    scopeRef: 'user:alice',
+    effect: 'Exempt',
+    replacementPolicyVersionId: null,
+    proposerSubjectId: 'user:bob',
+    approverSubjectId: null,
+    state: 'Proposed',
+    proposedAt: '2026-05-07T11:00:00Z',
+    approvedAt: null,
+    expiresAt: '2026-05-08T11:00:00Z',
+    rationale: 'temporary exemption',
+    revocationReason: null,
+  };
+
+  function build(opts: {
+    perStateRows?: Record<string, OverrideDto[]>;
+    listError?: HttpErrorResponse | null;
+  } = {}): void {
+    TestBed.resetTestingModule();
+    api = jasmine.createSpyObj<ApiService>('ApiService', [
+      'listOverrides',
+      'approveOverride',
+      'revokeOverride',
+    ]);
+    api.listOverrides.and.callFake((query: OverrideListQuery = {}) => {
+      if (opts.listError) return throwError(() => opts.listError!);
+      const state = query.state ?? 'Proposed';
+      return of(opts.perStateRows?.[state] ?? []);
+    });
+
+    TestBed.configureTestingModule({
+      imports: [OverridesManagerComponent],
+      providers: [{ provide: ApiService, useValue: api }],
+    });
+
+    fixture = TestBed.createComponent(OverridesManagerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  it('loads Proposed state by default and renders a row per override', () => {
+    build({ perStateRows: { Proposed: [proposed] } });
+    expect(component.state()).toBe('Proposed');
+    expect(component.overrides().length).toBe(1);
+
+    const row = fixture.nativeElement.querySelector('[data-testid="row-oid-1"]');
+    expect(row).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="approve-oid-1"]')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="revoke-oid-1"]')).toBeTruthy();
+  });
+
+  it('switching tabs reloads with the new state filter', () => {
+    build({
+      perStateRows: {
+        Proposed: [proposed],
+        Approved: [{ ...proposed, id: 'oid-2', state: 'Approved' }],
+      },
+    });
+    api.listOverrides.calls.reset();
+
+    component.setState('Approved');
+
+    expect(api.listOverrides).toHaveBeenCalled();
+    const args = api.listOverrides.calls.mostRecent().args[0] as OverrideListQuery;
+    expect(args.state).toBe('Approved');
+    expect(component.overrides()[0].id).toBe('oid-2');
+  });
+
+  it('renders empty state when no rows for the active tab', () => {
+    build({ perStateRows: { Proposed: [] } });
+    const empty = fixture.nativeElement.querySelector('[data-testid="empty"]');
+    expect(empty).toBeTruthy();
+    expect(empty.textContent).toContain('Proposed');
+  });
+
+  it('toggleExpand opens and closes the inline detail row', () => {
+    build({ perStateRows: { Proposed: [proposed] } });
+
+    component.toggleExpand('oid-1');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="detail-oid-1"]')).toBeTruthy();
+
+    component.toggleExpand('oid-1');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="detail-oid-1"]')).toBeFalsy();
+  });
+
+  it('approve removes the row when the override moves to a different state', () => {
+    build({ perStateRows: { Proposed: [proposed] } });
+    const moved: OverrideDto = { ...proposed, state: 'Approved' };
+    api.approveOverride.and.returnValue(of(moved));
+
+    component.approve(proposed);
+
+    expect(component.overrides().find(o => o.id === 'oid-1')).toBeUndefined();
+    expect(component.approveError()).toBeNull();
+  });
+
+  it('approve patches in place when the new DTO still matches the active tab', () => {
+    // Edge case — server returns a new revision but state unchanged.
+    build({ perStateRows: { Proposed: [proposed] } });
+    const samePatched: OverrideDto = { ...proposed, rationale: 'updated rationale' };
+    api.approveOverride.and.returnValue(of(samePatched));
+
+    component.approve(proposed);
+
+    const row = component.overrides().find(o => o.id === 'oid-1');
+    expect(row?.rationale).toBe('updated rationale');
+  });
+
+  it('approve 403 surfaces an inline approve-error banner', () => {
+    build({ perStateRows: { Proposed: [proposed] } });
+    api.approveOverride.and.returnValue(
+      throwError(() => new HttpErrorResponse({ status: 403, error: { detail: 'forbidden' } })),
+    );
+
+    component.approve(proposed);
+    fixture.detectChanges();
+
+    expect(component.approveError()).toContain('experimentally disabled');
+    const banner = fixture.nativeElement.querySelector('[data-testid="approve-error"]');
+    expect(banner).toBeTruthy();
+  });
+
+  it('onRevokeClosed(updated) routes through applyUpdated', () => {
+    build({ perStateRows: { Proposed: [proposed] } });
+
+    const revoked: OverrideDto = { ...proposed, state: 'Revoked' };
+    component.onRevokeClosed(revoked);
+
+    expect(component.overrides().find(o => o.id === 'oid-1')).toBeUndefined();
+    expect(component.revoking()).toBeNull();
+  });
+
+  it('list error sets a retryable banner', () => {
+    build({ listError: new HttpErrorResponse({ status: 500, error: { title: 'oops' } }) });
+
+    expect(component.errorMessage()).toContain('oops');
+    expect(fixture.nativeElement.querySelector('[data-testid="banner"]')).toBeTruthy();
+  });
+});

--- a/client/src/app/features/overrides/overrides-manager.component.ts
+++ b/client/src/app/features/overrides/overrides-manager.component.ts
@@ -1,0 +1,176 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  OnDestroy,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  ApiService,
+  OverrideDto,
+  OverrideState,
+} from '../../shared/services/api.service';
+import { ExpiryCountdownPipe } from './expiry-countdown.pipe';
+import { RevokeOverrideModalComponent } from './revoke-override-modal.component';
+
+const STATE_TABS: OverrideState[] = ['Proposed', 'Approved', 'Revoked', 'Expired'];
+
+/**
+ * P9.6 (rivoli-ai/andy-policies#88) — overrides browser + manager.
+ *
+ * Reality vs. spec compromises:
+ * - The original spec described a two-column layout (Proposals | Active+Expired
+ *   tabs) plus settings-driven banner gating, RBAC permission cache, and a
+ *   Reject endpoint. Server-side: there's no /api/settings runtime endpoint
+ *   (#191 family), no permissions cache endpoint (covered by P9.3 hold), and
+ *   no Reject endpoint. The settings gate IS enforced server-side via
+ *   `[OverrideWriteGate]` on the write endpoints, so we surface 403s
+ *   reactively from approve/revoke calls instead of preemptive banner.
+ * - Approve takes no body server-side (no rationale modal); revoke uses
+ *   `revocationReason`, not `rationale`.
+ * - "Active" in the spec maps to "Approved" in the actual `OverrideState`
+ *   enum. We use the server names.
+ *
+ * The view: filter by state (one tab per server enum value), table per
+ * state, click a row to expand inline detail (full chain + countdown).
+ * Approved/Proposed rows expose Approve / Revoke; the buttons call the
+ * server and rely on 403 / 409 to surface inline if the user lacks perms
+ * or the experimental gate is off.
+ */
+@Component({
+  selector: 'app-overrides-manager',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ExpiryCountdownPipe,
+    RevokeOverrideModalComponent,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './overrides-manager.component.html',
+  styleUrls: ['./overrides-manager.component.scss'],
+})
+export class OverridesManagerComponent implements OnInit, OnDestroy {
+  private readonly api = inject(ApiService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly STATE_TABS = STATE_TABS;
+  readonly state = signal<OverrideState>('Proposed');
+  readonly overrides = signal<OverrideDto[]>([]);
+  readonly loading = signal(false);
+  readonly errorMessage = signal<string | null>(null);
+  readonly expandedId = signal<string | null>(null);
+  readonly revoking = signal<OverrideDto | null>(null);
+  readonly approveError = signal<string | null>(null);
+
+  /** Drives the impure ExpiryCountdownPipe — reading this in the template
+   *  forces CD to re-evaluate the pipe each tick. */
+  readonly tick = signal(0);
+  private intervalId: number | null = null;
+
+  readonly currentRows = computed(() => this.overrides());
+  readonly hasRows = computed(() => this.currentRows().length > 0);
+
+  ngOnInit(): void {
+    this.reload();
+    // Re-render countdowns once a minute. Use window.setInterval (not RxJS
+    // timer) so the test harness can fast-forward via fakeAsync without
+    // pulling in extra zone glue; we explicitly clear in ngOnDestroy.
+    this.intervalId = window.setInterval(() => this.tick.update(t => t + 1), 60_000);
+  }
+
+  ngOnDestroy(): void {
+    if (this.intervalId !== null) {
+      window.clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  setState(state: OverrideState): void {
+    if (this.state() === state) return;
+    this.state.set(state);
+    this.expandedId.set(null);
+    this.reload();
+  }
+
+  toggleExpand(id: string): void {
+    this.expandedId.update(curr => (curr === id ? null : id));
+  }
+
+  approve(o: OverrideDto): void {
+    this.approveError.set(null);
+    this.api
+      .approveOverride(o.id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: updated => this.applyUpdated(updated),
+        error: (err: HttpErrorResponse) => this.approveError.set(this.describeError(err, 'approve')),
+      });
+  }
+
+  openRevoke(o: OverrideDto): void {
+    this.revoking.set(o);
+  }
+
+  onRevokeClosed(updated: OverrideDto | null): void {
+    this.revoking.set(null);
+    if (updated) this.applyUpdated(updated);
+  }
+
+  retry(): void {
+    this.errorMessage.set(null);
+    this.reload();
+  }
+
+  private reload(): void {
+    this.loading.set(true);
+    this.errorMessage.set(null);
+    this.api
+      .listOverrides({ state: this.state() })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: rows => {
+          this.overrides.set(rows);
+          this.loading.set(false);
+        },
+        error: (err: HttpErrorResponse) => {
+          this.loading.set(false);
+          this.errorMessage.set(this.describeError(err, 'load'));
+        },
+      });
+  }
+
+  /** When approve / revoke returns the new DTO, update or remove from
+   *  the current list depending on whether its new state still matches. */
+  private applyUpdated(updated: OverrideDto): void {
+    const currentTab = this.state();
+    if (updated.state === currentTab) {
+      this.overrides.update(rows =>
+        rows.map(r => (r.id === updated.id ? updated : r)),
+      );
+    } else {
+      // Moved to another state — drop from this list.
+      this.overrides.update(rows => rows.filter(r => r.id !== updated.id));
+      if (this.expandedId() === updated.id) this.expandedId.set(null);
+    }
+  }
+
+  private describeError(err: HttpErrorResponse, op: 'approve' | 'revoke' | 'load'): string {
+    if (err.status === 403) {
+      return op === 'approve'
+        ? 'You do not have permission to approve, or overrides are experimentally disabled.'
+        : 'Permission denied.';
+    }
+    const body = err.error;
+    if (typeof body?.detail === 'string' && body.detail) return body.detail;
+    if (typeof body?.title === 'string') return `${body.title} (${err.status}).`;
+    return `Unexpected error (${err.status}).`;
+  }
+}

--- a/client/src/app/features/overrides/revoke-override-modal.component.spec.ts
+++ b/client/src/app/features/overrides/revoke-override-modal.component.spec.ts
@@ -1,0 +1,91 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+import { ApiService, OverrideDto } from '../../shared/services/api.service';
+import { RevokeOverrideModalComponent } from './revoke-override-modal.component';
+
+describe('RevokeOverrideModalComponent (P9.6)', () => {
+  let fixture: ComponentFixture<RevokeOverrideModalComponent>;
+  let component: RevokeOverrideModalComponent;
+  let api: jasmine.SpyObj<ApiService>;
+
+  const proposedOverride: OverrideDto = {
+    id: 'oid-1',
+    policyVersionId: 'vid-1',
+    scopeKind: 'Principal',
+    scopeRef: 'user:alice',
+    effect: 'Exempt',
+    replacementPolicyVersionId: null,
+    proposerSubjectId: 'user:bob',
+    approverSubjectId: null,
+    state: 'Proposed',
+    proposedAt: '2026-05-07T11:00:00Z',
+    approvedAt: null,
+    expiresAt: '2026-05-08T11:00:00Z',
+    rationale: 'temporary exemption',
+    revocationReason: null,
+  };
+
+  beforeEach(async () => {
+    api = jasmine.createSpyObj<ApiService>('ApiService', ['revokeOverride']);
+    await TestBed.configureTestingModule({
+      imports: [RevokeOverrideModalComponent],
+      providers: [{ provide: ApiService, useValue: api }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RevokeOverrideModalComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('override', proposedOverride);
+    fixture.detectChanges();
+  });
+
+  it('Submit is disabled until revocationReason >= 10 chars', () => {
+    component.form.controls.revocationReason.setValue('short');
+    expect(component.form.invalid).toBeTrue();
+
+    component.form.controls.revocationReason.setValue('exactly 10');
+    expect(component.form.valid).toBeTrue();
+  });
+
+  it('submit calls revokeOverride with the trimmed reason', () => {
+    const updated: OverrideDto = { ...proposedOverride, state: 'Revoked', revocationReason: 'no longer needed for safety' };
+    api.revokeOverride.and.returnValue(of(updated));
+
+    const captures: (OverrideDto | null)[] = [];
+    component.closed.subscribe(v => captures.push(v));
+
+    component.form.controls.revocationReason.setValue('  no longer needed for safety  ');
+    component.submit();
+
+    expect(api.revokeOverride).toHaveBeenCalledWith('oid-1', 'no longer needed for safety');
+    expect(captures).toEqual([updated]);
+  });
+
+  it('on 403 surfaces the experimentally-disabled message inline', () => {
+    const forbidden = new HttpErrorResponse({
+      status: 403,
+      error: { detail: 'Overrides are experimentally disabled.', title: 'Forbidden' },
+    });
+    api.revokeOverride.and.returnValue(throwError(() => forbidden));
+
+    component.form.controls.revocationReason.setValue('valid revocation reason');
+    component.submit();
+    fixture.detectChanges();
+
+    expect(component.errorMessage()).toContain('experimentally disabled');
+    const banner = fixture.nativeElement.querySelector('[data-testid="banner"]');
+    expect(banner).toBeTruthy();
+  });
+
+  it('cancel emits null without calling the API', () => {
+    const captures: (OverrideDto | null)[] = [];
+    component.closed.subscribe(v => captures.push(v));
+
+    component.cancel();
+
+    expect(api.revokeOverride).not.toHaveBeenCalled();
+    expect(captures).toEqual([null]);
+  });
+});

--- a/client/src/app/features/overrides/revoke-override-modal.component.ts
+++ b/client/src/app/features/overrides/revoke-override-modal.component.ts
@@ -1,0 +1,219 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  EventEmitter,
+  Input,
+  Output,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  FormControl,
+  FormGroup,
+  NonNullableFormBuilder,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { ApiService, OverrideDto } from '../../shared/services/api.service';
+
+interface RevokeForm {
+  revocationReason: FormControl<string>;
+}
+
+/**
+ * P9.6 (rivoli-ai/andy-policies#88) — modal that captures a revocation
+ * reason and posts it to `POST /api/overrides/{id}/revoke`. Note the
+ * server expects `revocationReason`, not `rationale` — the field name
+ * from `RevokeOverrideRequest` is reflected here.
+ *
+ * 403 paths are surfaced inline (not as a toast) so the user stays in
+ * context; common cause is the `[OverrideWriteGate]` server-side
+ * filter when `andy.policies.experimentalOverridesEnabled = false`.
+ */
+@Component({
+  selector: 'app-revoke-override-modal',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="overlay" (click)="cancel()" data-testid="overlay">
+      <div
+        class="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="revoke-override-title"
+        (click)="$event.stopPropagation()">
+        <header class="modal-header">
+          <h2 id="revoke-override-title">Revoke override</h2>
+          <p class="subtitle">
+            <strong>{{ override.scopeKind }}</strong>
+            <code class="ref">{{ override.scopeRef }}</code>
+            · {{ override.effect }}
+          </p>
+        </header>
+
+        <form [formGroup]="form" (ngSubmit)="submit()" class="form">
+          <label class="field">
+            <span>
+              Revocation reason
+              <em>(required, min 10 chars — recorded in the audit chain)</em>
+            </span>
+            <textarea
+              formControlName="revocationReason"
+              class="input rationale"
+              rows="3"
+              data-testid="reason"
+              placeholder="Why is this override being revoked?"></textarea>
+          </label>
+
+          <div *ngIf="errorMessage()" class="banner-error" role="alert" data-testid="banner">
+            {{ errorMessage() }}
+          </div>
+
+          <footer class="modal-footer">
+            <button type="button" class="btn-secondary" (click)="cancel()" [disabled]="submitting()">
+              Cancel
+            </button>
+            <button
+              type="submit"
+              class="btn-danger"
+              [disabled]="form.invalid || submitting()"
+              data-testid="submit">
+              <span *ngIf="!submitting()">Revoke</span>
+              <span *ngIf="submitting()">Revoking…</span>
+            </button>
+          </footer>
+        </form>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .overlay {
+      position: fixed; inset: 0;
+      background: rgba(0, 0, 0, 0.45);
+      display: flex; align-items: center; justify-content: center;
+      z-index: 1000; padding: 16px;
+    }
+    .modal {
+      background: var(--surface);
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      padding: 20px 24px;
+      width: 100%; max-width: 480px;
+      display: flex; flex-direction: column; gap: 14px;
+      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
+    }
+    .modal-header h2 { margin: 0 0 4px; font-size: 18px; }
+    .subtitle { margin: 0; font-size: 13px; color: var(--text-secondary); }
+    .ref { background: var(--background); padding: 1px 6px; border-radius: 3px; font-size: 12px; }
+    .form { display: flex; flex-direction: column; gap: 12px; }
+    .field { display: flex; flex-direction: column; gap: 4px; font-size: 14px; }
+    .field > span {
+      color: var(--text-secondary);
+      font-size: 12px;
+      font-weight: 500;
+      em { font-weight: 400; font-style: normal; }
+    }
+    .input {
+      padding: 8px 12px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      background: var(--surface);
+      color: inherit;
+      font-size: 14px;
+      width: 100%;
+    }
+    .rationale { resize: vertical; min-height: 70px; font-family: inherit; }
+    .banner-error {
+      padding: 10px 14px;
+      border-radius: 6px;
+      font-size: 13px;
+      background: #fce8e6;
+      border: 1px solid #f0a99a;
+      color: var(--error);
+    }
+    .modal-footer {
+      display: flex; justify-content: flex-end; gap: 8px;
+      margin-top: 4px;
+    }
+    .btn-secondary, .btn-danger {
+      padding: 8px 16px; font-size: 14px; border-radius: 4px;
+      cursor: pointer; border: 1px solid var(--border);
+    }
+    .btn-secondary { background: var(--surface); color: inherit; }
+    .btn-secondary:hover:not([disabled]) { background: var(--background); }
+    .btn-danger {
+      background: var(--error);
+      color: white;
+      border-color: var(--error);
+    }
+    .btn-danger[disabled] { opacity: 0.55; cursor: not-allowed; }
+  `],
+})
+export class RevokeOverrideModalComponent {
+  static readonly minReasonLength = 10;
+
+  @Input({ required: true }) override!: OverrideDto;
+  @Output() readonly closed = new EventEmitter<OverrideDto | null>();
+
+  private readonly api = inject(ApiService);
+  private readonly fb = inject(NonNullableFormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly submitting = signal(false);
+  readonly errorMessage = signal<string | null>(null);
+
+  readonly form: FormGroup<RevokeForm> = this.fb.group<RevokeForm>({
+    revocationReason: this.fb.control('', [
+      Validators.required,
+      Validators.minLength(RevokeOverrideModalComponent.minReasonLength),
+    ]),
+  });
+
+  submit(): void {
+    if (this.form.invalid || this.submitting()) return;
+
+    const reason = this.form.controls.revocationReason.value.trim();
+    this.submitting.set(true);
+    this.errorMessage.set(null);
+    this.api
+      .revokeOverride(this.override.id, reason)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: updated => {
+          this.submitting.set(false);
+          this.closed.emit(updated);
+        },
+        error: (err: HttpErrorResponse) => {
+          this.submitting.set(false);
+          if (err.status === 403) {
+            this.errorMessage.set(
+              this.describeProblem(err)
+              ?? 'Overrides are experimentally disabled by this deployment.',
+            );
+            return;
+          }
+          this.errorMessage.set(this.describeProblem(err)
+            ?? `Unexpected error (${err.status}).`);
+        },
+      });
+  }
+
+  cancel(): void {
+    this.closed.emit(null);
+  }
+
+  private describeProblem(err: HttpErrorResponse): string | null {
+    const body = err.error;
+    if (!body) return null;
+    if (typeof body.detail === 'string' && body.detail) return body.detail;
+    if (typeof body.title === 'string') return `${body.title} (${err.status}).`;
+    return null;
+  }
+}

--- a/client/src/app/shared/services/api.service.ts
+++ b/client/src/app/shared/services/api.service.ts
@@ -112,6 +112,53 @@ export interface CreateBindingRequest {
 }
 
 /**
+ * P9.6 (#88) — Override lifecycle states. Note: the server has only four states
+ * (no Rejected); the only ways out of `Proposed` are `Approved` (via approve)
+ * or `Revoked` (via revoke). Spec asked for a Reject endpoint that doesn't exist.
+ */
+export type OverrideState = 'Proposed' | 'Approved' | 'Revoked' | 'Expired';
+
+/** Mirrors `Andy.Policies.Domain.Enums.OverrideScopeKind`. */
+export type OverrideScopeKind = 'Principal' | 'Cohort';
+
+/** Mirrors `Andy.Policies.Domain.Enums.OverrideEffect`. `Replace` requires a
+ *  non-null `replacementPolicyVersionId`; the DB enforces a CHECK constraint. */
+export type OverrideEffect = 'Exempt' | 'Replace';
+
+/** Wire shape for `OverrideDto`. ScopeRef format depends on `scopeKind`
+ *  (e.g. principal subject id, cohort name). */
+export interface OverrideDto {
+  id: string;
+  policyVersionId: string;
+  scopeKind: OverrideScopeKind;
+  scopeRef: string;
+  effect: OverrideEffect;
+  replacementPolicyVersionId: string | null;
+  proposerSubjectId: string;
+  approverSubjectId: string | null;
+  state: OverrideState;
+  proposedAt: string;
+  approvedAt: string | null;
+  expiresAt: string;
+  rationale: string;
+  revocationReason: string | null;
+}
+
+/** Filters accepted by `GET /api/overrides`. */
+export interface OverrideListQuery {
+  state?: OverrideState;
+  scopeKind?: OverrideScopeKind;
+  scopeRef?: string;
+  policyVersionId?: string;
+}
+
+/** Body for `POST /api/overrides/{id}/revoke` — note the field is
+ *  `revocationReason`, not `rationale`. */
+export interface RevokeOverrideRequest {
+  revocationReason: string;
+}
+
+/**
  * Maps a target lifecycle state to the action-shaped path segment used by
  * `PolicyVersionsLifecycleController`. `Draft` is intentionally null —
  * versions are born Draft, never transitioned to it.
@@ -246,6 +293,36 @@ export class ApiService {
     let params = new HttpParams();
     if (rationale) params = params.set('rationale', rationale);
     return this.http.delete<void>(`${this.baseUrl}/bindings/${bindingId}`, { params });
+  }
+
+  // --- Overrides (P9.6, #88) ---
+
+  listOverrides(query: OverrideListQuery = {}): Observable<OverrideDto[]> {
+    let params = new HttpParams();
+    if (query.state) params = params.set('state', query.state);
+    if (query.scopeKind) params = params.set('scopeKind', query.scopeKind);
+    if (query.scopeRef) params = params.set('scopeRef', query.scopeRef);
+    if (query.policyVersionId) params = params.set('policyVersionId', query.policyVersionId);
+    return this.http.get<OverrideDto[]>(`${this.baseUrl}/overrides`, { params });
+  }
+
+  /** Approve takes no body — server records the approver's subject id from
+   *  the JWT and stamps `approvedAt`. Spec called for a rationale field that
+   *  doesn't exist on this endpoint; deferred to a follow-up. */
+  approveOverride(id: string): Observable<OverrideDto> {
+    return this.http.post<OverrideDto>(
+      `${this.baseUrl}/overrides/${id}/approve`,
+      null,
+    );
+  }
+
+  /** Revoke body uses `revocationReason` (NOT `rationale`). */
+  revokeOverride(id: string, revocationReason: string): Observable<OverrideDto> {
+    const body: RevokeOverrideRequest = { revocationReason };
+    return this.http.post<OverrideDto>(
+      `${this.baseUrl}/overrides/${id}/revoke`,
+      body,
+    );
   }
 
   // --- Bundles (P8.3) ---


### PR DESCRIPTION
## Summary

\`/overrides\` admin surface — tabbed list (one per actual server state Proposed / Approved / Revoked / Expired), inline detail rows with the full override chain, impure \`ExpiryCountdownPipe\` ticking once a minute, and a revoke modal posting the server's actual \`revocationReason\` field. Approve / Revoke patch the list signals in place; 403 paths surface inline because the experimental gate is server-side (\`[OverrideWriteGate]\`).

## Spec deltas worth flagging

| Spec | Reality |
|---|---|
| \`OverrideState = ... 'Active' ... 'Rejected'\` | \`Proposed \| Approved \| Revoked \| Expired\` — no Active, no Rejected |
| \`POST .../reject\` endpoint | **Doesn't exist** — filed taxonomy follow-up #201 |
| \`Approve\` body \`{rationale}\` | Reality: no body |
| \`Revoke\` body \`{rationale}\` | Reality: \`{revocationReason}\` |
| \`OverrideDto\` flat shape with \`policyName / scope / revision\` | Reality: \`PolicyVersionId / ScopeKind / ScopeRef / Effect / ReplacementPolicyVersionId / Rationale / RevocationReason\` |
| \`/api/settings\` endpoint for experimentalOverridesEnabled | Doesn't exist (P9.1 family hold) — gate is server-side, we surface 403s reactively |
| RBAC perm cache | Doesn't exist (P9.3 hold) — 403 reactive |
| Permission codes \`overrides:approve\` (plural) | Reality: \`override:approve\` (singular) |

**No propose flow shipped** — needs a version picker that belongs on the policy detail page. Filed follow-up #200. Approve + Revoke + browsing flows are complete.

## Test plan

- [x] \`npm test\` — **78/78 pass**: 8 countdown-pipe cases, 4 revoke-modal cases, 9 manager cases (tabs, expand, approve drop-on-state-change + patch-in-place, approve 403 banner, list error retry, onRevokeClosed routing). 57 carried from P9.1/P9.2/P9.4/P9.5.
- [x] \`npm run build\` — prod bundle clean.
- [x] \`dotnet build\` — green.

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)