### PR TITLE
Implement #194 — optimistic concurrency token (ExpectedRevision)

### DIFF
--- a/docs/openapi/andy-policies-v1.yaml
+++ b/docs/openapi/andy-policies-v1.yaml
@@ -2477,8 +2477,12 @@ components:
         rationale:
           type: string
           nullable: true
+        expectedRevision:
+          type: integer
+          format: int32
+          nullable: true
       additionalProperties: false
-      description: "Request payload for the lifecycle transition endpoints (P2.3, story\r\nrivoli-ai/andy-policies#13): publish, winding-down, retire. The single\r\n`rationale` field is forwarded to `ILifecycleTransitionService`\r\nwhere `IRationalePolicy` validates it against the\r\n`andy.policies.rationaleRequired` setting (P2.4 wires the dynamic\r\ngate; P2.3 ships with the require-non-empty default)."
+      description: "Request payload for the lifecycle transition endpoints (P2.3, story\r\nrivoli-ai/andy-policies#13): publish, winding-down, retire. The\r\n`rationale` field is forwarded to `ILifecycleTransitionService`\r\nwhere `IRationalePolicy` validates it against the\r\n`andy.policies.rationaleRequired` setting (P2.4 wires the dynamic\r\ngate; P2.3 ships with the require-non-empty default).\r\n\n`ExpectedRevision` (P9 follow-up #194, 2026-05-07) is an optional\r\noptimistic-concurrency token. When supplied, the service verifies the\r\nloaded version's `Revision` matches before transitioning; mismatch\r\nreturns 412. Nullable for backward compat — clients that don't set it\r\nfall through to last-write-wins (the existing behavior).\r\n"
     OverrideDto:
       type: object
       properties:
@@ -2623,8 +2627,11 @@ components:
         proposerSubjectId:
           type: string
           nullable: true
+        revision:
+          type: integer
+          format: int32
       additionalProperties: false
-      description: "Wire-format projection of a `PolicyVersion`. Enum-shaped fields are\r\nserialised in the casing required by ADR 0001 §6:\r\n<list type=\"bullet\"><item><term>Enforcement</term><description>uppercase RFC 2119 tokens (`MUST` / `SHOULD` / `MAY`).</description></item><item><term>Severity</term><description>lowercase (`info` / `moderate` / `critical`).</description></item><item><term>State</term><description>PascalCase (`Draft` / `Active` / `WindingDown` / `Retired`) — matches DB storage and consumer-visible lifecycle labels.</description></item></list>\r\nService layer performs the casing conversion; controllers pass the DTO through unchanged."
+      description: "Wire-format projection of a `PolicyVersion`. Enum-shaped fields are\r\nserialised in the casing required by ADR 0001 §6:\r\n<list type=\"bullet\"><item><term>Enforcement</term><description>uppercase RFC 2119 tokens (`MUST` / `SHOULD` / `MAY`).</description></item><item><term>Severity</term><description>lowercase (`info` / `moderate` / `critical`).</description></item><item><term>State</term><description>PascalCase (`Draft` / `Active` / `WindingDown` / `Retired`) — matches DB storage and consumer-visible lifecycle labels.</description></item></list>\r\nService layer performs the casing conversion; controllers pass the DTO through unchanged.\r\n\n`Revision` is the optimistic-concurrency token (P9 follow-up #194,\r\n2026-05-07). On Postgres + SQLite alike it's a manually-bumped `uint`;\r\nEF raises `DbUpdateConcurrencyException` when the loaded version's\r\n`Revision` diverges from what's on disk. UI flows that present a\r\nversion DTO and let the user save later should round-trip the value via\r\n`UpdatePolicyVersionRequest.ExpectedRevision` and the lifecycle\r\ntransition request's `ExpectedRevision`; mismatch returns 412.\r\n"
     ProblemDetails:
       type: object
       properties:
@@ -2824,8 +2831,12 @@ components:
         rationale:
           type: string
           nullable: true
+        expectedRevision:
+          type: integer
+          format: int32
+          nullable: true
       additionalProperties: false
