### PR TITLE
Add bulk bundle contents tree endpoint (#204)

### DIFF
--- a/docs/openapi/andy-policies-v1.yaml
+++ b/docs/openapi/andy-policies-v1.yaml
@@ -650,6 +650,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
+  '/api/bundles/{id}/contents':
+    get:
+      tags:
+        - Bundles
+      summary: "P9 follow-up #204 (2026-05-07) — bulk contents tree for the\r\nfrozen-tree view in the bundle detail page. Returns every\r\npolicy in the snapshot with its bindings nested underneath,\r\nplus a flat list of overrides. Same ETag / Cache-Control\r\nposture as the other snapshot-backed reads (immutable, max-age\r\n= 1y) since the response body is bound to a specific snapshot\r\nhash. Returns 404 when the bundle is missing / soft-deleted."
+      operationId: Bundles_Contents
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BundleContentsDto'
+        '304':
+          description: Not Modified
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
   '/api/bundles/{id}/diff':
     get:
       tags:
@@ -2092,6 +2132,118 @@ components:
         - Tenant
         - Org
       type: string
+    BundleContentsBindingDto:
+      type: object
+      properties:
+        bindingId:
+          type: string
+          format: uuid
+        targetType:
+          type: string
+          nullable: true
+        targetRef:
+          type: string
+          nullable: true
+        bindStrength:
+          type: string
+          nullable: true
+      additionalProperties: false
+    BundleContentsDto:
+      type: object
+      properties:
+        bundleId:
+          type: string
+          format: uuid
+        bundleName:
+          type: string
+          nullable: true
+        snapshotHash:
+          type: string
+          nullable: true
+        capturedAt:
+          type: string
+          format: date-time
+        policies:
+          type: array
+          items:
+            $ref: '#/components/schemas/BundleContentsPolicyDto'
+          nullable: true
+        overrides:
+          type: array
+          items:
+            $ref: '#/components/schemas/BundleContentsOverrideDto'
+          nullable: true
+      additionalProperties: false
+      description: "Denormalised contents view of a frozen bundle (P9 follow-up #204,\r\n2026-05-07). Consumers (the bundle detail page) render this as a\r\ntree: policies grouped by name, each expandable to its bindings,\r\nplus a flat list of overrides. `SnapshotHash` is the same\r\nstrong validator the resolution endpoints emit so callers can\r\nshare an HTTP cache between this endpoint and `/resolve`."
+    BundleContentsOverrideDto:
+      type: object
+      properties:
+        overrideId:
+          type: string
+          format: uuid
+        policyVersionId:
+          type: string
+          format: uuid
+        scopeKind:
+          type: string
+          nullable: true
+        scopeRef:
+          type: string
+          nullable: true
+        effect:
+          type: string
+          nullable: true
+        replacementPolicyVersionId:
+          type: string
+          format: uuid
+          nullable: true
+        expiresAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+    BundleContentsPolicyDto:
+      type: object
+      properties:
+        policyId:
+          type: string
+          format: uuid
+        name:
+          type: string
+          nullable: true
+        policyVersionId:
+          type: string
+          format: uuid
+        version:
+          type: integer
+          format: int32
+        enforcement:
+          enum:
+            - MUST
+            - SHOULD
+            - MAY
+          type: string
+          nullable: true
+        severity:
+          enum:
+            - info
+            - moderate
+            - critical
+          type: string
+          nullable: true
+        scopes:
+          type: array
+          items:
+            type: string
+          nullable: true
+        summary:
+          type: string
+          nullable: true
+        bindings:
+          type: array
+          items:
+            $ref: '#/components/schemas/BundleContentsBindingDto'
+          nullable: true
+      additionalProperties: false
     BundleDiffResult:
       type: object
       properties:

--- a/src/Andy.Policies.Api/Controllers/BundlesController.cs
+++ b/src/Andy.Policies.Api/Controllers/BundlesController.cs
@@ -226,6 +226,36 @@ public sealed class BundlesController : ControllerBase
     }
 
     /// <summary>
