### PR TITLE
Implement #205 — includeOverrides flag on CreateBundleRequest

### DIFF
--- a/docs/openapi/andy-policies-v1.yaml
+++ b/docs/openapi/andy-policies-v1.yaml
@@ -2285,6 +2285,9 @@ components:
           type: string
           description: "Required non-empty rationale recorded\r\n            against the audit event."
           nullable: true
+        includeOverrides:
+          type: boolean
+          description: "When true (P9 follow-up #205,\r\n            2026-05-07), the snapshot also captures the current set of\r\n            Approved, non-expired overrides. Default `true` preserves the\r\n            pre-#205 behaviour where overrides were always included; pass\r\n            `false` for compliance / immutability bundles where overrides\r\n            are intentionally excluded."
       additionalProperties: false
       description: 'Inputs to M:Andy.Policies.Application.Interfaces.IBundleService.CreateAsync(Andy.Policies.Application.Interfaces.CreateBundleRequest,System.String,System.Threading.CancellationToken).'
     CreateItemRequest:

--- a/src/Andy.Policies.Application/Interfaces/IBundleService.cs
+++ b/src/Andy.Policies.Application/Interfaces/IBundleService.cs
@@ -59,7 +59,17 @@ public interface IBundleService
 /// <param name="Description">Optional human-readable summary.</param>
 /// <param name="Rationale">Required non-empty rationale recorded
 /// against the audit event.</param>
-public sealed record CreateBundleRequest(string Name, string? Description, string Rationale);
+/// <param name="IncludeOverrides">When true (P9 follow-up #205,
+/// 2026-05-07), the snapshot also captures the current set of
+/// Approved, non-expired overrides. Default <c>true</c> preserves the
+/// pre-#205 behaviour where overrides were always included; pass
+/// <c>false</c> for compliance / immutability bundles where overrides
+/// are intentionally excluded.</param>
+public sealed record CreateBundleRequest(
+    string Name,
+    string? Description,
+    string Rationale,
+    bool IncludeOverrides = true);
 
 /// <summary>Filter for <see cref="IBundleService.ListAsync"/>.</summary>
 public sealed record ListBundlesFilter(

--- a/src/Andy.Policies.Application/Interfaces/IBundleSnapshotBuilder.cs
+++ b/src/Andy.Policies.Application/Interfaces/IBundleSnapshotBuilder.cs
@@ -35,6 +35,13 @@ public interface IBundleSnapshotBuilder
     /// transaction. <paramref name="capturedAt"/> is the instant the
     /// caller wants stamped into <see cref="BundleSnapshot.CapturedAt"/>;
     /// it is also the cutoff for "non-expired" override rows.
+    /// <paramref name="includeOverrides"/> (P9 follow-up #205,
+    /// 2026-05-07) elides the override scan when false — useful for
+    /// compliance / immutability bundles whose runtime behaviour is
+    /// governed strictly by the active policy + binding set.
     /// </summary>
-    Task<BundleSnapshot> BuildAsync(DateTimeOffset capturedAt, CancellationToken ct = default);
+    Task<BundleSnapshot> BuildAsync(
+        DateTimeOffset capturedAt,
+        bool includeOverrides = true,
+        CancellationToken ct = default);
 }

--- a/src/Andy.Policies.Infrastructure/Services/BundleService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BundleService.cs
@@ -106,7 +106,9 @@ public sealed class BundleService : IBundleService
             }
 
             var capturedAt = _clock.GetUtcNow();
-            var snapshot = await _builder.BuildAsync(capturedAt, ct).ConfigureAwait(false);
+            var snapshot = await _builder
+                .BuildAsync(capturedAt, request.IncludeOverrides, ct)
+                .ConfigureAwait(false);
 
             var canonicalBytes = CanonicalJson.SerializeObject(snapshot);
             var snapshotJson = Encoding.UTF8.GetString(canonicalBytes);

--- a/src/Andy.Policies.Infrastructure/Services/BundleSnapshotBuilder.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BundleSnapshotBuilder.cs
@@ -31,7 +31,10 @@ public sealed class BundleSnapshotBuilder : IBundleSnapshotBuilder
         _db = db;
     }
 