-      description: "Request payload for `IPolicyService.UpdateDraftAsync`. Mutates the content\r\nof an existing Draft version. The `Policy.Name` slug is never updated via\r\nthis path — that would require a separate endpoint (deliberately deferred).\r\n\n`Rationale` is captured into the audit chain (P6.2) when supplied; the\r\n`RationaleRequiredFilter` rejects empty values when the\r\n`andy.policies.rationaleRequired` setting is on. Nullable for\r\nbackward compatibility (P9 follow-up #193).\r\n"
+      description: "Request payload for `IPolicyService.UpdateDraftAsync`. Mutates the content\r\nof an existing Draft version. The `Policy.Name` slug is never updated via\r\nthis path — that would require a separate endpoint (deliberately deferred).\r\n\n`Rationale` is captured into the audit chain (P6.2) when supplied; the\r\n`RationaleRequiredFilter` rejects empty values when the\r\n`andy.policies.rationaleRequired` setting is on. Nullable for\r\nbackward compatibility (P9 follow-up #193).\r\n\n`ExpectedRevision` (P9 follow-up #194, 2026-05-07) is an optional\r\noptimistic-concurrency token sourced from `PolicyVersionDto.Revision`.\r\nWhen supplied, the service verifies the loaded version's\r\n`Revision` matches before mutating; mismatch returns 412. Nullable\r\nfor backward compat — clients that don't set it fall through to\r\nlast-write-wins.\r\n"
   securitySchemes:
     Bearer:
       type: http

--- a/src/Andy.Policies.Api/Controllers/PolicyVersionsLifecycleController.cs
+++ b/src/Andy.Policies.Api/Controllers/PolicyVersionsLifecycleController.cs
@@ -105,7 +105,9 @@ public sealed class PolicyVersionsLifecycleController : ControllerBase
         var dto = await _transitions.TransitionAsync(
             id, versionId, target,
             body?.Rationale ?? string.Empty,
-            subjectId, ct);
+            subjectId,
+            body?.ExpectedRevision,
+            ct);
 
         return Ok(dto);
     }

--- a/src/Andy.Policies.Api/GrpcServices/LifecycleGrpcService.cs
+++ b/src/Andy.Policies.Api/GrpcServices/LifecycleGrpcService.cs
@@ -52,7 +52,7 @@ public class LifecycleGrpcService : Protos.LifecycleService.LifecycleServiceBase
                 policyId, versionId, LifecycleState.Active,
                 request.Rationale ?? string.Empty,
                 ResolveSubjectId(context),
-                context.CancellationToken);
+                ct: context.CancellationToken);
             return new PolicyVersionResponse { Version = ToMessage(dto) };
         }
         catch (Exception ex) { throw MapToRpcException(ex); }
@@ -76,7 +76,7 @@ public class LifecycleGrpcService : Protos.LifecycleService.LifecycleServiceBase
                 policyId, versionId, target,
                 request.Rationale ?? string.Empty,
                 ResolveSubjectId(context),
-                context.CancellationToken);
+                ct: context.CancellationToken);
             return new PolicyVersionResponse { Version = ToMessage(dto) };
         }
         catch (Exception ex) { throw MapToRpcException(ex); }

--- a/src/Andy.Policies.Api/Mcp/PolicyLifecycleTools.cs
+++ b/src/Andy.Policies.Api/Mcp/PolicyLifecycleTools.cs
@@ -142,7 +142,7 @@ public static class PolicyLifecycleTools
 
         try
         {
-            var dto = await transitions.TransitionAsync(pid, vid, target, rationale, subjectId, ct);
+            var dto = await transitions.TransitionAsync(pid, vid, target, rationale, subjectId, ct: ct);
             return FormatVersionDetail(dto);
         }
         catch (RationaleRequiredException ex)

--- a/src/Andy.Policies.Application/Dtos/LifecycleTransitionRequest.cs
+++ b/src/Andy.Policies.Application/Dtos/LifecycleTransitionRequest.cs
@@ -5,10 +5,17 @@ namespace Andy.Policies.Application.Dtos;
 
 /// <summary>
 /// Request payload for the lifecycle transition endpoints (P2.3, story
-/// rivoli-ai/andy-policies#13): publish, winding-down, retire. The single
+/// rivoli-ai/andy-policies#13): publish, winding-down, retire. The
 /// <c>rationale</c> field is forwarded to <c>ILifecycleTransitionService</c>
 /// where <c>IRationalePolicy</c> validates it against the
 /// <c>andy.policies.rationaleRequired</c> setting (P2.4 wires the dynamic
 /// gate; P2.3 ships with the require-non-empty default).