+    /// P9 follow-up #204 (2026-05-07) — bulk contents tree for the
+    /// frozen-tree view in the bundle detail page. Returns every
+    /// policy in the snapshot with its bindings nested underneath,
+    /// plus a flat list of overrides. Same ETag / Cache-Control
+    /// posture as the other snapshot-backed reads (immutable, max-age
+    /// = 1y) since the response body is bound to a specific snapshot
+    /// hash. Returns 404 when the bundle is missing / soft-deleted.
+    /// </summary>
+    [HttpGet("{id:guid}/contents")]
+    [Authorize(Policy = "andy-policies:bundle:read")]
+    [ProducesResponseType(typeof(BundleContentsDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status304NotModified)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Contents(Guid id, CancellationToken ct)
+    {
+        var dto = await _resolver.GetContentsAsync(id, ct);
+        if (dto is null) return NotFound();
+
+        if (TryReturnNotModified(dto.SnapshotHash, out var notModified))
+        {
+            return notModified;
+        }
+
+        SetSnapshotCacheHeaders(dto.SnapshotHash);
+        return Ok(dto);
+    }
+
+    /// <summary>
     /// Emit an RFC-6902 JSON Patch between two bundles' frozen
     /// snapshots (P8.6, story rivoli-ai/andy-policies#86). Returns
     /// 200 with a <see cref="BundleDiffResult"/>; 404 when either

--- a/src/Andy.Policies.Application/Interfaces/IBundleResolver.cs
+++ b/src/Andy.Policies.Application/Interfaces/IBundleResolver.cs
@@ -83,7 +83,69 @@ public interface IBundleResolver
     /// </remarks>
     Task<EffectivePolicySetDto?> ResolveEffectiveForScopeAsync(
         Guid bundleId, Guid scopeNodeId, CancellationToken ct = default);
+
+    /// <summary>
+    /// P9 follow-up #204 (2026-05-07): denormalised contents tree for the
+    /// frozen-tree view in the bundle detail page. Projects the parsed
+    /// snapshot into a policies-with-nested-bindings shape so the UI can
+    /// render <c>FrozenPolicyTreeComponent</c> in a single call instead
+    /// of fanning out to <c>GET /policies/{id}</c> per row. Returns
+    /// <c>null</c> when the bundle is missing / soft-deleted.
+    /// </summary>
+    /// <remarks>
+    /// Bindings are grouped by their <c>PolicyVersionId</c>; an empty
+    /// nested list is allowed (a policy may be in the bundle without
+    /// any bindings, e.g. the seed policy of a fresh bundle).
+    /// Wire casing matches the live surfaces — <c>Enforcement</c>
+    /// uppercase, <c>Severity</c> lowercase, per ADR 0001 §6.
+    /// <c>RulesJson</c> is intentionally omitted — fetch the per-policy
+    /// detail at <c>GET /api/bundles/{id}/policies/{policyId}</c> when
+    /// the rule body is needed.
+    /// </remarks>
+    Task<BundleContentsDto?> GetContentsAsync(Guid bundleId, CancellationToken ct = default);
 }
+
+/// <summary>
+/// Denormalised contents view of a frozen bundle (P9 follow-up #204,
+/// 2026-05-07). Consumers (the bundle detail page) render this as a
+/// tree: policies grouped by name, each expandable to its bindings,
+/// plus a flat list of overrides. <c>SnapshotHash</c> is the same
+/// strong validator the resolution endpoints emit so callers can
+/// share an HTTP cache between this endpoint and <c>/resolve</c>.
+/// </summary>
+public sealed record BundleContentsDto(
+    Guid BundleId,
+    string BundleName,
+    string SnapshotHash,
+    DateTimeOffset CapturedAt,
+    IReadOnlyList<BundleContentsPolicyDto> Policies,
+    IReadOnlyList<BundleContentsOverrideDto> Overrides);
+
+public sealed record BundleContentsPolicyDto(
+    Guid PolicyId,
+    string Name,
+    Guid PolicyVersionId,
+    int Version,
+    string Enforcement,
+    string Severity,
+    IReadOnlyList<string> Scopes,
+    string Summary,
+    IReadOnlyList<BundleContentsBindingDto> Bindings);
+
+public sealed record BundleContentsBindingDto(
+    Guid BindingId,
+    string TargetType,
+    string TargetRef,
+    string BindStrength);
+
+public sealed record BundleContentsOverrideDto(
+    Guid OverrideId,
+    Guid PolicyVersionId,
+    string ScopeKind,
+    string ScopeRef,
+    string Effect,
+    Guid? ReplacementPolicyVersionId,
+    DateTimeOffset ExpiresAt);
 
 /// <summary>
 /// View of a bundle row + its parsed snapshot (P8.4, #84). Carries

--- a/src/Andy.Policies.Infrastructure/Services/BundleResolver.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BundleResolver.cs
@@ -274,6 +274,69 @@ public sealed class BundleResolver : IBundleResolver
             Summary: policy.Summary);
     }
 
