### PR TITLE
Implement #193 + #197 — rationale on draft + binding mutations

### DIFF
--- a/docs/openapi/andy-policies-v1.yaml
+++ b/docs/openapi/andy-policies-v1.yaml
@@ -256,6 +256,17 @@ paths:
           in: query
           schema:
             type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteBindingBody'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/DeleteBindingBody'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/DeleteBindingBody'
       responses:
         '204':
           description: No Content
@@ -2254,8 +2265,11 @@ components:
           nullable: true
         bindStrength:
           $ref: '#/components/schemas/BindStrength'
+        rationale:
+          type: string
+          nullable: true
       additionalProperties: false
-      description: "Request payload for `IBindingService.CreateAsync` (P3.2, story\r\nrivoli-ai/andy-policies#20). The target version must exist and not be in\r\n`LifecycleState.Retired`; the service throws\r\n`BindingRetiredVersionException` on a retired target."
+      description: "Request payload for `IBindingService.CreateAsync` (P3.2, story\r\nrivoli-ai/andy-policies#20). The target version must exist and not be in\r\n`LifecycleState.Retired`; the service throws\r\n`BindingRetiredVersionException` on a retired target.\r\n\n`Rationale` is forwarded to `IAuditWriter.AppendAsync` on the\r\n`binding.created` event. Nullable for backward compatibility — when\r\nthe `andy.policies.rationaleRequired` gate is on, the\r\n`RationaleRequiredFilter` rejects requests with an empty rationale\r\n(P9 follow-up #197).\r\n"
     CreateBundleRequest:
       type: object
       properties:
@@ -2317,8 +2331,11 @@ components:
         rulesJson:
           type: string
           nullable: true
+        rationale:
+          type: string
+          nullable: true
       additionalProperties: false
-      description: "Request payload for `IPolicyService.CreateDraftAsync`. Creates both the\r\nstable `Policy` row and its first `PolicyVersion` (version 1, Draft).\r\nEnum fields accept any casing on input (parsed case-insensitively by the service)."
+      description: "Request payload for `IPolicyService.CreateDraftAsync`. Creates both the\r\nstable `Policy` row and its first `PolicyVersion` (version 1, Draft).\r\nEnum fields accept any casing on input (parsed case-insensitively by the service).\r\n\n`Rationale` is captured into the audit chain (P6.2) when supplied; the\r\n`RationaleRequiredFilter` (P2.4) rejects empty values when the\r\n`andy.policies.rationaleRequired` setting is on. Nullable for\r\nbackward compatibility — clients that pre-date the field continue to work\r\nwhen the gate is off (P9 follow-up #193, 2026-05-07).\r\n"
     CreateScopeNodeRequest:
       type: object
       properties:
@@ -2336,6 +2353,14 @@ components:
           nullable: true
       additionalProperties: false
       description: "Request payload for `IScopeService.CreateAsync` (P4.2, story\r\nrivoli-ai/andy-policies#29). Andy.Policies.Application.Dtos.CreateScopeNodeRequest.ParentId is null for a\r\nroot Andy.Policies.Domain.Enums.ScopeType.Org node; non-null for any other type.\r\nThe service enforces the canonical Org→Tenant→Team→Repo→Template→Run\r\nladder."
+    DeleteBindingBody:
+      type: object
+      properties:
+        rationale:
+          type: string
+          nullable: true
+      additionalProperties: false
+      description: "Optional body for `DELETE /api/bindings/{id}`. New canonical\r\nshape — the existing `?rationale=` query parameter still\r\nworks (P9.5 follow-up #197)."
     EffectivePolicyDto:
       type: object
       properties:
@@ -2796,8 +2821,11 @@ components:
         rulesJson:
           type: string
           nullable: true
+        rationale:
+          type: string
+          nullable: true
       additionalProperties: false