+/// <para>
+/// <c>ExpectedRevision</c> (P9 follow-up #194, 2026-05-07) is an optional
+/// optimistic-concurrency token. When supplied, the service verifies the
+/// loaded version's <c>Revision</c> matches before transitioning; mismatch
+/// returns 412. Nullable for backward compat — clients that don't set it
+/// fall through to last-write-wins (the existing behavior).
+/// </para>
 /// </summary>
-public record LifecycleTransitionRequest(string? Rationale);
+public record LifecycleTransitionRequest(string? Rationale, uint? ExpectedRevision = null);

--- a/src/Andy.Policies.Application/Dtos/PolicyVersionDto.cs
+++ b/src/Andy.Policies.Application/Dtos/PolicyVersionDto.cs
@@ -12,6 +12,15 @@ namespace Andy.Policies.Application.Dtos;
 ///   <item><term>State</term><description>PascalCase (<c>Draft</c> / <c>Active</c> / <c>WindingDown</c> / <c>Retired</c>) — matches DB storage and consumer-visible lifecycle labels.</description></item>
 /// </list>
 /// Service layer performs the casing conversion; controllers pass the DTO through unchanged.
+/// <para>
+/// <c>Revision</c> is the optimistic-concurrency token (P9 follow-up #194,
+/// 2026-05-07). On Postgres + SQLite alike it's a manually-bumped <c>uint</c>;
+/// EF raises <c>DbUpdateConcurrencyException</c> when the loaded version's
+/// <c>Revision</c> diverges from what's on disk. UI flows that present a
+/// version DTO and let the user save later should round-trip the value via
+/// <c>UpdatePolicyVersionRequest.ExpectedRevision</c> and the lifecycle
+/// transition request's <c>ExpectedRevision</c>; mismatch returns 412.
+/// </para>
 /// </summary>
 public record PolicyVersionDto(
     Guid Id,
@@ -25,4 +34,5 @@ public record PolicyVersionDto(
     string RulesJson,
     DateTimeOffset CreatedAt,
     string CreatedBySubjectId,
-    string ProposerSubjectId);
+    string ProposerSubjectId,
+    uint Revision = 0);

--- a/src/Andy.Policies.Application/Dtos/UpdatePolicyVersionRequest.cs
+++ b/src/Andy.Policies.Application/Dtos/UpdatePolicyVersionRequest.cs
@@ -13,6 +13,14 @@ namespace Andy.Policies.Application.Dtos;
 /// <c>andy.policies.rationaleRequired</c> setting is on. Nullable for
 /// backward compatibility (P9 follow-up #193).
 /// </para>
+/// <para>
+/// <c>ExpectedRevision</c> (P9 follow-up #194, 2026-05-07) is an optional
+/// optimistic-concurrency token sourced from <c>PolicyVersionDto.Revision</c>.
+/// When supplied, the service verifies the loaded version's
+/// <c>Revision</c> matches before mutating; mismatch returns 412. Nullable
+/// for backward compat — clients that don't set it fall through to
+/// last-write-wins.
+/// </para>
 /// </summary>
 public record UpdatePolicyVersionRequest(
     string Summary,
@@ -20,4 +28,5 @@ public record UpdatePolicyVersionRequest(
     string Severity,
     IReadOnlyList<string> Scopes,
     string RulesJson,
-    string? Rationale = null);
+    string? Rationale = null,
+    uint? ExpectedRevision = null);

--- a/src/Andy.Policies.Application/Interfaces/ILifecycleTransitionService.cs
+++ b/src/Andy.Policies.Application/Interfaces/ILifecycleTransitionService.cs
@@ -26,6 +26,7 @@ public interface ILifecycleTransitionService
         LifecycleState target,
         string rationale,
         string actorSubjectId,
+        uint? expectedRevision = null,
         CancellationToken ct = default);
 }
 

--- a/src/Andy.Policies.Infrastructure/Services/LifecycleTransitionService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/LifecycleTransitionService.cs
@@ -75,6 +75,7 @@ public sealed class LifecycleTransitionService : ILifecycleTransitionService
         LifecycleState target,
         string rationale,
         string actorSubjectId,
+        uint? expectedRevision = null,
         CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(actorSubjectId);
@@ -101,6 +102,17 @@ public sealed class LifecycleTransitionService : ILifecycleTransitionService
             .ConfigureAwait(false)
             ?? throw new NotFoundException(
                 $"PolicyVersion {versionId} not found under policy {policyId}.");
