### PR TITLE
Implement P9.7 — audit timeline + verify (#89)

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -6,6 +6,7 @@
       <a routerLink="/dashboard" routerLinkActive="active">Dashboard</a>
       <a routerLink="/policies" routerLinkActive="active">Policies</a>
       <a routerLink="/overrides" routerLinkActive="active">Overrides</a>
+      <a routerLink="/audit" routerLinkActive="active">Audit</a>
       <a routerLink="/help" routerLinkActive="active">Help</a>
     </div>
     <div class="auth-section">

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -58,6 +58,14 @@ export const routes: Routes = [
     canActivate: [authGuard],
   },
   {
+    path: 'audit',
+    loadComponent: () =>
+      import('./features/audit/audit-timeline.component').then(
+        (m) => m.AuditTimelineComponent
+      ),
+    canActivate: [authGuard],
+  },
+  {
     path: 'help',
     loadComponent: () =>
       import('./features/help/help.component').then(

--- a/client/src/app/features/audit/audit-timeline.component.html
+++ b/client/src/app/features/audit/audit-timeline.component.html
@@ -1,0 +1,166 @@
+<!-- Copyright (c) Rivoli AI 2026. All rights reserved. -->
+<div class="page">
+  <header class="page-header">
+    <div class="title-row">
+      <h1>Audit timeline</h1>
+      <button
+        type="button"
+        class="btn-primary"
+        (click)="verify()"
+        [disabled]="verifyState() === 'running'"
+        data-testid="verify">
+        <span *ngIf="verifyState() !== 'running'">Verify chain</span>
+        <span *ngIf="verifyState() === 'running'">Verifying…</span>
+      </button>
+    </div>
+    <p class="page-subtitle">
+      Tamper-evident, hash-chained record of every state-changing operation.
+      Reads via cursor pagination — newest first.
+    </p>
+  </header>
+
+  <!-- Verify result banners -->
+  <div
+    *ngIf="verifyState() === 'ok' && verifyResult() as r"
+    class="banner-ok"
+    role="status"
+    data-testid="verify-ok">
+    Chain verified through seq <strong>{{ r.lastSeq }}</strong> ·
+    inspected {{ r.inspectedCount }} events.
+  </div>
+
+  <div
+    *ngIf="verifyState() === 'diverged' && verifyResult() as r"
+    class="banner-diverged"
+    role="alert"
+    data-testid="verify-diverged">
+    <strong>Divergence at seq {{ r.firstDivergenceSeq }}.</strong>
+    Audit integrity is compromised. Last known-good seq: {{ r.lastSeq }}.
+    Contact an administrator.
+    <button type="button" class="btn-link" (click)="copyDiagnostic()">
+      Copy diagnostic
+    </button>
+  </div>
+
+  <div
+    *ngIf="verifyState() === 'error'"
+    class="banner-error"
+    role="alert"
+    data-testid="verify-error">
+    Verify failed — try again.
+  </div>
+
+  <!-- Filter bar -->
+  <section class="filter-bar" aria-label="Audit filters">
+    <input
+      class="input"
+      type="text"
+      placeholder="Actor subject id…"
+      [ngModel]="actor()"
+      (ngModelChange)="actor.set($event)"
+      (change)="reload()"
+      data-testid="filter-actor"
+      aria-label="Actor filter" />
+    <input
+      class="input"
+      type="text"
+      placeholder="Action (e.g. policy.publish)"
+      [ngModel]="action()"
+      (ngModelChange)="action.set($event)"
+      (change)="reload()"
+      data-testid="filter-action"
+      aria-label="Action filter" />
+    <input
+      class="input"
+      type="text"
+      placeholder="Entity type"
+      [ngModel]="entityType()"
+      (ngModelChange)="entityType.set($event)"
+      (change)="reload()"
+      data-testid="filter-entityType"
+      aria-label="Entity type filter" />
+    <input
+      class="input"
+      type="text"
+      placeholder="Entity id"
+      [ngModel]="entityId()"
+      (ngModelChange)="entityId.set($event)"
+      (change)="reload()"
+      data-testid="filter-entityId"
+      aria-label="Entity id filter" />
+  </section>
+
+  <!-- Status / banner / empty -->
+  <div *ngIf="loading() && events().length === 0" class="loading" data-testid="loading">
+    Loading audit events…
+  </div>
+
+  <div *ngIf="errorMessage()" class="banner-error" role="alert" data-testid="banner">
+    {{ errorMessage() }}
+    <button type="button" class="btn-link" (click)="reload()">Retry</button>
+  </div>
+
+  <p
+    *ngIf="!loading() && events().length === 0 && !errorMessage()"
+    class="empty"
+    data-testid="empty">
+    No audit events match the current filters.
+  </p>
+
+  <!-- Timeline -->
+  <ol *ngIf="events().length > 0" class="timeline" data-testid="timeline">
+    <li
+      *ngFor="let e of events()"
+      class="event"
+      [class.expanded]="isExpanded(e.id)"
+      [attr.data-testid]="'event-' + e.id">
+      <div class="event-header">
+        <span class="seq">#{{ e.seq }}</span>
+        <span class="action-badge">{{ e.action }}</span>
+        <span class="entity">
+          <strong>{{ e.entityType }}</strong>
+          <code>{{ e.entityId }}</code>
+        </span>
+        <span class="actor">{{ e.actorSubjectId }}</span>
+        <time class="ts">{{ e.timestamp | date: 'short' }}</time>
+        <button
+          type="button"
+          class="btn-link expand-btn"
+          (click)="toggle(e.id)"
+          [attr.data-testid]="'expand-' + e.id">
+          {{ isExpanded(e.id) ? 'Collapse' : 'Expand' }}
+        </button>
+      </div>
+      <p *ngIf="e.rationale" class="rationale">
+        <span class="rationale-label">Rationale:</span> {{ e.rationale }}
+      </p>
+      <div *ngIf="isExpanded(e.id)" class="diff-panel" [attr.data-testid]="'diff-' + e.id">
+        <app-rfc6902-diff-view [fieldDiff]="e.fieldDiff"></app-rfc6902-diff-view>
+        <details class="hashes">
+          <summary>Hashes</summary>
+          <dl class="hash-grid">
+            <dt>prev</dt><dd><code>{{ e.prevHashHex }}</code></dd>
+            <dt>hash</dt><dd><code>{{ e.hashHex }}</code></dd>
+          </dl>
+        </details>
+      </div>
+    </li>
+  </ol>
+
+  <!-- Footer + pagination -->
+  <footer
+    *ngIf="events().length > 0"
+    class="footer"
+    data-testid="footer">
+    <span class="count">{{ events().length }} events loaded</span>
+    <button
+      *ngIf="hasMore()"
+      class="btn-secondary"
+      (click)="loadMore()"
+      [disabled]="loading()"
+      data-testid="load-more">
+      <span *ngIf="!loading()">Load more</span>
+      <span *ngIf="loading()">Loading…</span>
+    </button>
+  </footer>
+</div>

--- a/client/src/app/features/audit/audit-timeline.component.scss
+++ b/client/src/app/features/audit/audit-timeline.component.scss
@@ -1,0 +1,247 @@
+/* Copyright (c) Rivoli AI 2026. All rights reserved. */
+
+.page { display: flex; flex-direction: column; gap: 16px; }
+
+.page-header h1 { margin: 0; }
+
+.title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.page-subtitle {
+  margin: 4px 0 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.banner-ok,
+.banner-diverged,
+.banner-error {
+  padding: 12px 16px;
+  border-radius: 6px;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.banner-ok {
+  background: #e6f4ea;
+  border: 1px solid #b6e0c2;
+  color: var(--success);
+}
+
+.banner-diverged {
+  background: #fce8e6;
+  border: 1px solid #f0a99a;
+  color: var(--error);
+}
+
+.banner-error {
+  background: #fff4e5;
+  border: 1px solid #f0b37e;
+  color: #7a4a00;
+}
+
+.banner-diverged strong,
+.banner-ok strong {
+  font-variant-numeric: tabular-nums;
+}
+
+.filter-bar {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(140px, 1fr));
+  gap: 8px;
+  background: var(--surface);
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.input {
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 14px;
+  background: var(--surface);
+  color: inherit;
+  width: 100%;
+}
+
+.input:focus { outline: 2px solid var(--primary); outline-offset: 1px; }
+
+.loading,
+.empty {
+  padding: 32px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 14px;
+  background: var(--surface);
+  border-radius: 8px;
+  border: 1px dashed var(--border);
+}
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.event {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.event.expanded {
+  border-color: var(--primary);
+}
+
+.event-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 13px;
+}
+
+.seq {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-weight: 600;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.action-badge {
+  background: var(--background);
+  border: 1px solid var(--border);
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.entity {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+  min-width: 200px;
+  font-size: 12px;
+
+  strong { color: var(--text-secondary); font-weight: 600; }
+  code {
+    background: var(--background);
+    padding: 1px 6px;
+    border-radius: 3px;
+  }
+}
+
+.actor {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.ts {
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.rationale {
+  margin: 0;
+  padding: 6px 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  border-top: 1px dashed var(--border);
+}
+
+.rationale-label { font-weight: 600; }
+
+.diff-panel {
+  border-top: 1px solid var(--border);
+  padding-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.hashes summary {
+  font-size: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.hash-grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 12px;
+  margin: 6px 0 0;
+  font-size: 12px;
+
+  dt { color: var(--text-secondary); }
+  dd { margin: 0; word-break: break-all; }
+  code { font-size: 11px; }
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.btn-primary {
+  padding: 8px 16px;
+  font-size: 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  background: var(--primary);
+  color: white;
+  border: 1px solid var(--primary);
+}
+
+.btn-primary[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: inherit;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.btn-secondary[disabled] { opacity: 0.55; cursor: not-allowed; }
+.btn-secondary:hover:not([disabled]) { background: var(--background); }
+
+.btn-link {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--primary);
+  font: inherit;
+  font-size: 12px;
+}
+
+.btn-link:hover { text-decoration: underline; }
+
+.expand-btn { font-size: 12px; }

--- a/client/src/app/features/audit/audit-timeline.component.spec.ts
+++ b/client/src/app/features/audit/audit-timeline.component.spec.ts
@@ -1,0 +1,186 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+import {
+  ApiService,
+  AuditEventDto,
+  AuditPageDto,
+  AuditQuery,
+  ChainVerificationDto,
+} from '../../shared/services/api.service';
+import { AuditTimelineComponent } from './audit-timeline.component';
+
+describe('AuditTimelineComponent (P9.7)', () => {
+  let fixture: ComponentFixture<AuditTimelineComponent>;
+  let component: AuditTimelineComponent;
+  let api: jasmine.SpyObj<ApiService>;
+
+  function makeEvent(seq: number, idSuffix: string): AuditEventDto {
+    return {
+      id: `evt-${idSuffix}`,
+      seq,
+      prevHashHex: 'a'.repeat(64),
+      hashHex: 'b'.repeat(64),
+      timestamp: '2026-05-07T12:00:00Z',
+      actorSubjectId: 'user:alice',
+      actorRoles: ['admin'],
+      action: 'policy.publish',
+      entityType: 'PolicyVersion',
+      entityId: 'vid-1',
+      fieldDiff: [{ op: 'replace', path: '/state', value: 'Active' }],
+      rationale: 'Promoting to Active',
+    };
+  }
+
+  function build(opts: {
+    pages?: AuditPageDto[];
+    listError?: HttpErrorResponse;
+  } = {}): void {
+    TestBed.resetTestingModule();
+    api = jasmine.createSpyObj<ApiService>('ApiService', [
+      'listAudit',
+      'verifyAuditChain',
+    ]);
+    if (opts.listError) {
+      api.listAudit.and.returnValue(throwError(() => opts.listError!));
+    } else {
+      let i = 0;
+      const pages = opts.pages ?? [{ items: [], nextCursor: null, pageSize: 50 }];
+      api.listAudit.and.callFake(() => of(pages[Math.min(i++, pages.length - 1)]));
+    }
+
+    TestBed.configureTestingModule({
+      imports: [AuditTimelineComponent],
+      providers: [{ provide: ApiService, useValue: api }],
+    });
+
+    fixture = TestBed.createComponent(AuditTimelineComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  it('loads first page on init', () => {
+    build({
+      pages: [{
+        items: [makeEvent(2, '2'), makeEvent(1, '1')],
+        nextCursor: 'cur-1',
+        pageSize: 50,
+      }],
+    });
+
+    expect(api.listAudit).toHaveBeenCalledTimes(1);
+    expect(component.events().length).toBe(2);
+    expect(component.events()[0].seq).toBe(2);
+    expect(component.hasMore()).toBeTrue();
+  });
+
+  it('renders empty state when first page is empty', () => {
+    build({ pages: [{ items: [], nextCursor: null, pageSize: 50 }] });
+    const empty = fixture.nativeElement.querySelector('[data-testid="empty"]');
+    expect(empty).toBeTruthy();
+  });
+
+  it('loadMore appends with the cursor; stops when nextCursor null', () => {
+    build({
+      pages: [
+        { items: [makeEvent(2, '2'), makeEvent(1, '1')], nextCursor: 'cur-1', pageSize: 50 },
+        { items: [makeEvent(0, '0')], nextCursor: null, pageSize: 50 },
+      ],
+    });
+
+    component.loadMore();
+    expect(api.listAudit).toHaveBeenCalledTimes(2);
+    const args = api.listAudit.calls.mostRecent().args[0] as AuditQuery;
+    expect(args.cursor).toBe('cur-1');
+    expect(component.events().length).toBe(3);
+    expect(component.hasMore()).toBeFalse();
+  });
+
+  it('filter change resets cursor and reloads from scratch', () => {
+    build({
+      pages: [
+        { items: [makeEvent(5, '5')], nextCursor: 'cur-x', pageSize: 50 },
+        { items: [makeEvent(9, '9')], nextCursor: null, pageSize: 50 },
+      ],
+    });
+
+    component.actor.set('user:bob');
+    component.reload();
+
+    // Second call carries the actor filter and no cursor.
+    const args = api.listAudit.calls.mostRecent().args[0] as AuditQuery;
+    expect(args.actor).toBe('user:bob');
+    expect(args.cursor).toBeUndefined();
+    expect(component.events().length).toBe(1);
+    expect(component.events()[0].id).toBe('evt-9');
+  });
+
+  it('toggle expands and collapses the diff panel for a row', () => {
+    build({
+      pages: [{ items: [makeEvent(1, '1')], nextCursor: null, pageSize: 50 }],
+    });
+
+    component.toggle('evt-1');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="diff-evt-1"]')).toBeTruthy();
+
+    component.toggle('evt-1');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="diff-evt-1"]')).toBeFalsy();
+  });
+
+  it('verify happy-path renders the OK banner', () => {
+    build({});
+    const ok: ChainVerificationDto = {
+      valid: true, firstDivergenceSeq: null, inspectedCount: 42, lastSeq: 42,
+    };
+    api.verifyAuditChain.and.returnValue(of(ok));
+
+    component.verify();
+    fixture.detectChanges();
+
+    expect(component.verifyState()).toBe('ok');
+    const banner = fixture.nativeElement.querySelector('[data-testid="verify-ok"]');
+    expect(banner).toBeTruthy();
+    expect(banner.textContent).toContain('42');
+  });
+
+  it('verify divergence renders the red banner with firstDivergenceSeq', () => {
+    build({});
+    const bad: ChainVerificationDto = {
+      valid: false, firstDivergenceSeq: 17, inspectedCount: 100, lastSeq: 16,
+    };
+    api.verifyAuditChain.and.returnValue(of(bad));
+
+    component.verify();
+    fixture.detectChanges();
+
+    expect(component.verifyState()).toBe('diverged');
+    const banner = fixture.nativeElement.querySelector('[data-testid="verify-diverged"]');
+    expect(banner).toBeTruthy();
+    expect(banner.textContent).toContain('17');
+  });
+
+  it('verify error sets the error banner', () => {
+    build({});
+    api.verifyAuditChain.and.returnValue(
+      throwError(() => new HttpErrorResponse({ status: 500 })),
+    );
+
+    component.verify();
+    fixture.detectChanges();
+
+    expect(component.verifyState()).toBe('error');
+    expect(fixture.nativeElement.querySelector('[data-testid="verify-error"]')).toBeTruthy();
+  });
+
+  it('list error surfaces a retryable banner', () => {
+    build({ listError: new HttpErrorResponse({ status: 500, error: { title: 'oops' } }) });
+    fixture.detectChanges();
+
+    expect(component.errorMessage()).toContain('oops');
+    expect(fixture.nativeElement.querySelector('[data-testid="banner"]')).toBeTruthy();
+  });
+});

--- a/client/src/app/features/audit/audit-timeline.component.ts
+++ b/client/src/app/features/audit/audit-timeline.component.ts
@@ -1,0 +1,172 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import {
+  ApiService,
+  AuditEventDto,
+  AuditQuery,
+  ChainVerificationDto,
+} from '../../shared/services/api.service';
+import { Rfc6902DiffViewComponent } from '../../shared/components/rfc6902-diff-view.component';
+
+type VerifyState = 'idle' | 'running' | 'ok' | 'diverged' | 'error';
+
+/**
+ * P9.7 (rivoli-ai/andy-policies#89) — chronological audit event browser.
+ *
+ * Reality vs. spec compromises:
+ * - The actual server pages by **opaque cursor** (`AuditPageDto.nextCursor`),
+ *   not by `fromSeq`. The UI advances via "Load more" rather than infinite-scroll.
+ * - `AuditEventDto.fieldDiff` arrives already parsed (JsonElement on the
+ *   server, plain array on the wire) so the diff renderer takes an array,
+ *   not a stringified blob.
+ * - `ChainVerificationDto` shape is `{ valid, firstDivergenceSeq,
+ *   inspectedCount, lastSeq }` — no `verifiedAt` timestamp; we display
+ *   the local UI clock instead.
+ *
+ * Filter changes reset the cursor and reload from scratch. "Verify chain"
+ * is independent of the filter (the server verifies the whole chain).
+ */
+@Component({
+  selector: 'app-audit-timeline',
+  standalone: true,
+  imports: [CommonModule, FormsModule, Rfc6902DiffViewComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './audit-timeline.component.html',
+  styleUrls: ['./audit-timeline.component.scss'],
+})
+export class AuditTimelineComponent {
+  private readonly api = inject(ApiService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  // Filter state.
+  readonly actor = signal<string>('');
+  readonly action = signal<string>('');
+  readonly entityType = signal<string>('');
+  readonly entityId = signal<string>('');
+  readonly pageSize = signal<number>(50);
+
+  // Result state.
+  readonly events = signal<AuditEventDto[]>([]);
+  readonly cursor = signal<string | null>(null);
+  readonly hasMore = computed(() => this.cursor() !== null);
+  readonly loading = signal(false);
+  readonly errorMessage = signal<string | null>(null);
+  readonly expanded = signal<ReadonlySet<string>>(new Set());
+
+  // Verify state.
+  readonly verifyState = signal<VerifyState>('idle');
+  readonly verifyResult = signal<ChainVerificationDto | null>(null);
+  readonly verifyAt = signal<Date | null>(null);
+
+  constructor() {
+    this.reload();
+  }
+
+  reload(): void {
+    this.loading.set(true);
+    this.errorMessage.set(null);
+    this.events.set([]);
+    this.cursor.set(null);
+    this.fetchPage(/* append */ false);
+  }
+
+  loadMore(): void {
+    if (!this.hasMore() || this.loading()) return;
+    this.fetchPage(/* append */ true);
+  }
+
+  toggle(eventId: string): void {
+    this.expanded.update(curr => {
+      const next = new Set(curr);
+      if (next.has(eventId)) next.delete(eventId); else next.add(eventId);
+      return next;
+    });
+  }
+
+  isExpanded(eventId: string): boolean {
+    return this.expanded().has(eventId);
+  }
+
+  verify(): void {
+    this.verifyState.set('running');
+    this.verifyResult.set(null);
+    this.api
+      .verifyAuditChain()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: r => {
+          this.verifyResult.set(r);
+          this.verifyAt.set(new Date());
+          this.verifyState.set(r.valid ? 'ok' : 'diverged');
+        },
+        error: () => {
+          this.verifyState.set('error');
+        },
+      });
+  }
+
+  copyDiagnostic(): void {
+    const r = this.verifyResult();
+    if (!r) return;
+    const payload = JSON.stringify(
+      {
+        ...r,
+        verifiedAt: this.verifyAt()?.toISOString() ?? null,
+      },
+      null,
+      2,
+    );
+    // navigator.clipboard is the only modern path; older browsers fall
+    // back silently — failure is not user-actionable beyond "screenshot".
+    if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      void navigator.clipboard.writeText(payload);
+    }
+  }
+
+  private fetchPage(append: boolean): void {
+    const query: AuditQuery = {
+      actor: this.actor() || undefined,
+      action: this.action() || undefined,
+      entityType: this.entityType() || undefined,
+      entityId: this.entityId() || undefined,
+      pageSize: this.pageSize(),
+      cursor: append ? this.cursor() ?? undefined : undefined,
+    };
+
+    this.loading.set(true);
+    this.errorMessage.set(null);
+    this.api
+      .listAudit(query)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: page => {
+          this.events.update(prev => (append ? [...prev, ...page.items] : page.items));
+          this.cursor.set(page.nextCursor);
+          this.loading.set(false);
+        },
+        error: (err: HttpErrorResponse) => {
+          this.loading.set(false);
+          this.errorMessage.set(this.describeError(err));
+        },
+      });
+  }
+
+  private describeError(err: HttpErrorResponse): string {
+    const body = err.error;
+    if (typeof body?.detail === 'string' && body.detail) return body.detail;
+    if (typeof body?.title === 'string') return `${body.title} (${err.status}).`;
+    return `Unexpected error (${err.status}).`;
+  }
+}

--- a/client/src/app/shared/components/rfc6902-diff-view.component.spec.ts
+++ b/client/src/app/shared/components/rfc6902-diff-view.component.spec.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Rfc6902DiffViewComponent } from './rfc6902-diff-view.component';
+
+describe('Rfc6902DiffViewComponent (P9.7)', () => {
+  let fixture: ComponentFixture<Rfc6902DiffViewComponent>;
+  let component: Rfc6902DiffViewComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Rfc6902DiffViewComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Rfc6902DiffViewComponent);
+    component = fixture.componentInstance;
+  });
+
+  function setOps(ops: unknown): void {
+    fixture.componentRef.setInput('fieldDiff', ops);
+    fixture.detectChanges();
+  }
+
+  it('renders empty-state copy when there are no ops', () => {
+    setOps([]);
+    expect(fixture.nativeElement.querySelector('.empty')).toBeTruthy();
+  });
+
+  it('renders + / - / ~ markers per op kind', () => {
+    setOps([
+      { op: 'add', path: '/policy/name', value: 'x' },
+      { op: 'remove', path: '/policy/old' },
+      { op: 'replace', path: '/policy/severity', value: 'critical' },
+    ]);
+    const markers = Array.from(fixture.nativeElement.querySelectorAll('.marker'))
+      .map((m: any) => m.textContent.trim());
+    expect(markers).toEqual(['+', '-', '~']);
+  });
+
+  it('formats path-to-path for move/copy with the from arrow', () => {
+    setOps([{ op: 'move', path: '/policy/dst', from: '/policy/src' }]);
+    const detail = fixture.nativeElement.querySelector('.detail').textContent;
+    expect(detail).toContain('from /policy/src');
+  });
+
+  it('truncates a long value past 200 chars and exposes Expand', () => {
+    const big = 'x'.repeat(500);
+    setOps([{ op: 'add', path: '/big', value: big }]);
+
+    const detail = fixture.nativeElement.querySelector('.detail').textContent;
+    expect(detail).toContain('…');
+    expect(fixture.nativeElement.querySelector('[data-testid="expand-0"]')).toBeTruthy();
+
+    component.toggle(0);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="collapse-0"]')).toBeTruthy();
+    const full = fixture.nativeElement.querySelector('.full').textContent;
+    expect(full.length).toBeGreaterThan(200);
+  });
+
+  it('accepts a stringified array as a defensive parse path', () => {
+    setOps(JSON.stringify([{ op: 'add', path: '/a', value: 1 }]));
+    expect(component.ops.length).toBe(1);
+    expect(component.parseError()).toBeFalse();
+  });
+
+  it('flags parseError when the input is malformed JSON or not an array', () => {
+    setOps('not json');
+    expect(component.parseError()).toBeTrue();
+    expect(fixture.nativeElement.querySelector('[data-testid="parse-error"]')).toBeTruthy();
+  });
+
+  it('treats null fieldDiff as empty without parseError', () => {
+    setOps(null);
+    expect(component.ops.length).toBe(0);
+    expect(component.parseError()).toBeFalse();
+  });
+});

--- a/client/src/app/shared/components/rfc6902-diff-view.component.ts
+++ b/client/src/app/shared/components/rfc6902-diff-view.component.ts
@@ -1,0 +1,243 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  computed,
+  signal,
+} from '@angular/core';
+import { Rfc6902Op } from '../services/api.service';
+
+interface RenderedOp {
+  op: Rfc6902Op['op'];
+  path: string;
+  marker: '+' | '-' | '~' | '↦';
+  /** Cached display string for `value` / `from`; truncated when long. */
+  detail: string;
+  /** True when `detail` was truncated and an Expand affordance should show. */
+  truncated: boolean;
+  /** Full value text for the expanded variant. */
+  fullDetail: string;
+}
+
+const TRUNCATE_AT = 200;
+
+/**
+ * P9.7 (rivoli-ai/andy-policies#89) — renders an array of RFC 6902
+ * operations as a colour-coded list. Reusable: P9.8 (bundle explorer)
+ * also consumes RFC 6902 patches for bundle diffs and feeds them into
+ * the same component.
+ *
+ * Marker conventions:
+ * - `+` add
+ * - `-` remove
+ * - `~` replace
+ * - `↦` move / copy (path-to-path)
+ *
+ * Long values truncate at 200 chars with an inline Expand toggle so a
+ * single 50KB field doesn't blow up the timeline DOM.
+ */
+@Component({
+  selector: 'app-rfc6902-diff-view',
+  standalone: true,
+  imports: [CommonModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="diff-view" data-testid="diff-view">
+      <p *ngIf="ops.length === 0 && !parseError()" class="empty">No field-level changes.</p>
+      <p *ngIf="parseError()" class="parse-error" data-testid="parse-error">
+        Could not render diff (unexpected payload shape).
+      </p>
+      <ol *ngIf="ops.length > 0" class="ops">
+        <li
+          *ngFor="let op of rendered(); let i = index"
+          class="op op-{{ op.op }}"
+          [attr.data-testid]="'op-' + i">
+          <span class="marker" [attr.aria-label]="op.op">{{ op.marker }}</span>
+          <code class="path">{{ op.path }}</code>
+          <span *ngIf="op.detail" class="detail">
+            <ng-container *ngIf="!isExpanded(i); else expandedTpl">
+              {{ op.detail }}
+              <button
+                *ngIf="op.truncated"
+                type="button"
+                class="expand-btn"
+                (click)="toggle(i)"
+                [attr.data-testid]="'expand-' + i">
+                Expand
+              </button>
+            </ng-container>
+            <ng-template #expandedTpl>
+              <pre class="full">{{ op.fullDetail }}</pre>
+              <button
+                type="button"
+                class="expand-btn"
+                (click)="toggle(i)"
+                [attr.data-testid]="'collapse-' + i">
+                Collapse
+              </button>
+            </ng-template>
+          </span>
+        </li>
+      </ol>
+    </div>
+  `,
+  styles: [`
+    .diff-view {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 12px;
+    }
+    .empty, .parse-error {
+      margin: 0;
+      color: var(--text-secondary);
+      font-style: italic;
+      font-size: 12px;
+    }
+    .parse-error { color: var(--error); font-style: normal; }
+    .ops { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 2px; }
+    .op {
+      display: flex;
+      align-items: baseline;
+      gap: 8px;
+      padding: 2px 4px;
+      border-radius: 3px;
+    }
+    .op-add { background: rgba(40, 167, 69, 0.07); }
+    .op-remove { background: rgba(220, 53, 69, 0.07); }
+    .op-replace { background: rgba(255, 193, 7, 0.07); }
+
+    .marker {
+      width: 14px;
+      text-align: center;
+      font-weight: 700;
+      flex-shrink: 0;
+    }
+    .op-add .marker { color: var(--success); }
+    .op-remove .marker { color: var(--error); }
+    .op-replace .marker { color: #a85d00; }
+
+    .path {
+      background: var(--background);
+      padding: 0 4px;
+      border-radius: 2px;
+      flex-shrink: 0;
+    }
+
+    .detail {
+      flex: 1;
+      word-break: break-word;
+      color: var(--text-secondary);
+    }
+
+    .full {
+      margin: 4px 0 0;
+      padding: 6px 8px;
+      background: var(--background);
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      white-space: pre-wrap;
+      font-size: 11px;
+    }
+
+    .expand-btn {
+      background: transparent;
+      border: none;
+      color: var(--primary);
+      font: inherit;
+      font-size: 11px;
+      cursor: pointer;
+      padding: 0 4px;
+    }
+
+    .expand-btn:hover { text-decoration: underline; }
+  `],
+})
+export class Rfc6902DiffViewComponent {
+  ops: Rfc6902Op[] = [];
+  readonly parseError = signal(false);
+
+  @Input({ required: true }) set fieldDiff(v: Rfc6902Op[] | string | null | undefined) {
+    this.parseError.set(false);
+    if (v == null) {
+      this.ops = [];
+      return;
+    }
+    if (Array.isArray(v)) {
+      // Already parsed by the server (the actual API shape).
+      this.ops = v;
+      return;
+    }
+    if (typeof v === 'string') {
+      // Defensive — some downstream consumers (P9.8 bundle diff) might
+      // receive a string blob; try to parse and fall back to error.
+      try {
+        const parsed = JSON.parse(v);
+        if (Array.isArray(parsed)) {
+          this.ops = parsed as Rfc6902Op[];
+          return;
+        }
+      } catch {
+        /* fallthrough */
+      }
+      this.parseError.set(true);
+      this.ops = [];
+      return;
+    }
+    this.parseError.set(true);
+    this.ops = [];
+  }
+
+  private readonly expandedSet = signal<ReadonlySet<number>>(new Set());
+
+  /** Recompute on each `ops` mutation; the parent re-binds `[fieldDiff]`
+   *  on every row, so this is naturally re-evaluated. */
+  readonly rendered = computed<RenderedOp[]>(() =>
+    this.ops.map(op => Rfc6902DiffViewComponent.render(op)),
+  );
+
+  isExpanded(index: number): boolean {
+    return this.expandedSet().has(index);
+  }
+
+  toggle(index: number): void {
+    const next = new Set(this.expandedSet());
+    if (next.has(index)) next.delete(index); else next.add(index);
+    this.expandedSet.set(next);
+  }
+
+  private static render(op: Rfc6902Op): RenderedOp {
+    let marker: RenderedOp['marker'];
+    switch (op.op) {
+      case 'add': marker = '+'; break;
+      case 'remove': marker = '-'; break;
+      case 'replace': marker = '~'; break;
+      default: marker = '↦';
+    }
+    const full = Rfc6902DiffViewComponent.formatDetail(op);
+    const truncated = full.length > TRUNCATE_AT;
+    return {
+      op: op.op,
+      path: op.path,
+      marker,
+      detail: truncated ? full.substring(0, TRUNCATE_AT) + '…' : full,
+      truncated,
+      fullDetail: full,
+    };
+  }
+
+  private static formatDetail(op: Rfc6902Op): string {
+    if (op.op === 'remove') return '';
+    if (op.op === 'move' || op.op === 'copy') return `from ${op.from ?? '?'}`;
+    if (op.op === 'test' || op.op === 'add' || op.op === 'replace') {
+      if (op.value === undefined) return '';
+      try {
+        return `→ ${JSON.stringify(op.value)}`;
+      } catch {
+        return '→ <unrenderable value>';
+      }
+    }
+    return '';
+  }
+}

--- a/client/src/app/shared/services/api.service.ts
+++ b/client/src/app/shared/services/api.service.ts
@@ -158,6 +158,66 @@ export interface RevokeOverrideRequest {
   revocationReason: string;
 }
 
+/** Subset of RFC 6902 operations we expect in `AuditEventDto.fieldDiff`. */
+export interface Rfc6902Op {
+  op: 'add' | 'remove' | 'replace' | 'move' | 'copy' | 'test';
+  path: string;
+  value?: unknown;
+  from?: string;
+}
+
+/**
+ * P9.7 (#89) — wire shape for `AuditEventDto`. Note `fieldDiff` arrives
+ * already parsed (server emits it as a JSON array, not a stringified blob)
+ * so client-side rendering can iterate operations directly. `prevHashHex`
+ * + `hashHex` are hex-encoded SHA-256 strings.
+ */
+export interface AuditEventDto {
+  id: string;
+  seq: number;
+  prevHashHex: string;
+  hashHex: string;
+  timestamp: string;
+  actorSubjectId: string;
+  actorRoles: string[];
+  action: string;
+  entityType: string;
+  entityId: string;
+  fieldDiff: Rfc6902Op[];
+  rationale: string | null;
+}
+
+/** Page envelope returned by `GET /api/audit`. Cursor-based: pass
+ *  `nextCursor` back as `cursor` to fetch the next page. */
+export interface AuditPageDto {
+  items: AuditEventDto[];
+  nextCursor: string | null;
+  pageSize: number;
+}
+
+/** Filters accepted by `GET /api/audit`. `from`/`to` are timestamps,
+ *  `cursor` is the opaque token from a previous page's `nextCursor`. */
+export interface AuditQuery {
+  actor?: string;
+  action?: string;
+  entityType?: string;
+  entityId?: string;
+  from?: string;
+  to?: string;
+  cursor?: string | null;
+  pageSize?: number;
+}
+
+/** Result of `GET /api/audit/verify`. `valid === true` ⇔
+ *  `firstDivergenceSeq === null`. `lastSeq` is the highest seq inspected
+ *  (or 0 if the chain is empty). */
+export interface ChainVerificationDto {
+  valid: boolean;
+  firstDivergenceSeq: number | null;
+  inspectedCount: number;
+  lastSeq: number;
+}
+
 /**
  * Maps a target lifecycle state to the action-shaped path segment used by
  * `PolicyVersionsLifecycleController`. `Draft` is intentionally null —
@@ -322,6 +382,31 @@ export class ApiService {
     return this.http.post<OverrideDto>(
       `${this.baseUrl}/overrides/${id}/revoke`,
       body,
+    );
+  }
+
+  // --- Audit (P9.7, #89) ---
+
+  listAudit(query: AuditQuery = {}): Observable<AuditPageDto> {
+    let params = new HttpParams();
+    if (query.actor) params = params.set('actor', query.actor);
+    if (query.action) params = params.set('action', query.action);
+    if (query.entityType) params = params.set('entityType', query.entityType);
+    if (query.entityId) params = params.set('entityId', query.entityId);
+    if (query.from) params = params.set('from', query.from);
+    if (query.to) params = params.set('to', query.to);
+    if (query.cursor) params = params.set('cursor', query.cursor);
+    if (query.pageSize != null) params = params.set('pageSize', query.pageSize.toString());
+    return this.http.get<AuditPageDto>(`${this.baseUrl}/audit`, { params });
+  }
+
+  verifyAuditChain(fromSeq?: number, toSeq?: number): Observable<ChainVerificationDto> {
+    let params = new HttpParams();
+    if (fromSeq != null) params = params.set('fromSeq', fromSeq.toString());
+    if (toSeq != null) params = params.set('toSeq', toSeq.toString());
+    return this.http.get<ChainVerificationDto>(
+      `${this.baseUrl}/audit/verify`,
+      { params },
     );
   }
 


### PR DESCRIPTION
## Summary

\`/audit\` surface backed by \`GET /api/audit\` (cursor-paginated) and \`GET /api/audit/verify\`. Filter bar (actor/action/entityType/entityId), expand-on-click rows with rationale + RFC 6902 diff + hash details, and a prominent Verify chain button rendering green / red / orange banners per outcome with a Copy diagnostic affordance on divergence.

Also ships the shared \`Rfc6902DiffViewComponent\` under \`shared/components/\` — **reused by P9.8** (bundle diffs).

## Spec deltas worth flagging

| Spec | Reality |
|---|---|
| Seq-based pagination (\`fromSeq\`) + IntersectionObserver | Cursor-based (\`nextCursor\`) + Load more button |
| \`AuditEventDto.patchJson\` stringified | Reality: \`fieldDiff: Rfc6902Op[]\` already parsed |
| \`actorDisplayName\` field | Doesn't exist — surfacing \`actorSubjectId\` instead |
| \`VerifyChainResult { lastGoodSeq, firstDivergenceSeq, verifiedAt }\` | Reality: \`{ valid, firstDivergenceSeq, inspectedCount, lastSeq }\`; verifiedAt synthesised client-side for the copy diagnostic |
| RBAC-gated Audit nav link | No permissions endpoint (P9.3 hold); link always visible, server returns 403 if unauthorised |

## Test plan

- [x] \`npm test\` — **94/94 pass**: 7 diff-view cases (markers, truncation w/ expand, parse paths), 9 timeline cases (init, empty, loadMore + cursor + stop, filter reset, expand toggle, verify ok / diverged / error banners, list-error retry). 78 carried.
- [x] \`npm run build\` — prod bundle clean.
- [x] \`dotnet build\` — green.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)