-      description: "Request payload for `IPolicyService.UpdateDraftAsync`. Mutates the content\r\nof an existing Draft version. The `Policy.Name` slug is never updated via\r\nthis path — that would require a separate endpoint (deliberately deferred)."
+      description: "Request payload for `IPolicyService.UpdateDraftAsync`. Mutates the content\r\nof an existing Draft version. The `Policy.Name` slug is never updated via\r\nthis path — that would require a separate endpoint (deliberately deferred).\r\n\n`Rationale` is captured into the audit chain (P6.2) when supplied; the\r\n`RationaleRequiredFilter` rejects empty values when the\r\n`andy.policies.rationaleRequired` setting is on. Nullable for\r\nbackward compatibility (P9 follow-up #193).\r\n"
   securitySchemes:
     Bearer:
       type: http

--- a/src/Andy.Policies.Api/Controllers/BindingsController.cs
+++ b/src/Andy.Policies.Api/Controllers/BindingsController.cs
@@ -91,14 +91,30 @@ public sealed class BindingsController : ControllerBase
     public async Task<IActionResult> Delete(
         Guid id,
         [FromQuery] string? rationale,
+        [FromBody] DeleteBindingBody? body,
         CancellationToken ct)
     {
         var actor = ResolveActor();
         if (actor is null) return Unauthorized();
 
-        await _bindings.DeleteAsync(id, actor, rationale, ct);
+        // P9.5 follow-up #197: prefer the body's rationale over the query
+        // string, but accept either for backward compat with clients that
+        // already send `?rationale=`. Body wins so the audit trail records
+        // the canonical, audited copy when both are supplied.
+        var effectiveRationale = !string.IsNullOrWhiteSpace(body?.Rationale)
+            ? body.Rationale
+            : rationale;
+
+        await _bindings.DeleteAsync(id, actor, effectiveRationale, ct);
         return NoContent();
     }
+
+    /// <summary>
+    /// Optional body for <c>DELETE /api/bindings/{id}</c>. New canonical
+    /// shape — the existing <c>?rationale=</c> query parameter still
+    /// works (P9.5 follow-up #197).
+    /// </summary>
+    public sealed record DeleteBindingBody(string? Rationale);
 
     /// <summary>
     /// List active bindings for a target — exact-equality match on

--- a/src/Andy.Policies.Application/Dtos/CreateBindingRequest.cs
+++ b/src/Andy.Policies.Application/Dtos/CreateBindingRequest.cs
@@ -10,9 +10,17 @@ namespace Andy.Policies.Application.Dtos;
 /// rivoli-ai/andy-policies#20). The target version must exist and not be in
 /// <c>LifecycleState.Retired</c>; the service throws
 /// <c>BindingRetiredVersionException</c> on a retired target.
+/// <para>
+/// <c>Rationale</c> is forwarded to <c>IAuditWriter.AppendAsync</c> on the
+/// <c>binding.created</c> event. Nullable for backward compatibility — when
+/// the <c>andy.policies.rationaleRequired</c> gate is on, the
+/// <c>RationaleRequiredFilter</c> rejects requests with an empty rationale
+/// (P9 follow-up #197).
+/// </para>
 /// </summary>
 public sealed record CreateBindingRequest(
     Guid PolicyVersionId,
     BindingTargetType TargetType,
     string TargetRef,
-    BindStrength BindStrength);
+    BindStrength BindStrength,
+    string? Rationale = null);

--- a/src/Andy.Policies.Application/Dtos/CreatePolicyRequest.cs
+++ b/src/Andy.Policies.Application/Dtos/CreatePolicyRequest.cs
@@ -7,6 +7,13 @@ namespace Andy.Policies.Application.Dtos;
 /// Request payload for <c>IPolicyService.CreateDraftAsync</c>. Creates both the
 /// stable <c>Policy</c> row and its first <c>PolicyVersion</c> (version 1, Draft).
 /// Enum fields accept any casing on input (parsed case-insensitively by the service).
+/// <para>
+/// <c>Rationale</c> is captured into the audit chain (P6.2) when supplied; the
+/// <c>RationaleRequiredFilter</c> (P2.4) rejects empty values when the
+/// <c>andy.policies.rationaleRequired</c> setting is on. Nullable for
+/// backward compatibility — clients that pre-date the field continue to work
+/// when the gate is off (P9 follow-up #193, 2026-05-07).
+/// </para>
 /// </summary>
 public record CreatePolicyRequest(
     string Name,
@@ -15,4 +22,5 @@ public record CreatePolicyRequest(
     string Enforcement,
     string Severity,
     IReadOnlyList<string> Scopes,
-    string RulesJson);
+    string RulesJson,
+    string? Rationale = null);