-    public async Task<BundleSnapshot> BuildAsync(DateTimeOffset capturedAt, CancellationToken ct = default)
+    public async Task<BundleSnapshot> BuildAsync(
+        DateTimeOffset capturedAt,
+        bool includeOverrides = true,
+        CancellationToken ct = default)
     {
         // Active policy versions, ordered (PolicyId, Version) for
         // deterministic serialisation. Include the parent Policy so
@@ -98,33 +101,47 @@ public sealed class BundleSnapshotBuilder : IBundleSnapshotBuilder
         // and refine on ExpiresAt client-side. The Approved set is
         // bounded in practice; for catalogs that grow large here, a
         // future migration would push the predicate via raw SQL.
-        var approvedRows = await _db.Overrides
-            .AsNoTracking()
-            .Where(o => o.State == OverrideState.Approved)
-            .Select(o => new
-            {
-                o.Id,
-                o.PolicyVersionId,
-                o.ScopeKind,
-                o.ScopeRef,
-                o.Effect,
-                o.ReplacementPolicyVersionId,
-                o.ExpiresAt,
-            })
-            .ToListAsync(ct)
-            .ConfigureAwait(false);
-        var overrides = approvedRows
-            .Where(o => o.ExpiresAt > capturedAt)
-            .OrderBy(o => o.Id)
-            .Select(o => new BundleOverrideEntry(
-                o.Id,
-                o.PolicyVersionId,
-                o.ScopeKind.ToString(),
-                o.ScopeRef,
-                o.Effect.ToString(),
-                o.ReplacementPolicyVersionId,
-                o.ExpiresAt))
-            .ToList();
+        //
+        // P9 follow-up #205 (2026-05-07): when `includeOverrides` is
+        // false, skip the query entirely and emit an empty list.
+        // Compliance / immutability bundles use this to publish a
+        // snapshot whose runtime behavior is governed strictly by the
+        // active policy + binding set, with no override surface.
+        List<BundleOverrideEntry> overrides;
+        if (includeOverrides)
+        {
+            var approvedRows = await _db.Overrides
+                .AsNoTracking()
+                .Where(o => o.State == OverrideState.Approved)
+                .Select(o => new
+                {
+                    o.Id,
+                    o.PolicyVersionId,
+                    o.ScopeKind,
+                    o.ScopeRef,
+                    o.Effect,
+                    o.ReplacementPolicyVersionId,
+                    o.ExpiresAt,
+                })
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+            overrides = approvedRows
+                .Where(o => o.ExpiresAt > capturedAt)
+                .OrderBy(o => o.Id)
+                .Select(o => new BundleOverrideEntry(
+                    o.Id,
+                    o.PolicyVersionId,
+                    o.ScopeKind.ToString(),
+                    o.ScopeRef,
+                    o.Effect.ToString(),
+                    o.ReplacementPolicyVersionId,
+                    o.ExpiresAt))
+                .ToList();
+        }
+        else
+        {
+            overrides = new List<BundleOverrideEntry>();
+        }
 
         // Scope tree: every node, ordered by Id. Consumers reconstruct
         // the hierarchy via ParentId; the snapshot does not pre-build

--- a/tests/Andy.Policies.Tests.Unit/Services/BundleServiceValidationTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/BundleServiceValidationTests.cs
@@ -23,7 +23,10 @@ public class BundleServiceValidationTests
 {
     private sealed class ThrowingBuilder : IBundleSnapshotBuilder
     {
-        public Task<BundleSnapshot> BuildAsync(DateTimeOffset capturedAt, CancellationToken ct = default)
+        public Task<BundleSnapshot> BuildAsync(
+            DateTimeOffset capturedAt,
+            bool includeOverrides = true,
+            CancellationToken ct = default)
             => throw new InvalidOperationException(
                 "BundleSnapshotBuilder must not be invoked when validation fails.");
     }

--- a/tests/Andy.Policies.Tests.Unit/Services/BundleSnapshotBuilderTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/BundleSnapshotBuilderTests.cs
@@ -192,6 +192,41 @@ public class BundleSnapshotBuilderTests
     }
 
     [Fact]
+    public async Task Build_WithIncludeOverridesFalse_EmitsEmptyOverridesList()
+    {
+        // P9 follow-up #205 (2026-05-07): when CreateBundleRequest sets
+        // IncludeOverrides=false, the builder must skip the override
+        // scan even if Approved+non-expired rows exist. Used by
+        // compliance/immutability bundles whose runtime behaviour is
+        // governed strictly by the active policy + binding set.
+        await using var db = NewDb();
+        var (_, versionId) = await SeedPolicyVersionAsync(db);
+        db.Overrides.Add(new Override
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = versionId,
+            ScopeKind = OverrideScopeKind.Principal,
+            ScopeRef = "user:would-be-included",
+            Effect = OverrideEffect.Exempt,
+            State = OverrideState.Approved,
+            ExpiresAt = Now.AddDays(7),
+            ProposerSubjectId = "alice",
+            Rationale = "live",
+            ProposedAt = Now.AddDays(-1),
+        });
+        await db.SaveChangesAsync();
+
+        var snapshot = await new BundleSnapshotBuilder(db)
+            .BuildAsync(Now, includeOverrides: false);
+
+        snapshot.Overrides.Should().BeEmpty(
+            "IncludeOverrides=false elides the override scan entirely");
+        // Sanity check: policies + scopes still load — the flag only
+        // affects the override slice.
+        snapshot.Policies.Should().NotBeEmpty();
+    }
+
+    [Fact]
     public async Task Build_OrdersCollectionsStably()
     {
         await using var db = NewDb();


### PR DESCRIPTION
## Summary

\`CreateBundleRequest\` gains an opt-out for overrides. Default unchanged (true → continue to include the Approved + non-expired override set). When false, the snapshot's overrides slice is emitted as an empty list — useful for compliance / immutability bundles whose runtime behaviour is governed strictly by the active policy + binding set.

\`IBundleSnapshotBuilder.BuildAsync\` carries the flag through; the builder elides the override scan entirely (the most expensive part of the build for catalogs with large Approved sets).

## Test plan

- [x] New unit test \`Build_WithIncludeOverridesFalse_EmitsEmptyOverridesList\` pins the elision.
- [x] Existing 8 builder tests continue to pass with the default-true semantics.
- [x] Full \`dotnet test\` — only failure is the known-flaky \`BundlePerfTests.Create_p95_StaysUnderBudget\`.
- [x] OpenAPI export refreshed.

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)