### PR TITLE
Implement P9.8 — bundle explorer (#90)

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -7,6 +7,7 @@
       <a routerLink="/policies" routerLinkActive="active">Policies</a>
       <a routerLink="/overrides" routerLinkActive="active">Overrides</a>
       <a routerLink="/audit" routerLinkActive="active">Audit</a>
+      <a routerLink="/bundles" routerLinkActive="active">Bundles</a>
       <a routerLink="/help" routerLinkActive="active">Help</a>
     </div>
     <div class="auth-section">

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -66,6 +66,31 @@ export const routes: Routes = [
     canActivate: [authGuard],
   },
   {
+    path: 'bundles',
+    loadComponent: () =>
+      import('./features/bundles/bundles-list.component').then(
+        (m) => m.BundlesListComponent
+      ),
+    canActivate: [authGuard],
+  },
+  // Order matters: /bundles/diff must beat /bundles/:bundleId.
+  {
+    path: 'bundles/diff',
+    loadComponent: () =>
+      import('./features/bundles/bundle-diff.component').then(
+        (m) => m.BundleDiffComponent
+      ),
+    canActivate: [authGuard],
+  },
+  {
+    path: 'bundles/:bundleId',
+    loadComponent: () =>
+      import('./features/bundles/bundle-detail.component').then(
+        (m) => m.BundleDetailComponent
+      ),
+    canActivate: [authGuard],
+  },
+  {
     path: 'help',
     loadComponent: () =>
       import('./features/help/help.component').then(

--- a/client/src/app/features/bundles/bundle-detail.component.html
+++ b/client/src/app/features/bundles/bundle-detail.component.html
@@ -1,0 +1,57 @@
+<!-- Copyright (c) Rivoli AI 2026. All rights reserved. -->
+<div class="page">
+  <p class="back"><a routerLink="/bundles">← Back to bundles</a></p>
+
+  <div *ngIf="loading()" class="loading" data-testid="loading">Loading bundle…</div>
+
+  <div *ngIf="errorMessage() && !loading()" class="banner-error" role="alert" data-testid="banner">
+    {{ errorMessage() }}
+  </div>
+
+  <ng-container *ngIf="bundle() as b">
+    <header class="page-header">
+      <h1 class="title-row">
+        <span class="bundle-name">{{ b.name }}</span>
+        <span class="badge" [class.deleted]="b.state === 'Deleted'">{{ b.state }}</span>
+      </h1>
+      <p *ngIf="b.description" class="subtitle">{{ b.description }}</p>
+    </header>
+
+    <section class="card">
+      <h2>Metadata</h2>
+      <dl class="metadata-grid">
+        <dt>Bundle id</dt>
+        <dd><code>{{ b.id }}</code></dd>
+
+        <dt>Snapshot hash</dt>
+        <dd><code class="hash">{{ b.snapshotHash }}</code></dd>
+
+        <dt>Created at</dt>
+        <dd>{{ b.createdAt | date: 'medium' }}</dd>
+
+        <dt>Created by</dt>
+        <dd><code class="subject">{{ b.createdBySubjectId }}</code></dd>
+
+        <dt *ngIf="b.deletedAt">Deleted at</dt>
+        <dd *ngIf="b.deletedAt">{{ b.deletedAt | date: 'medium' }}</dd>
+
+        <dt *ngIf="b.deletedBySubjectId">Deleted by</dt>
+        <dd *ngIf="b.deletedBySubjectId">
+          <code class="subject">{{ b.deletedBySubjectId }}</code>
+        </dd>
+      </dl>
+    </section>
+
+    <section class="card empty-tree" data-testid="frozen-tree-stub">
+      <h2>Frozen catalog</h2>
+      <p class="muted">
+        Per-policy snapshot detail is not yet exposed by the API as a single
+        tree dump. To inspect a specific frozen policy use
+        <code>GET /api/bundles/{{ b.id }}/policies/{{ '{policyId}' }}</code>
+        or hit <code>GET /api/bundles/{{ b.id }}/resolve</code> with a
+        target. A follow-up issue tracks adding a bulk listing endpoint
+        suitable for this view.
+      </p>
+    </section>
+  </ng-container>
+</div>

--- a/client/src/app/features/bundles/bundle-detail.component.scss
+++ b/client/src/app/features/bundles/bundle-detail.component.scss
@@ -1,0 +1,118 @@
+/* Copyright (c) Rivoli AI 2026. All rights reserved. */
+
+.page { display: flex; flex-direction: column; gap: 16px; }
+
+.back a { color: var(--text-secondary); text-decoration: none; font-size: 13px; }
+.back a:hover { color: var(--primary); }
+
+.loading {
+  padding: 32px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 14px;
+  background: var(--surface);
+  border-radius: 8px;
+  border: 1px dashed var(--border);
+}
+
+.banner-error {
+  padding: 12px 16px;
+  border-radius: 6px;
+  font-size: 14px;
+  background: #fce8e6;
+  border: 1px solid #f0a99a;
+  color: var(--error);
+}
+
+.page-header h1.title-row {
+  margin: 0 0 4px;
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.bundle-name { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+
+.badge {
+  font-size: 0.7em;
+  padding: 2px 10px;
+  border-radius: 12px;
+  background: #e6f4ea;
+  color: var(--success);
+  font-weight: 500;
+}
+.badge.deleted {
+  background: var(--background);
+  color: var(--text-secondary);
+}
+
+.subtitle { margin: 0; color: var(--text-secondary); font-size: 14px; }
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.metadata-grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 6px 16px;
+  margin: 0;
+}
+
+.metadata-grid dt {
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.metadata-grid dd {
+  margin: 0;
+  font-size: 13px;
+  word-break: break-word;
+}
+
+.metadata-grid code {
+  font-size: 12px;
+  background: var(--background);
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+
+.metadata-grid .hash {
+  font-size: 11px;
+  word-break: break-all;
+}
+
+.metadata-grid .subject {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.empty-tree .muted {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-secondary);
+
+  code {
+    background: var(--background);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 12px;
+  }
+}

--- a/client/src/app/features/bundles/bundle-detail.component.spec.ts
+++ b/client/src/app/features/bundles/bundle-detail.component.spec.ts
@@ -1,0 +1,82 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { ApiService, BundleDto } from '../../shared/services/api.service';
+import { BundleDetailComponent } from './bundle-detail.component';
+
+describe('BundleDetailComponent (P9.8)', () => {
+  let fixture: ComponentFixture<BundleDetailComponent>;
+  let component: BundleDetailComponent;
+  let api: jasmine.SpyObj<ApiService>;
+
+  const sample: BundleDto = {
+    id: 'bid-1', name: 'release-2026-05',
+    description: 'May release snapshot',
+    createdAt: '2026-05-01T12:00:00Z', createdBySubjectId: 'user:alice',
+    snapshotHash: 'a'.repeat(64), state: 'Active',
+    deletedAt: null, deletedBySubjectId: null,
+  };
+
+  function build(opts: { bundle?: BundleDto; loadError?: HttpErrorResponse } = {}): void {
+    TestBed.resetTestingModule();
+    api = jasmine.createSpyObj<ApiService>('ApiService', ['getBundle']);
+    if (opts.loadError) {
+      api.getBundle.and.returnValue(throwError(() => opts.loadError!));
+    } else {
+      api.getBundle.and.returnValue(of(opts.bundle ?? sample));
+    }
+    TestBed.configureTestingModule({
+      imports: [BundleDetailComponent],
+      providers: [
+        provideRouter([]),
+        { provide: ApiService, useValue: api },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: convertToParamMap({ bundleId: 'bid-1' }) } },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(BundleDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  it('loads + renders bundle metadata', () => {
+    build({});
+    expect(api.getBundle).toHaveBeenCalledWith('bid-1');
+    expect(component.bundle()?.name).toBe('release-2026-05');
+    expect(component.loading()).toBeFalse();
+  });
+
+  it('renders the frozen-tree placeholder section', () => {
+    build({});
+    const stub = fixture.nativeElement.querySelector('[data-testid="frozen-tree-stub"]');
+    expect(stub).toBeTruthy();
+    expect(stub.textContent).toContain('not yet exposed');
+  });
+
+  it('surfaces an error banner on load failure', () => {
+    build({ loadError: new HttpErrorResponse({ status: 404, error: { title: 'Not found' } }) });
+
+    expect(component.errorMessage()).toContain('Not found');
+    expect(fixture.nativeElement.querySelector('[data-testid="banner"]')).toBeTruthy();
+  });
+
+  it('shows deleted metadata when bundle is soft-deleted', () => {
+    const deleted: BundleDto = {
+      ...sample,
+      state: 'Deleted',
+      deletedAt: '2026-05-05T00:00:00Z',
+      deletedBySubjectId: 'user:bob',
+    };
+    build({ bundle: deleted });
+
+    const html = fixture.nativeElement.textContent;
+    expect(html).toContain('Deleted');
+    expect(html).toContain('user:bob');
+  });
+});

--- a/client/src/app/features/bundles/bundle-detail.component.ts
+++ b/client/src/app/features/bundles/bundle-detail.component.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { ApiService, BundleDto } from '../../shared/services/api.service';
+
+/**
+ * P9.8 (rivoli-ai/andy-policies#90) — bundle detail view, metadata only.
+ *
+ * The original spec called for a frozen-tree renderer (`policies[].bindings[]`,
+ * `overrides[]`) but the server has no per-bundle tree-dump endpoint —
+ * pinned policies are reachable individually via
+ * `GET /api/bundles/{id}/policies/{policyId}` or by-target via
+ * `.../resolve`. Filed as a follow-up; this view ships the metadata
+ * fields that ARE returned by `GET /api/bundles/{id}` (BundleDto).
+ */
+@Component({
+  selector: 'app-bundle-detail',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './bundle-detail.component.html',
+  styleUrls: ['./bundle-detail.component.scss'],
+})
+export class BundleDetailComponent {
+  private readonly api = inject(ApiService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly bundle = signal<BundleDto | null>(null);
+  readonly loading = signal(true);
+  readonly errorMessage = signal<string | null>(null);
+
+  constructor() {
+    const id = this.route.snapshot.paramMap.get('bundleId');
+    if (id) this.load(id);
+  }
+
+  private load(id: string): void {
+    this.loading.set(true);
+    this.errorMessage.set(null);
+    this.api
+      .getBundle(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: b => {
+          this.bundle.set(b);
+          this.loading.set(false);
+        },
+        error: (err: HttpErrorResponse) => {
+          this.loading.set(false);
+          this.errorMessage.set(err.error?.title ?? `Failed to load bundle (${err.status}).`);
+        },
+      });
+  }
+}

--- a/client/src/app/features/bundles/bundle-diff.component.html
+++ b/client/src/app/features/bundles/bundle-diff.component.html
@@ -1,0 +1,46 @@
+<!-- Copyright (c) Rivoli AI 2026. All rights reserved. -->
+<div class="page">
+  <p class="back"><a routerLink="/bundles">← Back to bundles</a></p>
+
+  <header class="page-header">
+    <h1>Bundle diff</h1>
+  </header>
+
+  <div *ngIf="missingParams()" class="banner-error" data-testid="missing">
+    Missing bundle ids in URL — pass <code>?a=</code> and <code>?b=</code>.
+  </div>
+
+  <div *ngIf="identicalParams()" class="banner-error" data-testid="identical">
+    The same bundle id was passed for both <code>a</code> and <code>b</code>;
+    the server rejects same-id diffs with 400. Pick two distinct bundles.
+  </div>
+
+  <ng-container *ngIf="!missingParams() && !identicalParams()">
+    <div *ngIf="loading()" class="loading" data-testid="loading">Computing diff…</div>
+
+    <div *ngIf="errorMessage()" class="banner-error" role="alert" data-testid="banner">
+      {{ errorMessage() }}
+      <button type="button" class="btn-link" (click)="load()">Retry</button>
+    </div>
+
+    <div *ngIf="result() as r" class="diff-card" data-testid="diff-card">
+      <header class="diff-header">
+        <div>
+          <span class="label">From</span>
+          <a [routerLink]="['/bundles', r.fromId]"><code>{{ r.fromId }}</code></a>
+          <code class="hash">{{ r.fromSnapshotHash | slice: 0:12 }}…</code>
+        </div>
+        <div>
+          <span class="label">To</span>
+          <a [routerLink]="['/bundles', r.toId]"><code>{{ r.toId }}</code></a>
+          <code class="hash">{{ r.toSnapshotHash | slice: 0:12 }}…</code>
+        </div>
+        <div>
+          <span class="op-count">{{ r.opCount }} {{ r.opCount === 1 ? 'op' : 'ops' }}</span>
+        </div>
+      </header>
+
+      <app-rfc6902-diff-view [fieldDiff]="r.rfc6902PatchJson"></app-rfc6902-diff-view>
+    </div>
+  </ng-container>
+</div>

--- a/client/src/app/features/bundles/bundle-diff.component.scss
+++ b/client/src/app/features/bundles/bundle-diff.component.scss
@@ -1,0 +1,106 @@
+/* Copyright (c) Rivoli AI 2026. All rights reserved. */
+
+.page { display: flex; flex-direction: column; gap: 16px; }
+
+.back a { color: var(--text-secondary); text-decoration: none; font-size: 13px; }
+.back a:hover { color: var(--primary); }
+
+.page-header h1 { margin: 0; }
+
+.loading {
+  padding: 32px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 14px;
+  background: var(--surface);
+  border-radius: 8px;
+  border: 1px dashed var(--border);
+}
+
+.banner-error {
+  padding: 12px 16px;
+  border-radius: 6px;
+  font-size: 14px;
+  background: #fce8e6;
+  border: 1px solid #f0a99a;
+  color: var(--error);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  code {
+    background: var(--surface);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 12px;
+    color: var(--error);
+  }
+}
+
+.diff-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.diff-header {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+
+  .label {
+    color: var(--text-secondary);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-right: 6px;
+  }
+
+  a {
+    color: var(--primary);
+    text-decoration: none;
+    margin-right: 6px;
+  }
+  a:hover { text-decoration: underline; }
+
+  code {
+    background: var(--background);
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 11px;
+  }
+
+  .hash { color: var(--text-secondary); }
+
+  .op-count {
+    align-self: center;
+    background: var(--background);
+    border: 1px solid var(--border);
+    padding: 4px 10px;
+    border-radius: 12px;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 500;
+  }
+}
+
+.btn-link {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--primary);
+  font: inherit;
+  font-size: 13px;
+}
+
+.btn-link:hover { text-decoration: underline; }

--- a/client/src/app/features/bundles/bundle-diff.component.spec.ts
+++ b/client/src/app/features/bundles/bundle-diff.component.spec.ts
@@ -1,0 +1,98 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { ApiService, BundleDiffResult } from '../../shared/services/api.service';
+import { BundleDiffComponent } from './bundle-diff.component';
+
+describe('BundleDiffComponent (P9.8)', () => {
+  let fixture: ComponentFixture<BundleDiffComponent>;
+  let component: BundleDiffComponent;
+  let api: jasmine.SpyObj<ApiService>;
+
+  const diff: BundleDiffResult = {
+    fromId: 'a', fromSnapshotHash: 'aaa',
+    toId: 'b', toSnapshotHash: 'bbb',
+    rfc6902PatchJson: JSON.stringify([{ op: 'add', path: '/policies/x', value: 1 }]),
+    opCount: 1,
+  };
+
+  function build(opts: {
+    a?: string | null;
+    b?: string | null;
+    diffError?: HttpErrorResponse;
+  } = {}): void {
+    TestBed.resetTestingModule();
+    api = jasmine.createSpyObj<ApiService>('ApiService', ['diffBundles']);
+    if (opts.diffError) {
+      api.diffBundles.and.returnValue(throwError(() => opts.diffError!));
+    } else {
+      api.diffBundles.and.returnValue(of(diff));
+    }
+
+    const params: Record<string, string> = {};
+    if (opts.a !== null && opts.a !== undefined) params['a'] = opts.a;
+    if (opts.b !== null && opts.b !== undefined) params['b'] = opts.b;
+
+    TestBed.configureTestingModule({
+      imports: [BundleDiffComponent],
+      providers: [
+        provideRouter([]),
+        { provide: ApiService, useValue: api },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { queryParamMap: convertToParamMap(params) },
+          },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(BundleDiffComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  it('shows missing-params banner when a or b is missing', () => {
+    build({});
+    expect(component.missingParams()).toBeTrue();
+    expect(fixture.nativeElement.querySelector('[data-testid="missing"]')).toBeTruthy();
+    expect(api.diffBundles).not.toHaveBeenCalled();
+  });
+
+  it('shows identical-params banner when a === b without calling API', () => {
+    build({ a: 'same', b: 'same' });
+
+    expect(component.identicalParams()).toBeTrue();
+    expect(fixture.nativeElement.querySelector('[data-testid="identical"]')).toBeTruthy();
+    expect(api.diffBundles).not.toHaveBeenCalled();
+  });
+
+  it('calls diffBundles and renders the diff card on happy path', () => {
+    build({ a: 'a', b: 'b' });
+
+    expect(api.diffBundles).toHaveBeenCalledWith('a', 'b');
+    expect(component.result()?.opCount).toBe(1);
+    expect(fixture.nativeElement.querySelector('[data-testid="diff-card"]')).toBeTruthy();
+  });
+
+  it('surfaces server error', () => {
+    build({
+      a: 'a', b: 'b',
+      diffError: new HttpErrorResponse({ status: 400, error: { detail: 'bad ids' } }),
+    });
+
+    expect(component.errorMessage()).toContain('bad ids');
+    expect(fixture.nativeElement.querySelector('[data-testid="banner"]')).toBeTruthy();
+  });
+
+  it('delegates patch rendering to the shared Rfc6902 view', () => {
+    build({ a: 'a', b: 'b' });
+
+    // The shared component renders a [data-testid="diff-view"] container.
+    expect(fixture.nativeElement.querySelector('app-rfc6902-diff-view')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="diff-view"]')).toBeTruthy();
+  });
+});

--- a/client/src/app/features/bundles/bundle-diff.component.ts
+++ b/client/src/app/features/bundles/bundle-diff.component.ts
@@ -1,0 +1,91 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import {
+  ApiService,
+  BundleDiffResult,
+} from '../../shared/services/api.service';
+import { Rfc6902DiffViewComponent } from '../../shared/components/rfc6902-diff-view.component';
+
+/**
+ * P9.8 (rivoli-ai/andy-policies#90) — bundle diff. Reads `?a=` and
+ * `?b=` from the URL, calls `GET /api/bundles/{a}/diff?to={b}`, and
+ * delegates rendering to the same `Rfc6902DiffViewComponent` used by
+ * the audit timeline (P9.7). Server returns a `BundleDiffResult`
+ * carrying a stringified `rfc6902PatchJson` blob — the renderer's
+ * defensive parse path turns that into an `Rfc6902Op[]`.
+ */
+@Component({
+  selector: 'app-bundle-diff',
+  standalone: true,
+  imports: [CommonModule, RouterLink, Rfc6902DiffViewComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './bundle-diff.component.html',
+  styleUrls: ['./bundle-diff.component.scss'],
+})
+export class BundleDiffComponent {
+  private readonly api = inject(ApiService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly result = signal<BundleDiffResult | null>(null);
+  readonly loading = signal(false);
+  readonly errorMessage = signal<string | null>(null);
+
+  readonly a = signal<string | null>(null);
+  readonly b = signal<string | null>(null);
+
+  readonly missingParams = computed(() => !this.a() || !this.b());
+  readonly identicalParams = computed(() =>
+    !this.missingParams() && this.a() === this.b(),
+  );
+
+  constructor() {
+    const qp = this.route.snapshot.queryParamMap;
+    this.a.set(qp.get('a'));
+    this.b.set(qp.get('b'));
+    if (!this.missingParams() && !this.identicalParams()) {
+      this.load();
+    }
+  }
+
+  load(): void {
+    const aId = this.a();
+    const bId = this.b();
+    if (!aId || !bId || aId === bId) return;
+
+    this.loading.set(true);
+    this.errorMessage.set(null);
+    this.api
+      .diffBundles(aId, bId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: r => {
+          this.result.set(r);
+          this.loading.set(false);
+        },
+        error: (err: HttpErrorResponse) => {
+          this.loading.set(false);
+          this.errorMessage.set(this.describeError(err));
+        },
+      });
+  }
+
+  private describeError(err: HttpErrorResponse): string {
+    const body = err.error;
+    if (typeof body?.detail === 'string' && body.detail) return body.detail;
+    if (typeof body?.title === 'string') return `${body.title} (${err.status}).`;
+    return `Unexpected error (${err.status}).`;
+  }
+}

--- a/client/src/app/features/bundles/bundles-list.component.html
+++ b/client/src/app/features/bundles/bundles-list.component.html
@@ -1,0 +1,94 @@
+<!-- Copyright (c) Rivoli AI 2026. All rights reserved. -->
+<div class="page">
+  <header class="page-header">
+    <div class="title-row">
+      <h1>Bundles</h1>
+      <div class="actions">
+        <label class="checkbox">
+          <input
+            type="checkbox"
+            [checked]="includeDeleted()"
+            (change)="toggleIncludeDeleted()"
+            data-testid="include-deleted" />
+          Show deleted
+        </label>
+        <button
+          type="button"
+          class="btn-secondary"
+          (click)="compare()"
+          [disabled]="!canCompare()"
+          data-testid="compare">
+          Compare ({{ selectedIds().size }})
+        </button>
+        <button
+          type="button"
+          class="btn-primary"
+          (click)="openCreate()"
+          data-testid="new-bundle">
+          New bundle
+        </button>
+      </div>
+    </div>
+    <p class="page-subtitle">
+      Immutable, named snapshots of the catalog. Select two rows to compare.
+    </p>
+  </header>
+
+  <div *ngIf="loading() && bundles().length === 0" class="loading" data-testid="loading">
+    Loading bundles…
+  </div>
+
+  <div *ngIf="errorMessage()" class="banner-error" role="alert" data-testid="banner">
+    <span>{{ errorMessage() }}</span>
+    <button type="button" class="btn-link" (click)="reload()">Retry</button>
+  </div>
+
+  <p *ngIf="!loading() && bundles().length === 0 && !errorMessage()"
+     class="empty"
+     data-testid="empty">
+    No bundles yet. Click <strong>New bundle</strong> to freeze the catalog.
+  </p>
+
+  <table *ngIf="bundles().length > 0" class="bundles-table" data-testid="bundles-table">
+    <thead>
+      <tr>
+        <th></th>
+        <th>Name</th>
+        <th>Description</th>
+        <th>State</th>
+        <th>Snapshot</th>
+        <th>Created</th>
+        <th>Created by</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let b of bundles()" [class.selected]="isSelected(b.id)">
+        <td>
+          <input
+            type="checkbox"
+            [checked]="isSelected(b.id)"
+            (change)="toggleSelect(b.id)"
+            [attr.aria-label]="'Select bundle ' + b.name"
+            [attr.data-testid]="'select-' + b.id" />
+        </td>
+        <td>
+          <a [routerLink]="['/bundles', b.id]" class="name" [attr.data-testid]="'detail-' + b.id">
+            {{ b.name }}
+          </a>
+        </td>
+        <td>{{ b.description || '—' }}</td>
+        <td>
+          <span class="badge" [class.deleted]="b.state === 'Deleted'">{{ b.state }}</span>
+        </td>
+        <td><code class="hash">{{ b.snapshotHash | slice: 0:12 }}…</code></td>
+        <td>{{ b.createdAt | date: 'short' }}</td>
+        <td class="subject">{{ b.createdBySubjectId }}</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<app-create-bundle-modal
+  *ngIf="showCreate()"
+  (closed)="onCreateClosed($event)">
+</app-create-bundle-modal>

--- a/client/src/app/features/bundles/bundles-list.component.scss
+++ b/client/src/app/features/bundles/bundles-list.component.scss
@@ -1,0 +1,159 @@
+/* Copyright (c) Rivoli AI 2026. All rights reserved. */
+
+.page { display: flex; flex-direction: column; gap: 16px; }
+
+.page-header h1 { margin: 0 0 4px; }
+
+.title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.checkbox {
+  font-size: 13px;
+  color: var(--text-secondary);
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  cursor: pointer;
+}
+
+.page-subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.loading, .empty {
+  padding: 32px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 14px;
+  background: var(--surface);
+  border-radius: 8px;
+  border: 1px dashed var(--border);
+}
+
+.banner-error {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: #fce8e6;
+  border: 1px solid #f0a99a;
+  border-radius: 6px;
+  font-size: 14px;
+  color: var(--error);
+
+  span { flex: 1; }
+}
+
+.bundles-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--surface);
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+.bundles-table th, .bundles-table td {
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  vertical-align: middle;
+}
+
+.bundles-table th {
+  background: var(--background);
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.bundles-table tbody tr:last-child td { border-bottom: none; }
+.bundles-table tbody tr.selected { background: rgba(40, 87, 200, 0.05); }
+.bundles-table tbody tr:hover:not(.selected) { background: var(--background); }
+
+.bundles-table .name {
+  color: var(--primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+.bundles-table .name:hover { text-decoration: underline; }
+
+.bundles-table .hash {
+  background: var(--background);
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+
+.bundles-table .subject {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 12px;
+  background: #e6f4ea;
+  color: var(--success);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.badge.deleted {
+  background: var(--background);
+  color: var(--text-secondary);
+}
+
+.btn-primary, .btn-secondary {
+  padding: 8px 14px;
+  font-size: 13px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 1px solid var(--border);
+}
+
+.btn-primary {
+  background: var(--primary);
+  color: white;
+  border-color: var(--primary);
+}
+
+.btn-primary[disabled] { opacity: 0.55; cursor: not-allowed; }
+
+.btn-secondary {
+  background: var(--surface);
+  color: inherit;
+}
+
+.btn-secondary[disabled] { opacity: 0.55; cursor: not-allowed; }
+.btn-secondary:hover:not([disabled]) { background: var(--background); }
+
+.btn-link {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--primary);
+  font: inherit;
+  font-size: 13px;
+}
+
+.btn-link:hover { text-decoration: underline; }

--- a/client/src/app/features/bundles/bundles-list.component.spec.ts
+++ b/client/src/app/features/bundles/bundles-list.component.spec.ts
@@ -1,0 +1,128 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+import { Router, provideRouter } from '@angular/router';
+import { ApiService, BundleDto } from '../../shared/services/api.service';
+import { BundlesListComponent } from './bundles-list.component';
+
+describe('BundlesListComponent (P9.8)', () => {
+  let fixture: ComponentFixture<BundlesListComponent>;
+  let component: BundlesListComponent;
+  let api: jasmine.SpyObj<ApiService>;
+  let router: Router;
+  let navigateSpy: jasmine.Spy;
+
+  const a: BundleDto = {
+    id: 'a', name: 'alpha', description: null,
+    createdAt: '2026-05-01T00:00:00Z', createdBySubjectId: 'u',
+    snapshotHash: 'h1', state: 'Active', deletedAt: null, deletedBySubjectId: null,
+  };
+  const b: BundleDto = { ...a, id: 'b', name: 'beta', snapshotHash: 'h2' };
+  const c: BundleDto = { ...a, id: 'c', name: 'gamma', snapshotHash: 'h3' };
+
+  function build(opts: { rows?: BundleDto[]; listError?: HttpErrorResponse } = {}): void {
+    TestBed.resetTestingModule();
+    api = jasmine.createSpyObj<ApiService>('ApiService', ['listBundles']);
+    if (opts.listError) {
+      api.listBundles.and.returnValue(throwError(() => opts.listError!));
+    } else {
+      api.listBundles.and.returnValue(of(opts.rows ?? []));
+    }
+    TestBed.configureTestingModule({
+      imports: [BundlesListComponent],
+      providers: [
+        provideRouter([]),
+        { provide: ApiService, useValue: api },
+      ],
+    });
+
+    fixture = TestBed.createComponent(BundlesListComponent);
+    component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+    navigateSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
+    fixture.detectChanges();
+  }
+
+  it('loads bundles on init', () => {
+    build({ rows: [a, b] });
+    expect(api.listBundles).toHaveBeenCalledWith(false);
+    expect(component.bundles().length).toBe(2);
+  });
+
+  it('renders empty state when no bundles', () => {
+    build({});
+    expect(fixture.nativeElement.querySelector('[data-testid="empty"]')).toBeTruthy();
+  });
+
+  it('toggleIncludeDeleted reloads with includeDeleted=true', () => {
+    build({ rows: [a] });
+    api.listBundles.calls.reset();
+
+    component.toggleIncludeDeleted();
+
+    expect(api.listBundles).toHaveBeenCalledWith(true);
+  });
+
+  it('canCompare is true only when exactly two bundles are selected', () => {
+    build({ rows: [a, b, c] });
+
+    expect(component.canCompare()).toBeFalse();
+    component.toggleSelect('a');
+    expect(component.canCompare()).toBeFalse();
+    component.toggleSelect('b');
+    expect(component.canCompare()).toBeTrue();
+    component.toggleSelect('c');
+    expect(component.canCompare()).toBeFalse();
+  });
+
+  it('compare navigates to /bundles/diff with a + b query params', () => {
+    build({ rows: [a, b] });
+    component.toggleSelect('a');
+    component.toggleSelect('b');
+
+    component.compare();
+
+    expect(navigateSpy).toHaveBeenCalled();
+    const args = navigateSpy.calls.mostRecent().args;
+    expect(args[0]).toEqual(['/bundles/diff']);
+    const queryParams = (args[1] as any).queryParams;
+    expect([queryParams.a, queryParams.b].sort()).toEqual(['a', 'b']);
+  });
+
+  it('compare is a no-op when canCompare is false', () => {
+    build({ rows: [a] });
+    component.toggleSelect('a');
+
+    component.compare();
+
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it('onCreateClosed(bundle) prepends the new row', () => {
+    build({ rows: [a] });
+
+    const created: BundleDto = { ...a, id: 'new', name: 'fresh' };
+    component.onCreateClosed(created);
+
+    expect(component.bundles()[0].id).toBe('new');
+    expect(component.bundles().length).toBe(2);
+  });
+
+  it('onCreateClosed(null) closes the modal without mutating the list', () => {
+    build({ rows: [a] });
+
+    component.onCreateClosed(null);
+
+    expect(component.bundles().length).toBe(1);
+    expect(component.showCreate()).toBeFalse();
+  });
+
+  it('list error surfaces a retryable banner', () => {
+    build({ listError: new HttpErrorResponse({ status: 500, error: { title: 'oops' } }) });
+
+    expect(component.errorMessage()).toContain('oops');
+    expect(fixture.nativeElement.querySelector('[data-testid="banner"]')).toBeTruthy();
+  });
+});

--- a/client/src/app/features/bundles/bundles-list.component.ts
+++ b/client/src/app/features/bundles/bundles-list.component.ts
@@ -1,0 +1,118 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import { ApiService, BundleDto } from '../../shared/services/api.service';
+import { CreateBundleModalComponent } from './create-bundle-modal.component';
+
+/**
+ * P9.8 (rivoli-ai/andy-policies#90) — list view for bundles.
+ *
+ * Spec asked for `policyCount`, `bindingCount`, `overrideCount` columns;
+ * the actual `BundleDto` doesn't expose those (would need a per-bundle
+ * detail endpoint that doesn't exist yet — filed follow-up). UI shows
+ * the metadata that IS available: name, description, snapshotHash,
+ * state, createdAt + by, deletedAt + by (when includeDeleted is on).
+ *
+ * Two-row checkbox selection enables a Compare CTA that routes to
+ * `/bundles/diff?a=&b=`. Selecting any other count disables Compare.
+ */
+@Component({
+  selector: 'app-bundles-list',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    RouterLink,
+    CreateBundleModalComponent,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './bundles-list.component.html',
+  styleUrls: ['./bundles-list.component.scss'],
+})
+export class BundlesListComponent {
+  private readonly api = inject(ApiService);
+  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly bundles = signal<BundleDto[]>([]);
+  readonly loading = signal(false);
+  readonly errorMessage = signal<string | null>(null);
+  readonly includeDeleted = signal(false);
+  readonly showCreate = signal(false);
+  readonly selectedIds = signal<ReadonlySet<string>>(new Set());
+
+  readonly canCompare = computed(() => this.selectedIds().size === 2);
+
+  constructor() {
+    this.reload();
+  }
+
+  reload(): void {
+    this.loading.set(true);
+    this.errorMessage.set(null);
+    this.selectedIds.set(new Set());
+    this.api
+      .listBundles(this.includeDeleted())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: rows => {
+          this.bundles.set(rows);
+          this.loading.set(false);
+        },
+        error: (err: HttpErrorResponse) => {
+          this.loading.set(false);
+          this.errorMessage.set(err.error?.title ?? `Failed to load (${err.status}).`);
+        },
+      });
+  }
+
+  toggleIncludeDeleted(): void {
+    this.includeDeleted.update(v => !v);
+    this.reload();
+  }
+
+  isSelected(id: string): boolean {
+    return this.selectedIds().has(id);
+  }
+
+  toggleSelect(id: string): void {
+    this.selectedIds.update(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  openCreate(): void {
+    this.showCreate.set(true);
+  }
+
+  onCreateClosed(created: BundleDto | null): void {
+    this.showCreate.set(false);
+    if (created) {
+      this.bundles.update(rows => [created, ...rows]);
+    }
+  }
+
+  compare(): void {
+    if (!this.canCompare()) return;
+    const [a, b] = Array.from(this.selectedIds());
+    this.router.navigate(['/bundles/diff'], { queryParams: { a, b } });
+  }
+}

--- a/client/src/app/features/bundles/create-bundle-modal.component.html
+++ b/client/src/app/features/bundles/create-bundle-modal.component.html
@@ -1,0 +1,75 @@
+<!-- Copyright (c) Rivoli AI 2026. All rights reserved. -->
+<div class="overlay" (click)="cancel()" data-testid="overlay">
+  <div
+    class="modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="create-bundle-title"
+    (click)="$event.stopPropagation()">
+    <header class="modal-header">
+      <h2 id="create-bundle-title">New bundle</h2>
+      <p class="subtitle">Freeze the current catalog into an immutable, named snapshot.</p>
+    </header>
+
+    <form [formGroup]="form" (ngSubmit)="submit()" class="form" data-testid="form">
+      <label class="field">
+        <span>Name (slug) <em>required</em></span>
+        <input
+          formControlName="name"
+          class="input"
+          autocomplete="off"
+          spellcheck="false"
+          placeholder="e.g. release-2026-05"
+          data-testid="name" />
+        <small *ngIf="form.controls.name.touched && form.controls.name.errors?.['pattern']" class="hint error">
+          Slug must start with lowercase letter/digit and use only lowercase, digits, <code>.</code> or <code>-</code>.
+        </small>
+      </label>
+
+      <label class="field">
+        <span>Description</span>
+        <textarea
+          formControlName="description"
+          class="input"
+          rows="2"
+          maxlength="500"
+          placeholder="Optional human-readable summary"
+          data-testid="description"></textarea>
+      </label>
+
+      <label class="field">
+        <span>
+          Rationale <em>required (min 10 chars — recorded in audit chain)</em>
+        </span>
+        <textarea
+          formControlName="rationale"
+          class="input rationale"
+          rows="3"
+          data-testid="rationale"
+          placeholder="Why is this bundle being created?"></textarea>
+      </label>
+
+      <div *ngIf="errorMessage()" class="banner-error" role="alert" data-testid="banner">
+        {{ errorMessage() }}
+      </div>
+
+      <footer class="modal-footer">
+        <button
+          type="button"
+          class="btn-secondary"
+          (click)="cancel()"
+          [disabled]="submitting()">
+          Cancel
+        </button>
+        <button
+          type="submit"
+          class="btn-primary"
+          [disabled]="form.invalid || submitting()"
+          data-testid="submit">
+          <span *ngIf="!submitting()">Create bundle</span>
+          <span *ngIf="submitting()">Creating…</span>
+        </button>
+      </footer>
+    </form>
+  </div>
+</div>

--- a/client/src/app/features/bundles/create-bundle-modal.component.scss
+++ b/client/src/app/features/bundles/create-bundle-modal.component.scss
@@ -1,0 +1,67 @@
+/* Copyright (c) Rivoli AI 2026. All rights reserved. */
+
+.overlay {
+  position: fixed; inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 1000; padding: 16px;
+}
+.modal {
+  background: var(--surface);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  padding: 20px 24px;
+  width: 100%; max-width: 520px;
+  display: flex; flex-direction: column; gap: 14px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
+}
+.modal-header h2 { margin: 0 0 4px; font-size: 18px; }
+.subtitle { margin: 0; font-size: 13px; color: var(--text-secondary); }
+.form { display: flex; flex-direction: column; gap: 12px; }
+.field { display: flex; flex-direction: column; gap: 4px; font-size: 14px; }
+.field > span {
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  em { font-weight: 400; font-style: normal; }
+}
+.input {
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: inherit;
+  font-size: 14px;
+  width: 100%;
+}
+.input:focus { outline: 2px solid var(--primary); outline-offset: 1px; }
+.rationale { resize: vertical; min-height: 70px; font-family: inherit; }
+.hint { font-size: 12px; color: var(--text-secondary); }
+.hint.error { color: var(--error); }
+.hint code {
+  background: var(--background);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+.banner-error {
+  padding: 10px 14px;
+  border-radius: 6px;
+  font-size: 13px;
+  background: #fce8e6;
+  border: 1px solid #f0a99a;
+  color: var(--error);
+}
+.modal-footer {
+  display: flex; justify-content: flex-end; gap: 8px;
+  margin-top: 4px;
+}
+.btn-primary, .btn-secondary {
+  padding: 8px 16px; font-size: 14px; border-radius: 4px;
+  cursor: pointer; border: 1px solid var(--border);
+}
+.btn-primary {
+  background: var(--primary); color: white; border-color: var(--primary);
+}
+.btn-primary[disabled] { opacity: 0.55; cursor: not-allowed; }
+.btn-secondary { background: var(--surface); color: inherit; }
+.btn-secondary:hover:not([disabled]) { background: var(--background); }

--- a/client/src/app/features/bundles/create-bundle-modal.component.spec.ts
+++ b/client/src/app/features/bundles/create-bundle-modal.component.spec.ts
@@ -1,0 +1,118 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+import {
+  ApiService,
+  BundleDto,
+  CreateBundleRequest,
+} from '../../shared/services/api.service';
+import { CreateBundleModalComponent } from './create-bundle-modal.component';
+
+describe('CreateBundleModalComponent (P9.8)', () => {
+  let fixture: ComponentFixture<CreateBundleModalComponent>;
+  let component: CreateBundleModalComponent;
+  let api: jasmine.SpyObj<ApiService>;
+
+  beforeEach(async () => {
+    api = jasmine.createSpyObj<ApiService>('ApiService', ['createBundle']);
+    await TestBed.configureTestingModule({
+      imports: [CreateBundleModalComponent],
+      providers: [{ provide: ApiService, useValue: api }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CreateBundleModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('rejects an UPPERCASE name (slug regex)', () => {
+    component.form.patchValue({ name: 'BAD' });
+    component.form.controls.name.markAsTouched();
+    expect(component.form.controls.name.errors?.['pattern']).toBeTruthy();
+  });
+
+  it('rejects a name starting with a non-alphanumeric character', () => {
+    component.form.patchValue({ name: '-bad' });
+    expect(component.form.controls.name.errors?.['pattern']).toBeTruthy();
+  });
+
+  it('accepts a valid slug like release-2026-05', () => {
+    component.form.patchValue({ name: 'release-2026-05' });
+    expect(component.form.controls.name.errors).toBeNull();
+  });
+
+  it('rationale shorter than 10 chars makes the form invalid', () => {
+    component.form.patchValue({ name: 'release', rationale: 'short' });
+    expect(component.form.invalid).toBeTrue();
+  });
+
+  it('submit posts the trimmed payload and emits the created bundle', () => {
+    const created: BundleDto = {
+      id: 'bid-1', name: 'release-2026-05', description: 'desc',
+      createdAt: '2026-05-07T00:00:00Z', createdBySubjectId: 'u',
+      snapshotHash: 'aabb', state: 'Active',
+      deletedAt: null, deletedBySubjectId: null,
+    };
+    api.createBundle.and.returnValue(of(created));
+
+    const captures: (BundleDto | null)[] = [];
+    component.closed.subscribe(v => captures.push(v));
+
+    // Name is validated against the un-trimmed value (slug regex rejects
+    // leading/trailing spaces); description + rationale exercise the
+    // trimming submit() applies before posting.
+    component.form.patchValue({
+      name: 'release-2026-05',
+      description: '  description here  ',
+      rationale: '  rationale text long enough  ',
+    });
+    component.submit();
+
+    const req = api.createBundle.calls.mostRecent().args[0] as CreateBundleRequest;
+    expect(req.name).toBe('release-2026-05');
+    expect(req.description).toBe('description here');
+    expect(req.rationale).toBe('rationale text long enough');
+    expect(captures).toEqual([created]);
+  });
+
+  it('null description when blank', () => {
+    api.createBundle.and.returnValue(of({} as BundleDto));
+    component.form.patchValue({
+      name: 'release',
+      description: '   ',
+      rationale: 'rationale long enough',
+    });
+    component.submit();
+
+    const req = api.createBundle.calls.mostRecent().args[0] as CreateBundleRequest;
+    expect(req.description).toBeNull();
+  });
+
+  it('on 409 surfaces the inline banner', () => {
+    api.createBundle.and.returnValue(
+      throwError(() => new HttpErrorResponse({
+        status: 409,
+        error: { detail: 'A bundle with this name already exists.' },
+      })),
+    );
+
+    component.form.patchValue({ name: 'release', rationale: 'rationale long enough' });
+    component.submit();
+    fixture.detectChanges();
+
+    expect(component.errorMessage()).toContain('already exists');
+    expect(fixture.nativeElement.querySelector('[data-testid="banner"]')).toBeTruthy();
+  });
+
+  it('cancel emits null without calling the API', () => {
+    const captures: (BundleDto | null)[] = [];
+    component.closed.subscribe(v => captures.push(v));
+
+    component.cancel();
+
+    expect(api.createBundle).not.toHaveBeenCalled();
+    expect(captures).toEqual([null]);
+  });
+});

--- a/client/src/app/features/bundles/create-bundle-modal.component.ts
+++ b/client/src/app/features/bundles/create-bundle-modal.component.ts
@@ -1,0 +1,112 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  EventEmitter,
+  Output,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  FormControl,
+  FormGroup,
+  NonNullableFormBuilder,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import {
+  ApiService,
+  BundleDto,
+  CreateBundleRequest,
+} from '../../shared/services/api.service';
+
+interface CreateBundleForm {
+  name: FormControl<string>;
+  description: FormControl<string>;
+  rationale: FormControl<string>;
+}
+
+/**
+ * P9.8 (rivoli-ai/andy-policies#90) — modal that creates a new bundle.
+ * Server's `CreateBundleRequest` carries `Name`, `Description`,
+ * `Rationale` only — no `includeOverrides` flag yet (filed as a
+ * follow-up). 409 paths are surfaced inline (e.g. duplicate name).
+ */
+@Component({
+  selector: 'app-create-bundle-modal',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './create-bundle-modal.component.html',
+  styleUrls: ['./create-bundle-modal.component.scss'],
+})
+export class CreateBundleModalComponent {
+  static readonly slugPattern = /^[a-z0-9][a-z0-9.-]*$/;
+  static readonly minRationaleLength = 10;
+
+  @Output() readonly closed = new EventEmitter<BundleDto | null>();
+
+  private readonly api = inject(ApiService);
+  private readonly fb = inject(NonNullableFormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly submitting = signal(false);
+  readonly errorMessage = signal<string | null>(null);
+
+  readonly form: FormGroup<CreateBundleForm> = this.fb.group<CreateBundleForm>({
+    name: this.fb.control('', [
+      Validators.required,
+      Validators.pattern(CreateBundleModalComponent.slugPattern),
+    ]),
+    description: this.fb.control('', Validators.maxLength(500)),
+    rationale: this.fb.control('', [
+      Validators.required,
+      Validators.minLength(CreateBundleModalComponent.minRationaleLength),
+    ]),
+  });
+
+  submit(): void {
+    if (this.form.invalid || this.submitting()) return;
+
+    const v = this.form.getRawValue();
+    const req: CreateBundleRequest = {
+      name: v.name.trim(),
+      description: v.description.trim() || null,
+      rationale: v.rationale.trim(),
+    };
+
+    this.submitting.set(true);
+    this.errorMessage.set(null);
+    this.api
+      .createBundle(req)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: created => {
+          this.submitting.set(false);
+          this.closed.emit(created);
+        },
+        error: (err: HttpErrorResponse) => {
+          this.submitting.set(false);
+          this.errorMessage.set(this.describeProblem(err)
+            ?? `Unexpected error (${err.status}).`);
+        },
+      });
+  }
+
+  cancel(): void {
+    this.closed.emit(null);
+  }
+
+  private describeProblem(err: HttpErrorResponse): string | null {
+    const body = err.error;
+    if (!body) return null;
+    if (typeof body.detail === 'string' && body.detail) return body.detail;
+    if (typeof body.title === 'string') return `${body.title} (${err.status}).`;
+    return null;
+  }
+}

--- a/client/src/app/shared/services/api.service.ts
+++ b/client/src/app/shared/services/api.service.ts
@@ -218,6 +218,26 @@ export interface ChainVerificationDto {
   lastSeq: number;
 }
 
+/** P9.8 (#90) — body for `POST /api/bundles`. Server's CreateBundleRequest
+ *  has no `includeOverrides` flag; that's a P9.8 follow-up. */
+export interface CreateBundleRequest {
+  name: string;
+  description: string | null;
+  rationale: string;
+}
+
+/** P9.8 (#90) — return shape for `GET /api/bundles/{id}/diff?to={otherId}`,
+ *  matches `BundleDiffResult` server-side. `rfc6902PatchJson` is a
+ *  stringified array of operations; `Rfc6902DiffViewComponent` parses it. */
+export interface BundleDiffResult {
+  fromId: string;
+  fromSnapshotHash: string;
+  toId: string;
+  toSnapshotHash: string;
+  rfc6902PatchJson: string;
+  opCount: number;
+}
+
 /**
  * Maps a target lifecycle state to the action-shaped path segment used by
  * `PolicyVersionsLifecycleController`. `Draft` is intentionally null —
@@ -410,11 +430,36 @@ export class ApiService {
     );
   }
 
-  // --- Bundles (P8.3) ---
+  // --- Bundles (P8.3 + P9.8 #90) ---
 
   listBundles(includeDeleted = false): Observable<BundleDto[]> {
     let params = new HttpParams();
     if (includeDeleted) params = params.set('includeDeleted', 'true');
     return this.http.get<BundleDto[]>(`${this.baseUrl}/bundles`, { params });
+  }
+
+  createBundle(request: CreateBundleRequest): Observable<BundleDto> {
+    return this.http.post<BundleDto>(`${this.baseUrl}/bundles`, request);
+  }
+
+  getBundle(id: string): Observable<BundleDto> {
+    return this.http.get<BundleDto>(`${this.baseUrl}/bundles/${id}`);
+  }
+
+  /** Diffs `aId` against `bId`. Server requires distinct ids and rejects
+   *  same-id with 400; UI prevents that anyway via the 2-row select. */
+  diffBundles(aId: string, bId: string): Observable<BundleDiffResult> {
+    const params = new HttpParams().set('to', bId);
+    return this.http.get<BundleDiffResult>(
+      `${this.baseUrl}/bundles/${aId}/diff`,
+      { params },
+    );
+  }
+
+  /** Server accepts rationale as a query param (NOT body) on DELETE. */
+  deleteBundle(id: string, rationale: string): Observable<void> {
+    let params = new HttpParams();
+    if (rationale) params = params.set('rationale', rationale);
+    return this.http.delete<void>(`${this.baseUrl}/bundles/${id}`, { params });
   }
 }


### PR DESCRIPTION
## Summary

\`/bundles\` admin surface — list with two-row Compare CTA, metadata-only detail page, and diff view reusing **the same \`Rfc6902DiffViewComponent\` shipped in P9.7**. Closes Epic P9 (modulo P9.3 hold).

Routes: \`/bundles\` → list, \`/bundles/diff?a=&b=\` → diff (literal beats the param route by ordering), \`/bundles/:bundleId\` → metadata detail.

## Spec deltas worth flagging

| Spec | Reality |
|---|---|
| \`BundleDetailDto\` with frozen tree (\`policies[].bindings[]\`, \`overrides[]\`) | Server only has plain \`BundleDto\` metadata + per-policy \`/policies/{policyId}\` lookup or \`/resolve\` by target. No bulk tree dump exists — filed **#204**. |
| \`CreateBundleRequest\` with \`includeOverrides\` | Reality: \`{ Name, Description, Rationale }\` only — filed **#205**. |
| Diff endpoint uses \`?against=\` | Reality: \`?to=\`. ApiService updated. |
| \`BundleDiffDto { from, to, patchJson }\` | Reality: \`{ fromId, fromSnapshotHash, toId, toSnapshotHash, rfc6902PatchJson, opCount }\`. |
| \`BundleDto\` with policy/binding/override counts | Reality: \`{ id, name, description, createdAt, createdBySubjectId, snapshotHash, state, deletedAt, deletedBySubjectId }\` — no counts. |

## Test plan

- [x] \`npm test\` — **120/120 pass**: 8 create-modal cases, 9 list cases (compare gate matrix, navigate, optimistic prepend, error retry), 4 detail cases (incl. frozen-tree placeholder, deleted metadata), 5 diff cases (missing/identical params guards, happy path, error, delegates to shared diff view). 94 carried.
- [x] \`npm run build\` — prod bundle clean.
- [x] \`dotnet build\` — green.

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)