--- a/src/Andy.Policies.Application/Dtos/UpdatePolicyVersionRequest.cs
+++ b/src/Andy.Policies.Application/Dtos/UpdatePolicyVersionRequest.cs
@@ -7,10 +7,17 @@ namespace Andy.Policies.Application.Dtos;
 /// Request payload for <c>IPolicyService.UpdateDraftAsync</c>. Mutates the content
 /// of an existing Draft version. The <c>Policy.Name</c> slug is never updated via
 /// this path — that would require a separate endpoint (deliberately deferred).
+/// <para>
+/// <c>Rationale</c> is captured into the audit chain (P6.2) when supplied; the
+/// <c>RationaleRequiredFilter</c> rejects empty values when the
+/// <c>andy.policies.rationaleRequired</c> setting is on. Nullable for
+/// backward compatibility (P9 follow-up #193).
+/// </para>
 /// </summary>
 public record UpdatePolicyVersionRequest(
     string Summary,
     string Enforcement,
     string Severity,
     IReadOnlyList<string> Scopes,
-    string RulesJson);
+    string RulesJson,
+    string? Rationale = null);

--- a/src/Andy.Policies.Infrastructure/Services/BindingService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BindingService.cs
@@ -114,7 +114,7 @@ public sealed class BindingService : IBindingService
         await _db.SaveChangesAsync(ct).ConfigureAwait(false);
 
         await _audit.AppendAsync(
-            "binding.created", binding.Id, actorSubjectId, rationale: null, ct)
+            "binding.created", binding.Id, actorSubjectId, request.Rationale, ct)
             .ConfigureAwait(false);
 
         return ToDto(binding);

--- a/src/Andy.Policies.Infrastructure/Services/PolicyService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/PolicyService.cs
@@ -35,10 +35,17 @@ public sealed partial class PolicyService : IPolicyService
     public const int MaxPageSize = 500;
 
     private readonly AppDbContext _db;
+    private readonly IAuditWriter? _audit;
 
-    public PolicyService(AppDbContext db)
+    /// <param name="audit">Optional audit writer. Production DI wires
+    /// <c>NoopAuditWriter</c> (P3.2) and the real hash-chained writer
+    /// (P6.2). Tests that construct directly may pass <c>null</c> to
+    /// skip audit emission — the 57 pre-existing direct-instantiation
+    /// tests rely on that. New audit-aware tests inject a spy.</param>
+    public PolicyService(AppDbContext db, IAuditWriter? audit = null)
     {
         _db = db;
+        _audit = audit;
     }
 
     public async Task<IReadOnlyList<PolicyDto>> ListPoliciesAsync(ListPoliciesQuery query, CancellationToken ct = default)
@@ -186,6 +193,16 @@ public sealed partial class PolicyService : IPolicyService
         await _db.SaveChangesAsync(ct);
         await tx.CommitAsync(ct);
 
+        // Audit append after commit — matches BindingService.CreateAsync's
+        // pattern. NoopAuditWriter today; the P6.2 real writer will need
+        // to fold this into the same transaction when it lands.
+        if (_audit is not null)
+        {
+            await _audit.AppendAsync(
+                "policy.draft.created", policy.Id, subjectId, request.Rationale, ct)
+                .ConfigureAwait(false);
+        }
+
         return ToVersionDto(version);
     }
 
@@ -228,6 +245,13 @@ public sealed partial class PolicyService : IPolicyService
         // the load above and this save — the API layer (P1.5) maps that to 412 Precondition
         // Failed.
         await _db.SaveChangesAsync(ct);
+
+        if (_audit is not null)
+        {
+            await _audit.AppendAsync(
+                "policy.draft.updated", version.Id, subjectId, request.Rationale, ct)
+                .ConfigureAwait(false);
+        }
 
         return ToVersionDto(version);
     }

--- a/tests/Andy.Policies.Tests.Integration/Api/OverridesControllerTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Api/OverridesControllerTests.cs
@@ -10,6 +10,7 @@ using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Application.Settings;
 using Andy.Policies.Domain.Enums;
 using Andy.Policies.Tests.Integration.Controllers;