+    public async Task<BundleContentsDto?> GetContentsAsync(
+        Guid bundleId, CancellationToken ct = default)
+    {
+        var carrier = await LoadAsync(bundleId, ct).ConfigureAwait(false);
+        if (carrier is null)
+        {
+            return null;
+        }
+
+        // Group bindings by PolicyVersionId so each policy node carries
+        // its own bindings. Snapshot bindings are already deterministically
+        // ordered (P8.2 sort by BindingId asc); preserve that order
+        // inside each group so the wire is stable across calls.
+        var bindingsByVersionId = carrier.Snapshot.Bindings
+            .GroupBy(b => b.PolicyVersionId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        var policies = carrier.Snapshot.Policies
+            .OrderBy(p => p.Name, StringComparer.Ordinal)
+            .ThenByDescending(p => p.Version)
+            .Select(p =>
+            {
+                bindingsByVersionId.TryGetValue(p.PolicyVersionId, out var rows);
+                var bindingDtos = (rows ?? new List<BundleBindingEntry>())
+                    .Select(b => new BundleContentsBindingDto(
+                        BindingId: b.BindingId,
+                        TargetType: b.TargetType,
+                        TargetRef: b.TargetRef,
+                        BindStrength: b.BindStrength))
+                    .ToList();
+                return new BundleContentsPolicyDto(
+                    PolicyId: p.PolicyId,
+                    Name: p.Name,
+                    PolicyVersionId: p.PolicyVersionId,
+                    Version: p.Version,
+                    Enforcement: ToEnforcementWire(p.Enforcement),
+                    Severity: ToSeverityWire(p.Severity),
+                    Scopes: p.Scopes,
+                    Summary: p.Summary,
+                    Bindings: bindingDtos);
+            })
+            .ToList();
+
+        var overrides = carrier.Snapshot.Overrides
+            .Select(o => new BundleContentsOverrideDto(
+                OverrideId: o.OverrideId,
+                PolicyVersionId: o.PolicyVersionId,
+                ScopeKind: o.ScopeKind,
+                ScopeRef: o.ScopeRef,
+                Effect: o.Effect,
+                ReplacementPolicyVersionId: o.ReplacementPolicyVersionId,
+                ExpiresAt: o.ExpiresAt))
+            .ToList();
+
+        return new BundleContentsDto(
+            BundleId: carrier.Id,
+            BundleName: carrier.Name,
+            SnapshotHash: carrier.SnapshotHash,
+            CapturedAt: carrier.Snapshot.CapturedAt,
+            Policies: policies,
+            Overrides: overrides);
+    }
+
     /// <summary>
     /// Load the bundle row + parsed snapshot. Returns <c>null</c>
     /// when the bundle is missing or soft-deleted. The parsed

--- a/tests/Andy.Policies.Tests.Integration/Controllers/BundlesControllerTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/BundlesControllerTests.cs
@@ -316,4 +316,80 @@ public class BundlesControllerTests : IClassFixture<PoliciesApiFactory>
 
         resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
+
+    // ---- P9 follow-up #204 — bulk contents tree ----------------------
+
+    [Fact]
+    public async Task GetContents_HappyPath_ReturnsTreeWithBindingsNestedUnderPolicy()
+    {
+        var (bundleId, hash, policyId, policyVersionId) = await SeedActiveBundleAsync(
+            $"snap-{Guid.NewGuid():N}".Substring(0, 16),
+            $"p-{Guid.NewGuid():N}".Substring(0, 12),
+            "repo:rivoli-ai/contents");
+
+        var resp = await _client.GetAsync($"/api/bundles/{bundleId}/contents");
+        resp.EnsureSuccessStatusCode();
+
+        resp.Headers.ETag!.Tag.Should().Be($"\"{hash}\"",
+            "the contents endpoint shares the snapshot-hash strong validator with /resolve and /policies/{id}");
+
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        body.GetProperty("bundleId").GetGuid().Should().Be(bundleId);
+        body.GetProperty("snapshotHash").GetString().Should().Be(hash);
+
+        // The shared-factory DB carries leftover policies from sibling
+        // tests, so locate this test's policy by id rather than asserting
+        // count==1. The shape and casing are the load-bearing assertions.
+        var policyNode = body.GetProperty("policies").EnumerateArray()
+            .First(p => p.GetProperty("policyId").GetGuid() == policyId);
+        policyNode.GetProperty("policyVersionId").GetGuid().Should().Be(policyVersionId);
+        policyNode.GetProperty("enforcement").GetString().Should().Be("SHOULD",
+            "wire casing is uppercase per ADR 0001 §6");
+        policyNode.GetProperty("severity").GetString().Should().Be("moderate");
+
+        var bindingNode = policyNode.GetProperty("bindings").EnumerateArray()
+            .Single(b => b.GetProperty("targetRef").GetString() == "repo:rivoli-ai/contents");
+        bindingNode.GetProperty("targetType").GetString().Should().Be("Repo");
+        bindingNode.GetProperty("bindStrength").GetString().Should().Be("Mandatory");
+    }
+
+    [Fact]
+    public async Task GetContents_IfNoneMatchMatchesSnapshotHash_Returns304()
+    {
+        var (bundleId, hash, _, _) = await SeedActiveBundleAsync(
+            $"snap-{Guid.NewGuid():N}".Substring(0, 16),
+            $"p-{Guid.NewGuid():N}".Substring(0, 12),
+            "repo:rivoli-ai/x");
+
+        var req = new HttpRequestMessage(HttpMethod.Get, $"/api/bundles/{bundleId}/contents");
+        req.Headers.IfNoneMatch.Add(new EntityTagHeaderValue($"\"{hash}\""));
+        var resp = await _client.SendAsync(req);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotModified);
+    }
+
+    [Fact]
+    public async Task GetContents_OnUnknownBundleId_Returns404()
+    {
+        var resp = await _client.GetAsync($"/api/bundles/{Guid.NewGuid()}/contents");
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetContents_OnSoftDeletedBundle_Returns404()
+    {
+        var (bundleId, _, _, _) = await SeedActiveBundleAsync(
+            $"snap-{Guid.NewGuid():N}".Substring(0, 16),
+            $"p-{Guid.NewGuid():N}".Substring(0, 12),
+            "repo:rivoli-ai/x");
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var bundles = scope.ServiceProvider.GetRequiredService<IBundleService>();
+            await bundles.SoftDeleteAsync(bundleId, "seed", "tombstone", CancellationToken.None);
+        }
+
+        var resp = await _client.GetAsync($"/api/bundles/{bundleId}/contents");
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
 }


### PR DESCRIPTION
## Summary
- New `GET /api/bundles/{id}/contents` returns the full denormalised tree the bundle detail page needs: every policy in the snapshot with its bindings nested underneath, plus a flat list of overrides.
- Removes the N+1 fanout to `/policies/{policyId}` that the frozen-tree view would otherwise need.
- Projected from the parsed `BundleSnapshot` via `IBundleResolver` — reuses the existing 5-min snapshot cache keyed by `(bundleId, snapshotHash)`.
- ETag + `Cache-Control: public, max-age=31536000, immutable` mirror the other snapshot-backed reads. `If-None-Match` short-circuits to 304.
- `RulesJson` intentionally omitted (fetch per-policy detail when needed); enforcement uppercase, severity lowercase per ADR 0001 §6.

## Test plan
- [x] `dotnet build` clean
- [x] 4 new integration tests cover happy path + 304 + 404 (unknown bundle, soft-deleted bundle)
- [x] Full integration suite — 621/621 passed
- [x] OpenAPI export refreshed

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)