+
+        // P9 follow-up #194 (2026-05-07): when ExpectedRevision is supplied,
+        // verify it before mutating. Throwing DbUpdateConcurrencyException
+        // mirrors the existing 412 mapping in PolicyExceptionHandler so
+        // callers see a uniform "Stale revision" response shape regardless
+        // of whether the conflict is detected up-front or by EF on save.
+        if (expectedRevision is { } expected && version.Revision != expected)
+        {
+            throw new DbUpdateConcurrencyException(
+                $"PolicyVersion {versionId} revision is {version.Revision}; client expected {expected}.");
+        }
 
         if (!IsTransitionAllowed(version.State, target))
         {

--- a/src/Andy.Policies.Infrastructure/Services/PolicyService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/PolicyService.cs
@@ -215,6 +215,17 @@ public sealed partial class PolicyService : IPolicyService
             v => v.PolicyId == policyId && v.Id == versionId, ct)
             ?? throw new NotFoundException($"PolicyVersion {versionId} not found under policy {policyId}.");
 
+        // P9 follow-up #194 (2026-05-07): when ExpectedRevision is supplied,
+        // verify it before mutating. Throwing DbUpdateConcurrencyException
+        // matches the existing 412 mapping in PolicyExceptionHandler so the
+        // wire shape stays uniform whether we catch the staleness up-front
+        // or EF detects it on SaveChangesAsync.
+        if (request.ExpectedRevision is { } expected && version.Revision != expected)
+        {
+            throw new DbUpdateConcurrencyException(
+                $"PolicyVersion {versionId} revision is {version.Revision}; client expected {expected}.");
+        }
+
         // Service-level guard mirrors the domain MutateDraftField + the AppDbContext guard;
         // rejecting here yields a clearer error message than waiting for SaveChangesAsync.
         // Surfaced as ConflictException so the REST/MCP/gRPC layers map to 409 — wrong-state
@@ -343,7 +354,8 @@ public sealed partial class PolicyService : IPolicyService
         v.RulesJson,
         v.CreatedAt,
         v.CreatedBySubjectId,
-        v.ProposerSubjectId);
+        v.ProposerSubjectId,
+        v.Revision);
 
     /// <summary>ADR 0001 §6: uppercase RFC 2119 tokens on the wire.</summary>
     private static string ToEnforcementWire(EnforcementLevel level) => level switch

--- a/tests/Andy.Policies.Tests.Integration/Controllers/PoliciesControllerTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/PoliciesControllerTests.cs
@@ -34,6 +34,60 @@ public class PoliciesControllerTests : IClassFixture<PoliciesApiFactory>
         RulesJson: "{}");
 
     [Fact]