+using Andy.Policies.Tests.Integration.Fixtures;
 using FluentAssertions;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
@@ -98,6 +99,11 @@ public class OverridesControllerTests : IDisposable
                         .RequireAuthenticatedUser()
                         .Build();
                 });
+
+                // P9 follow-up #193: rationale gate stubbed off so the
+                // override-focused tests don't trip on the new draft create
+                // gate. RationaleEnforcementTests covers gate behaviour.
+                services.StubRationaleOff();
 
                 using var sp = services.BuildServiceProvider();
                 using var scope = sp.CreateScope();

--- a/tests/Andy.Policies.Tests.Integration/Cli/CliLifecycleEndToEndTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Cli/CliLifecycleEndToEndTests.cs
@@ -7,6 +7,7 @@ using Andy.Policies.Application.Dtos;
 using Andy.Policies.Cli.Commands;
 using Andy.Policies.Cli.Http;
 using Andy.Policies.Tests.Integration.Controllers;
+using Andy.Policies.Tests.Integration.Fixtures;
 using FluentAssertions;
 using Microsoft.AspNetCore.TestHost;
 using Xunit;
@@ -62,6 +63,8 @@ public class CliLifecycleEndToEndTests : IClassFixture<PoliciesApiFactory>
             severity = "Critical",
             scopes = Array.Empty<string>(),
             rulesJson = "{}",
+            // P9 follow-up #193: CreatePolicyRequest now carries Rationale.
+            rationale = "test-create-draft",
         }, "test-creator");
         resp.EnsureSuccessStatusCode();
         return (await resp.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
@@ -99,10 +102,40 @@ public class CliLifecycleEndToEndTests : IClassFixture<PoliciesApiFactory>
         // because System.CommandLine reserves exit 2 for parser-level errors.
         // The acceptance criterion is that the binary exits non-zero and the
         // DB stays untouched.
-        using var _scope = ClientFactory.UseHandlerForTesting(_factory.Server.CreateHandler());
-        var draft = await CreateDraftAsync($"cli-norat-{Guid.NewGuid():N}".Substring(0, 16));
+        //
+        // P9 follow-up #193: PoliciesApiFactory now stubs the rationale gate
+        // OFF for the bulk of tests; flip it back ON via a dedicated subclass
+        // for this test, and route the CLI's HTTP through that factory's
+        // handler + base address.
+        using var factoryOn = new RationaleOnFactory();
+        using var _scope = ClientFactory.UseHandlerForTesting(factoryOn.Server.CreateHandler());
+        var slug = $"cli-norat-{Guid.NewGuid():N}".Substring(0, 16);
+        var setupClient = factoryOn.CreateClient();
+        var setupResp = await setupClient.PostAsJsonAsSubjectAsync("/api/policies", new
+        {
+            name = slug,
+            description = (string?)null,
+            summary = "summary",
+            enforcement = "Must",
+            severity = "Critical",
+            scopes = Array.Empty<string>(),
+            rulesJson = "{}",
+            rationale = "test-create-draft",
+        }, "test-creator");
+        setupResp.EnsureSuccessStatusCode();
+        var draft = (await setupResp.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
 
-        var root = BuildRootCommand();
+        var apiUrl = new Option<string>("--api-url", () => factoryOn.Server.BaseAddress.ToString());
+        var token = new Option<string?>("--token");
+        var output = new Option<string>("--output", () => "json");
+        var root = new RootCommand("test-cli");
+        root.AddGlobalOption(apiUrl);
+        root.AddGlobalOption(token);
+        root.AddGlobalOption(output);
+        var versions = new Command("versions");
+        VersionCommands.Register(versions, apiUrl, token, output);
+        root.AddCommand(versions);
+
         var exit = await root.InvokeAsync(new[]
         {
             "versions", "publish",
@@ -112,10 +145,23 @@ public class CliLifecycleEndToEndTests : IClassFixture<PoliciesApiFactory>
 
         exit.Should().Be(1);
 
-        var client = _factory.CreateClient();
-        var reloaded = await client.GetFromJsonAsync<PolicyVersionDto>(
+        var reloaded = await setupClient.GetFromJsonAsync<PolicyVersionDto>(
             $"/api/policies/{draft.PolicyId}/versions/{draft.Id}");
         reloaded!.State.Should().Be("Draft");
+    }
+
+    /// <summary>
+    /// One-off PoliciesApiFactory subclass with the rationale gate ON.
+    /// Used by the empty-rationale CLI test only; the parent class stubs
+    /// the gate off for the bulk of unrelated tests.
+    /// </summary>
+    private sealed class RationaleOnFactory : PoliciesApiFactory
+    {
+        protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
+        {
+            base.ConfigureWebHost(builder);
+            builder.ConfigureServices(services => services.StubRationaleOn());
+        }
     }
 
     [Fact]

--- a/tests/Andy.Policies.Tests.Integration/Controllers/PoliciesApiFactory.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/PoliciesApiFactory.cs
@@ -20,7 +20,7 @@ namespace Andy.Policies.Tests.Integration.Controllers;
 /// pre-existing <c>ItemsControllerTests</c> failure mode (default factory tries to
 /// migrate against Postgres on :5439 because of the auto-migrate in <c>Program.cs</c>).
 /// </summary>
-public sealed class PoliciesApiFactory : WebApplicationFactory<Program>
+public class PoliciesApiFactory : WebApplicationFactory<Program>
 {
     // Connection lives for the lifetime of the factory; closing it would drop the
     // in-memory database. SQLite's :memory: store is per-connection, so a single
@@ -111,6 +111,24 @@ public sealed class PoliciesApiFactory : WebApplicationFactory<Program>
             services.AddSingleton<Andy.Policies.Application.Interfaces.IPinningPolicy>(
                 new StaticPinningPolicy(required: false));
 
+            // P9 follow-up #193 (rationale on draft mutations): the manifest
+            // default for `andy.policies.rationaleRequired` is `true`. Now
+            // that CreatePolicyRequest / UpdatePolicyVersionRequest /
+            // CreateBindingRequest carry a `Rationale` field, the
+            // RationaleRequiredFilter (P2.4) enforces it on every mutating
+            // request when the gate is on. Most pre-existing integration
+            // tests don't supply rationale and aren't testing the gate;
+            // stub IRationalePolicy off so they stay focused on their
+            // actual subject. RationaleEnforcementTests uses its own
+            // RationaleFactory with the gate on for the dedicated
+            // enforcement coverage.
+            var rationaleDescriptors = services
+                .Where(d => d.ServiceType == typeof(Andy.Policies.Application.Interfaces.IRationalePolicy))
+                .ToList();
+            foreach (var d in rationaleDescriptors) services.Remove(d);
+            services.AddSingleton<Andy.Policies.Application.Interfaces.IRationalePolicy>(
+                new StaticRationalePolicy(required: false));
+
             // Build the schema once on the shared connection.
             using var sp = services.BuildServiceProvider();
             using var scope = sp.CreateScope();
@@ -134,6 +152,21 @@ public sealed class PoliciesApiFactory : WebApplicationFactory<Program>
             string? resourceInstanceId,
             CancellationToken ct)
             => Task.FromResult(new RbacDecision(true, "test-allow"));
+    }
+
+    /// <summary>
+    /// Static <see cref="Andy.Policies.Application.Interfaces.IRationalePolicy"/> for tests
+    /// that don't exercise the gate themselves; <see cref="RationaleEnforcementTests"/>
+    /// uses its own factory variant for tests that flip the value.
+    /// </summary>
+    internal sealed class StaticRationalePolicy : Andy.Policies.Application.Interfaces.IRationalePolicy
+    {
+        public StaticRationalePolicy(bool required) => IsRequired = required;
+        public bool IsRequired { get; }
+        public string? ValidateRationale(string? rationale)
+            => IsRequired && string.IsNullOrWhiteSpace(rationale)
+                ? "Rationale is required for this operation."
+                : null;
     }
 
     /// <summary>

--- a/tests/Andy.Policies.Tests.Integration/Controllers/PolicyVersionsLifecycleControllerTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/PolicyVersionsLifecycleControllerTests.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using Andy.Policies.Application.Dtos;
+using Andy.Policies.Tests.Integration.Fixtures;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
@@ -21,10 +22,12 @@ namespace Andy.Policies.Tests.Integration.Controllers;
 /// </summary>
 public class PolicyVersionsLifecycleControllerTests : IClassFixture<PoliciesApiFactory>
 {
+    private readonly PoliciesApiFactory _factory;
     private readonly HttpClient _client;
 
     public PolicyVersionsLifecycleControllerTests(PoliciesApiFactory factory)
     {
+        _factory = factory;
         _client = factory.CreateClient();
     }
 
@@ -35,7 +38,12 @@ public class PolicyVersionsLifecycleControllerTests : IClassFixture<PoliciesApiF
         Enforcement: "Must",
         Severity: "Critical",
         Scopes: Array.Empty<string>(),
-        RulesJson: "{}");
+        RulesJson: "{}",
+        // P9 follow-up #193: CreatePolicyRequest now carries Rationale.
+        // The publish-gate tests below test the publish endpoint's
+        // empty-rationale rejection; the draft-create setup step needs
+        // a non-empty value so it can pass through and reach publish.
+        Rationale: "test-create-draft");
 
     private static LifecycleTransitionRequest WithRationale(string rationale = "ship-it")
         => new(rationale);
@@ -102,9 +110,18 @@ public class PolicyVersionsLifecycleControllerTests : IClassFixture<PoliciesApiF
     [Fact]
     public async Task Publish_WithEmptyRationale_Returns400()
     {
-        var draft = await CreateDraftAsync("publish-no-rationale");
+        // P9 follow-up #193: PoliciesApiFactory now stubs the rationale
+        // gate OFF (most tests don't supply rationale). This test
+        // specifically tests the gate's empty-rationale rejection on
+        // publish — flip it back ON locally.
+        using var rationaleOn = _factory.WithRationaleOn();
+        var client = rationaleOn.CreateClient();
+        var slug = "publish-no-rationale";
+        var createResp = await client.PostAsJsonAsync("/api/policies", MinimalCreate(slug));
+        createResp.EnsureSuccessStatusCode();
+        var draft = (await createResp.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
 
-        var response = await _client.PostAsJsonAsApproverAsync(
+        var response = await client.PostAsJsonAsApproverAsync(
             $"/api/policies/{draft.PolicyId}/versions/{draft.Id}/publish",
             new LifecycleTransitionRequest(Rationale: "   "));
 

--- a/tests/Andy.Policies.Tests.Integration/Controllers/RationaleEnforcementTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/RationaleEnforcementTests.cs
@@ -121,7 +121,12 @@ public class RationaleEnforcementTests
         Enforcement: "Must",
         Severity: "Critical",
         Scopes: Array.Empty<string>(),
-        RulesJson: "{}");
+        RulesJson: "{}",
+        // P9 follow-up #193: CreatePolicyRequest now carries Rationale.
+        // This fixture toggles RationaleRequired per-test on the
+        // publish endpoint, so we always supply rationale on the
+        // create-draft setup step regardless of the gate.
+        Rationale: "test-create-draft");
 
     private static async Task<PolicyVersionDto> CreateDraftAsync(HttpClient client, string name)
     {

--- a/tests/Andy.Policies.Tests.Integration/Fixtures/RbacTestApplicationFactory.cs
+++ b/tests/Andy.Policies.Tests.Integration/Fixtures/RbacTestApplicationFactory.cs
@@ -80,6 +80,11 @@ public sealed class RbacTestApplicationFactory : WebApplicationFactory<Program>
             services.AddSingleton<Andy.Policies.Application.Interfaces.IPinningPolicy>(
                 new PoliciesApiFactory.StaticPinningPolicy(required: false));
 
+            // P9 follow-up #193: rationale gate stubbed off so RBAC-focused
+            // tests don't have to thread rationale through every CreateDraft
+            // call. RationaleEnforcementTests use their own snapshot factory.
+            services.StubRationaleOff();
+
             using var sp = services.BuildServiceProvider();
             using var scope = sp.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();

--- a/tests/Andy.Policies.Tests.Integration/Fixtures/TestRationaleStub.cs
+++ b/tests/Andy.Policies.Tests.Integration/Fixtures/TestRationaleStub.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Interfaces;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Andy.Policies.Tests.Integration.Fixtures;
+
+/// <summary>
+/// P9 follow-up #193 (rationale on draft create/update) made
+/// <see cref="IRationalePolicy"/> matter for `POST /api/policies`,
+/// `PUT /api/policies/{id}/versions/{vId}`, and `POST /api/bindings`.
+/// The manifest default for <c>andy.policies.rationaleRequired</c> is
+/// <c>true</c>; tests that don't supply rationale on those mutations
+/// previously skipped the filter (no Rationale field) but now hit the
+/// gate. Tests that aren't testing the gate flip it off via this stub.
+/// <see cref="Controllers.RationaleEnforcementTests"/> uses its own
+/// snapshot-driven factory for the dedicated enforcement coverage.
+/// </summary>
+internal static class TestRationaleStub
+{
+    public static IServiceCollection StubRationaleOff(this IServiceCollection services)
+        => Replace(services, required: false);
+
+    public static IServiceCollection StubRationaleOn(this IServiceCollection services)
+        => Replace(services, required: true);
+
+    private static IServiceCollection Replace(IServiceCollection services, bool required)
+    {
+        var existing = services
+            .Where(d => d.ServiceType == typeof(IRationalePolicy))
+            .ToList();
+        foreach (var d in existing) services.Remove(d);
+        services.AddSingleton<IRationalePolicy>(new StaticRationalePolicy(required));
+        return services;
+    }
+
+    /// <summary>
+    /// Returns a derivative factory with the rationale gate flipped ON.
+    /// Used by the few tests that specifically exercise empty-rationale
+    /// rejection on publish/transition (where the parent factory has the
+    /// gate OFF for the bulk of unrelated mutating tests).
+    /// </summary>
+    public static WebApplicationFactory<TEntry> WithRationaleOn<TEntry>(
+        this WebApplicationFactory<TEntry> factory)
+        where TEntry : class
+        => factory.WithWebHostBuilder(b =>
+            b.ConfigureServices(services => services.StubRationaleOn()));
+
+    private sealed class StaticRationalePolicy : IRationalePolicy
+    {
+        public StaticRationalePolicy(bool required) => IsRequired = required;
+        public bool IsRequired { get; }
+        public string? ValidateRationale(string? rationale)
+            => IsRequired && string.IsNullOrWhiteSpace(rationale)
+                ? "Rationale is required for this operation."
+                : null;
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/GrpcServices/LifecycleGrpcServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/GrpcServices/LifecycleGrpcServiceTests.cs
@@ -3,6 +3,7 @@
 
 using Andy.Policies.Api.Protos;
 using Andy.Policies.Tests.Integration.Controllers;
+using Andy.Policies.Tests.Integration.Fixtures;
 using FluentAssertions;
 using Grpc.Core;
 using Grpc.Net.Client;
@@ -21,12 +22,14 @@ namespace Andy.Policies.Tests.Integration.GrpcServices;
 /// </summary>
 public class LifecycleGrpcServiceTests : IClassFixture<PoliciesApiFactory>, IDisposable
 {
+    private readonly PoliciesApiFactory _factory;
     private readonly GrpcChannel _channel;
     private readonly LifecycleService.LifecycleServiceClient _lifecycle;
     private readonly Andy.Policies.Api.Protos.PolicyService.PolicyServiceClient _policies;
 
     public LifecycleGrpcServiceTests(PoliciesApiFactory factory)
     {
+        _factory = factory;
         var handler = factory.Server.CreateHandler();
         _channel = GrpcChannel.ForAddress(factory.Server.BaseAddress, new GrpcChannelOptions
         {
@@ -125,10 +128,23 @@ public class LifecycleGrpcServiceTests : IClassFixture<PoliciesApiFactory>, IDis
     [Fact]
     public async Task PublishVersion_EmptyRationale_ThrowsInvalidArgument()
     {
-        var draft = await CreateDraftAsync(Slug("nora"));
+        // P9 follow-up #193: PoliciesApiFactory now stubs the rationale gate
+        // OFF. This test specifically tests the gate's empty-rationale
+        // rejection on publish — flip it back ON locally with its own
+        // channel + clients pinned to the new factory.
+        using var rationaleOn = _factory.WithRationaleOn();
+        using var localHandler = rationaleOn.Server.CreateHandler();
+        using var localChannel = GrpcChannel.ForAddress(
+            rationaleOn.Server.BaseAddress,
+            new GrpcChannelOptions { HttpHandler = localHandler });
+        var lifecycle = new LifecycleService.LifecycleServiceClient(localChannel);
+        var policies = new Andy.Policies.Api.Protos.PolicyService.PolicyServiceClient(localChannel);
+
+        var metadata = new Metadata { { TestAuthHandler.SubjectHeader, "test-creator" } };
+        var draft = (await policies.CreateDraftAsync(MinimalCreate(Slug("nora")), metadata)).Version;
 
         var ex = await Assert.ThrowsAsync<RpcException>(() =>
-            _lifecycle.PublishVersionAsync(new PublishVersionRequest
+            lifecycle.PublishVersionAsync(new PublishVersionRequest
             {
                 PolicyId = draft.PolicyId,
                 VersionId = draft.Id,

--- a/tests/Andy.Policies.Tests.Integration/GrpcServices/OverridesGrpcServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/GrpcServices/OverridesGrpcServiceTests.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Json;
 using Andy.Policies.Api.Protos;
 using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Tests.Integration.Fixtures;
 using Andy.Policies.Application.Settings;
 using Andy.Policies.Infrastructure.Data;
 using Andy.Policies.Tests.Integration.Controllers;
@@ -92,6 +93,9 @@ public class OverridesGrpcServiceTests : IDisposable
                         .RequireAuthenticatedUser()
                         .Build();
                 });
+
+                // P9 follow-up #193: rationale gate stubbed off.
+                services.StubRationaleOff();
 
                 using var sp = services.BuildServiceProvider();
                 using var scope = sp.CreateScope();

--- a/tests/Andy.Policies.Tests.Integration/Overrides/OverridesGateToggleTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Overrides/OverridesGateToggleTests.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Andy.Policies.Application.Dtos;
+using Andy.Policies.Tests.Integration.Fixtures;
 using Andy.Policies.Application.Settings;
 using Andy.Policies.Domain.Enums;
 using Andy.Policies.Tests.Integration.Controllers;
@@ -90,6 +91,10 @@ public class OverridesGateToggleTests : IDisposable
                         .RequireAuthenticatedUser()
                         .Build();
                 });
+
+                // P9 follow-up #193: rationale gate stubbed off — these tests
+                // exercise the override write gate, not the rationale filter.
+                services.StubRationaleOff();
 
                 using var sp = services.BuildServiceProvider();
                 using var scope = sp.CreateScope();


### PR DESCRIPTION
## Summary

Closes the audit-trail gap on draft create/update + binding create/delete. \`CreatePolicyRequest\`, \`UpdatePolicyVersionRequest\`, and \`CreateBindingRequest\` gain an optional \`Rationale\` string (nullable for backward compat). \`PolicyService\` gets DI-wired \`IAuditWriter\` and now emits \`policy.draft.created\` / \`policy.draft.updated\` events. \`BindingService\` threads the request rationale into its existing audit append (previously hardcoded to null). \`DELETE /api/bindings/{id}\` accepts a body \`{ rationale }\` alongside the existing \`?rationale=\` query param.

## Test infrastructure

The manifest default for \`andy.policies.rationaleRequired\` is \`true\`, so tests that send mutating requests without rationale now hit the filter (84 failures pre-fix). Mirrored the existing \`IPinningPolicy\` stub pattern: most factories call a new \`StubRationaleOff()\` extension; the 3 publish-empty-rationale tests (REST, gRPC, CLI) explicitly flip the gate ON for their scope. \`PoliciesApiFactory\` was unsealed so the CLI test could subclass for an inline gate-on variant.

## Test plan

- [x] \`dotnet test\` — **609/609 integration + all unit + E2E pass**.
- [x] OpenAPI export refreshed (\`docs/openapi/andy-policies-v1.yaml\` shows the new \`Rationale\` properties).

Closes #193
Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)