+    public async Task UpdateDraft_WithStaleExpectedRevision_Returns412()
+    {
+        // P9 follow-up #194 (2026-05-07): when the client sends an
+        // ExpectedRevision that doesn't match the loaded version's
+        // Revision, the service throws DbUpdateConcurrencyException
+        // which PolicyExceptionHandler maps to 412 Precondition Failed.
+        var createResp = await _client.PostAsJsonAsync(
+            "/api/policies", MinimalCreate("rev-stale"));
+        createResp.EnsureSuccessStatusCode();
+        var draft = (await createResp.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
+
+        // Submit an update with a wrong ExpectedRevision (any non-matching uint).
+        var stale = new UpdatePolicyVersionRequest(
+            Summary: "updated",
+            Enforcement: "Must",
+            Severity: "Critical",
+            Scopes: Array.Empty<string>(),
+            RulesJson: "{}",
+            Rationale: null,
+            ExpectedRevision: draft.Revision + 9999);
+        var updateResp = await _client.PutAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}",
+            stale);
+
+        Assert.Equal(HttpStatusCode.PreconditionFailed, updateResp.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateDraft_WithMatchingExpectedRevision_Returns200()
+    {
+        var createResp = await _client.PostAsJsonAsync(
+            "/api/policies", MinimalCreate("rev-fresh"));
+        createResp.EnsureSuccessStatusCode();
+        var draft = (await createResp.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
+
+        var fresh = new UpdatePolicyVersionRequest(
+            Summary: "updated",
+            Enforcement: "Must",
+            Severity: "Critical",
+            Scopes: Array.Empty<string>(),
+            RulesJson: "{}",
+            Rationale: null,
+            ExpectedRevision: draft.Revision);
+        var updateResp = await _client.PutAsJsonAsync(
+            $"/api/policies/{draft.PolicyId}/versions/{draft.Id}",
+            fresh);
+
+        Assert.Equal(HttpStatusCode.OK, updateResp.StatusCode);
+        var updated = (await updateResp.Content.ReadFromJsonAsync<PolicyVersionDto>())!;
+        Assert.True(updated.Revision > draft.Revision,
+            "EF should have bumped Revision on save (manual uint token, not row-version).");
+    }
+
+    [Fact]
     public async Task List_ReturnsEmptyArray_WhenNoPolicies()
     {
         var response = await _client.GetAsync("/api/policies?namePrefix=zzzzz");

--- a/tests/Andy.Policies.Tests.Integration/Controllers/PolicyVersionsLifecycleControllerActorClaimTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/PolicyVersionsLifecycleControllerActorClaimTests.cs
@@ -126,7 +126,9 @@ public class PolicyVersionsLifecycleControllerActorClaimTests
 
         public Task<PolicyVersionDto> TransitionAsync(
             Guid policyId, Guid versionId, LifecycleState target,
-            string rationale, string actorSubjectId, CancellationToken ct = default)
+            string rationale, string actorSubjectId,
+            uint? expectedRevision = null,
+            CancellationToken ct = default)
         {
             Calls.Add(new RecordedCall(policyId, versionId, target, rationale, actorSubjectId));
             return Task.FromResult(new PolicyVersionDto(

--- a/tests/Andy.Policies.Tests.Integration/OpenApi/SchemaShapeTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/OpenApi/SchemaShapeTests.cs
@@ -84,8 +84,14 @@ public class SchemaShapeTests : IClassFixture<PoliciesApiFactory>
     }
 
     [Fact]
-    public async Task SchemaComponents_DoNotExpose_RevisionConcurrencyToken()
+    public async Task SchemaComponents_OnlyPolicyVersionDto_Exposes_RevisionConcurrencyToken()
     {
+        // P9 follow-up #194 (2026-05-07): PolicyVersionDto now exposes
+        // `revision` so clients can round-trip the optimistic-concurrency
+        // token via UpdatePolicyVersionRequest.ExpectedRevision and
+        // LifecycleTransitionRequest.ExpectedRevision. Other DTOs must
+        // continue to keep the token internal — only the canonical
+        // version projection should leak it.
         using var doc = await LoadAsync();
         var schemas = doc.RootElement.GetProperty("components").GetProperty("schemas");
         foreach (var schema in schemas.EnumerateObject())
@@ -96,9 +102,12 @@ public class SchemaShapeTests : IClassFixture<PoliciesApiFactory>
             }
             foreach (var prop in props.EnumerateObject())
             {
-                Assert.False(
-                    string.Equals(prop.Name, "revision", StringComparison.OrdinalIgnoreCase),
-                    $"Schema '{schema.Name}' leaks the EF concurrency token 'revision'");
+                if (string.Equals(prop.Name, "revision", StringComparison.OrdinalIgnoreCase))
+                {
+                    Assert.True(
+                        string.Equals(schema.Name, "PolicyVersionDto", StringComparison.Ordinal),
+                        $"Schema '{schema.Name}' leaks the EF concurrency token 'revision'; only PolicyVersionDto should expose it.");
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

\`PolicyVersion.Revision\` already existed as a uint EF concurrency token; the gap was exposing it on the wire and accepting it on writes. \`PolicyVersionDto\` now exposes \`revision\`; \`UpdatePolicyVersionRequest\` and \`LifecycleTransitionRequest\` accept an optional \`ExpectedRevision\`. Mismatch on update or transition throws \`DbUpdateConcurrencyException\` → 412 Precondition Failed via the existing handler mapping.

The interface change to \`ILifecycleTransitionService.TransitionAsync\` (new \`expectedRevision\` parameter ahead of \`ct\`) required converting three positional-arg call sites to named (gRPC publish + transition, MCP shared executor).

## Test plan

- [x] \`dotnet build\` — clean.
- [x] \`dotnet test\` — only failure is known-flaky \`ScopeWalkPerfTests\`.
- [x] Two new integration tests on \`PoliciesControllerTests\`:
  - matching \`ExpectedRevision\` → 200, Revision bumps.
  - stale \`ExpectedRevision\` → 412.
- [x] \`SchemaShapeTests.SchemaComponents_OnlyPolicyVersionDto_Exposes_RevisionConcurrencyToken\` flipped from "no schema exposes revision" to "only PolicyVersionDto exposes it".
- [x] OpenAPI export refreshed.

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)