### PR TITLE
Add Reject endpoint for Override state machine (#201)

### DIFF
--- a/config/rbac-seed.json
+++ b/config/rbac-seed.json
@@ -24,6 +24,7 @@
     { "code": "andy-policies:override:propose",  "name": "Propose an override",      "resourceType": "override" },
     { "code": "andy-policies:override:approve",  "name": "Approve an override",      "resourceType": "override" },
     { "code": "andy-policies:override:revoke",   "name": "Revoke an override",       "resourceType": "override" },
+    { "code": "andy-policies:override:reject",   "name": "Reject a proposal",        "resourceType": "override" },
     { "code": "andy-policies:bundle:read",       "name": "Read bundles",             "resourceType": "bundle"   },
     { "code": "andy-policies:bundle:create",     "name": "Create a bundle",          "resourceType": "bundle"   },
     { "code": "andy-policies:bundle:delete",     "name": "Soft-delete a bundle",     "resourceType": "bundle"   },
@@ -70,6 +71,7 @@
         "andy-policies:override:read",
         "andy-policies:override:approve",
         "andy-policies:override:revoke",
+        "andy-policies:override:reject",
         "andy-policies:bundle:read",
         "andy-policies:bundle:create",
         "andy-policies:audit:read"

--- a/config/registration.json
+++ b/config/registration.json
@@ -77,6 +77,7 @@
       { "code": "andy-policies:override:propose",  "name": "Propose an override",      "resourceType": "override" },
       { "code": "andy-policies:override:approve",  "name": "Approve an override",      "resourceType": "override" },
       { "code": "andy-policies:override:revoke",   "name": "Revoke an override",       "resourceType": "override" },
+      { "code": "andy-policies:override:reject",   "name": "Reject a proposal",        "resourceType": "override" },
       { "code": "andy-policies:bundle:read",       "name": "Read bundles",             "resourceType": "bundle"   },
       { "code": "andy-policies:bundle:create",     "name": "Create a bundle",          "resourceType": "bundle"   },
       { "code": "andy-policies:bundle:delete",     "name": "Soft-delete a bundle",     "resourceType": "bundle"   },
@@ -123,6 +124,7 @@
           "andy-policies:override:read",
           "andy-policies:override:approve",
           "andy-policies:override:revoke",
+          "andy-policies:override:reject",
           "andy-policies:bundle:read",
           "andy-policies:bundle:create",
           "andy-policies:audit:read"

--- a/docs/openapi/andy-policies-v1.yaml
+++ b/docs/openapi/andy-policies-v1.yaml
@@ -1170,6 +1170,74 @@ paths:
         - validation_failed
         - not_found
         - invalid_state
+  '/api/overrides/{id}/reject':
+    post:
+      tags:
+        - Overrides
+      summary: "Reject a `Proposed` override (P9 follow-up #201,\r\n2026-05-07). Terminates a proposal before it ever takes effect;\r\ndistinct from `revoke` which is the operator-initiated\r\nterminal path for already-approved rows. Returns 409 if the\r\nrow is past `Proposed`; 404 on unknown id."
+      operationId: Overrides_Reject
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RejectOverrideRequest'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/RejectOverrideRequest'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/RejectOverrideRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OverrideDto'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+      x-error-codes:
+        - override.disabled
+        - override.self_approval_forbidden
+        - rbac.denied
+        - validation_failed
+        - not_found
+        - invalid_state
   '/api/overrides/{id}':
     get:
       tags:
@@ -2747,6 +2815,7 @@ components:
         - Approved
         - Revoked
         - Expired
+        - Rejected
       type: string
     PolicyDto:
       type: object
@@ -2879,6 +2948,14 @@ components:
           nullable: true
       additionalProperties: false
       description: "Request payload for `IOverrideService.ProposeAsync` (P5.2,\r\nstory rivoli-ai/andy-policies#52). The service validates that\r\nAndy.Policies.Application.Dtos.ProposeOverrideRequest.Effect matches the presence of\r\nAndy.Policies.Application.Dtos.ProposeOverrideRequest.ReplacementPolicyVersionId: `Replace` requires\r\nnon-null, `Exempt` requires null. Both\r\nAndy.Policies.Application.Dtos.ProposeOverrideRequest.PolicyVersionId and (if present)\r\nAndy.Policies.Application.Dtos.ProposeOverrideRequest.ReplacementPolicyVersionId must reference an\r\nexisting `PolicyVersion`."
+    RejectOverrideRequest:
+      type: object
+      properties:
+        rejectionReason:
+          type: string
+          nullable: true
+      additionalProperties: false
+      description: "Request payload for `IOverrideService.RejectAsync` (P9 follow-up\r\n#201, 2026-05-07). The reason is required and persisted to\r\n`Override.RevocationReason` — the column is reused so the audit\r\nchain can record the human-readable cause regardless of which\r\nterminal state was reached. The Andy.Policies.Application.Dtos.RejectOverrideRequest.RejectionReason\r\nalias makes the intent explicit on the wire."
     ResolveBindingsResponse:
       type: object
       properties:

--- a/docs/reference/permission-catalog.md
+++ b/docs/reference/permission-catalog.md
@@ -32,6 +32,7 @@ Application code: `andy-policies`
 | `andy-policies:override:propose` | Propose an override | `override` |
 | `andy-policies:override:approve` | Approve an override | `override` |
 | `andy-policies:override:revoke` | Revoke an override | `override` |
+| `andy-policies:override:reject` | Reject a proposal | `override` |
 | `andy-policies:bundle:read` | Read bundles | `bundle` |
 | `andy-policies:bundle:create` | Create a bundle | `bundle` |
 | `andy-policies:bundle:delete` | Soft-delete a bundle | `bundle` |
@@ -45,12 +46,12 @@ Application code: `andy-policies`
 |------|------|-------------|-------------|
 | `admin` | Administrator | Full access: author, publish, transition, edit bindings, manage overrides. | `*` (all permissions) |
 | `author` | Policy Author | May author drafts and propose publish; cannot approve own publishes. | `andy-policies:policy:read`, `andy-policies:policy:author`, `andy-policies:binding:read`, `andy-policies:scope:read`, `andy-policies:override:read`, `andy-policies:override:propose`, `andy-policies:bundle:read`, `andy-policies:audit:read` |
-| `approver` | Publish Approver | Approves transitions of drafts to active versions. | `andy-policies:policy:read`, `andy-policies:policy:publish`, `andy-policies:policy:transition`, `andy-policies:binding:read`, `andy-policies:binding:manage`, `andy-policies:scope:read`, `andy-policies:override:read`, `andy-policies:override:approve`, `andy-policies:override:revoke`, `andy-policies:bundle:read`, `andy-policies:bundle:create`, `andy-policies:audit:read` |
+| `approver` | Publish Approver | Approves transitions of drafts to active versions. | `andy-policies:policy:read`, `andy-policies:policy:publish`, `andy-policies:policy:transition`, `andy-policies:binding:read`, `andy-policies:binding:manage`, `andy-policies:scope:read`, `andy-policies:override:read`, `andy-policies:override:approve`, `andy-policies:override:revoke`, `andy-policies:override:reject`, `andy-policies:bundle:read`, `andy-policies:bundle:create`, `andy-policies:audit:read` |
 | `risk` | Risk / Compliance | Read-all plus audit-export. | `andy-policies:policy:read`, `andy-policies:binding:read`, `andy-policies:scope:read`, `andy-policies:override:read`, `andy-policies:bundle:read`, `andy-policies:audit:read`, `andy-policies:audit:export`, `andy-policies:audit:verify` |
 | `viewer` | Viewer | Read-only access to active policies and public audit trail. | `andy-policies:policy:read`, `andy-policies:binding:read`, `andy-policies:scope:read`, `andy-policies:override:read`, `andy-policies:bundle:read` |
 
 ## Counts
 
 - Resource types: 7
-- Permissions: 18
+- Permissions: 19
 - Roles: 5

--- a/src/Andy.Policies.Api/Controllers/OverridesController.cs
+++ b/src/Andy.Policies.Api/Controllers/OverridesController.cs
@@ -131,6 +131,33 @@ public sealed class OverridesController : ControllerBase
     }
 
     /// <summary>
+    /// Reject a <c>Proposed</c> override (P9 follow-up #201,
+    /// 2026-05-07). Terminates a proposal before it ever takes effect;
+    /// distinct from <c>revoke</c> which is the operator-initiated
+    /// terminal path for already-approved rows. Returns 409 if the
+    /// row is past <c>Proposed</c>; 404 on unknown id.
+    /// </summary>
+    [HttpPost("{id:guid}/reject")]
+    [Authorize(Policy = "andy-policies:override:reject")]
+    [OverrideWriteGate]
+    [ProducesResponseType(typeof(OverrideDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<OverrideDto>> Reject(
+        Guid id,
+        [FromBody] RejectOverrideRequest request,
+        CancellationToken ct)
+    {
+        var subject = ResolveSubjectId();
+        if (subject is null) return Unauthorized();
+
+        return Ok(await _service.RejectAsync(id, request, subject, ct));
+    }
+
+    /// <summary>
     /// List overrides matching the optional filter. Returns rows in
     /// any state; use <c>state=Approved</c> for the live set or
     /// <c>GET /api/overrides/active</c> for the

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -66,6 +66,7 @@ string[] rbacPermissionCodes =
     "andy-policies:scope:read",         "andy-policies:scope:manage",
     "andy-policies:override:read",      "andy-policies:override:propose",
     "andy-policies:override:approve",   "andy-policies:override:revoke",
+    "andy-policies:override:reject",
     "andy-policies:bundle:read",        "andy-policies:bundle:create",
     "andy-policies:bundle:delete",      "andy-policies:audit:read",
     "andy-policies:audit:export",       "andy-policies:audit:verify",

--- a/src/Andy.Policies.Application/Dtos/RejectOverrideRequest.cs
+++ b/src/Andy.Policies.Application/Dtos/RejectOverrideRequest.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.Dtos;
+
+/// <summary>
+/// Request payload for <c>IOverrideService.RejectAsync</c> (P9 follow-up
+/// #201, 2026-05-07). The reason is required and persisted to
+/// <c>Override.RevocationReason</c> — the column is reused so the audit
+/// chain can record the human-readable cause regardless of which
+/// terminal state was reached. The <see cref="RejectionReason"/>
+/// alias makes the intent explicit on the wire.
+/// </summary>
+public sealed record RejectOverrideRequest(string RejectionReason);

--- a/src/Andy.Policies.Application/Events/OverrideEvents.cs
+++ b/src/Andy.Policies.Application/Events/OverrideEvents.cs
@@ -47,6 +47,19 @@ public sealed record OverrideRevoked(
     DateTimeOffset At);
 
 /// <summary>
+/// Emitted in-process when an <c>Override</c> in <c>Proposed</c> is
+/// explicitly rejected before approval (P9 follow-up #201,
+/// 2026-05-07). Distinct from <see cref="OverrideRevoked"/> so audit
+/// can tell "never approved" from "was approved, then pulled".
+/// </summary>
+public sealed record OverrideRejected(
+    Guid OverrideId,
+    Guid PolicyVersionId,
+    string ActorSubjectId,
+    string Reason,
+    DateTimeOffset At);
+
+/// <summary>
 /// Emitted in-process when <c>OverrideExpiryReaper</c> transitions an
 /// approved <c>Override</c> past <c>ExpiresAt</c> to
 /// <see cref="OverrideState.Expired"/> (P5.3, story

--- a/src/Andy.Policies.Application/Interfaces/IOverrideService.cs
+++ b/src/Andy.Policies.Application/Interfaces/IOverrideService.cs
@@ -51,6 +51,28 @@ public interface IOverrideService
         CancellationToken ct = default);
 
     /// <summary>
+    /// Reject a <c>Proposed</c> override (P9 follow-up #201, 2026-05-07).
+    /// Distinct from <see cref="RevokeAsync"/>: rejection only fires
+    /// from <c>Proposed</c>, terminating the proposal before it ever
+    /// took effect; revocation fires from <c>Approved</c> (and
+    /// continues to accept <c>Proposed</c> for backward compat). The
+    /// audit trail can therefore distinguish "this proposal was
+    /// declined" from "this active override was pulled". Self-rejection
+    /// is allowed — proposers may withdraw their own proposals.
+    /// </summary>
+    /// <exception cref="Andy.Policies.Application.Exceptions.NotFoundException">
+    /// No row matches <paramref name="id"/>.</exception>
+    /// <exception cref="Andy.Policies.Application.Exceptions.ValidationException">
+    /// Empty or oversized rejection reason.</exception>
+    /// <exception cref="Andy.Policies.Application.Exceptions.ConflictException">
+    /// Row is not in <see cref="OverrideState.Proposed"/>.</exception>
+    Task<OverrideDto> RejectAsync(
+        Guid id,
+        RejectOverrideRequest request,
+        string actorSubjectId,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// System-only transition: moves an <c>Approved</c> override past
     /// its <c>ExpiresAt</c> into <see cref="OverrideState.Expired"/>.
     /// Called exclusively by <c>OverrideExpiryReaper</c> (P5.3,

--- a/src/Andy.Policies.Domain/Enums/OverrideState.cs
+++ b/src/Andy.Policies.Domain/Enums/OverrideState.cs
@@ -5,7 +5,7 @@ namespace Andy.Policies.Domain.Enums;
 
 /// <summary>
 /// Lifecycle state of an <see cref="Entities.Override"/> (P5.1,
-/// story rivoli-ai/andy-policies#49). The four-state machine:
+/// story rivoli-ai/andy-policies#49). Five-state machine:
 /// <list type="bullet">
 ///   <item><see cref="Proposed"/> — created by an author; awaiting
 ///     approver. <c>ApproverSubjectId</c> + <c>ApprovedAt</c> are
@@ -19,6 +19,12 @@ namespace Andy.Policies.Domain.Enums;
 ///   <item><see cref="Expired"/> — the reaper (P5.3) flipped the
 ///     row when <c>ExpiresAt</c> passed; transition is automatic
 ///     and irreversible.</item>
+///   <item><see cref="Rejected"/> — explicitly rejected by an
+///     approver while still in <c>Proposed</c> (P9 follow-up #201,
+///     2026-05-07). Distinct from <see cref="Revoked"/> so the audit
+///     chain can tell "never approved" from "was approved, then
+///     pulled". Carries a non-null <c>RevocationReason</c> (reused
+///     column — the rejection reason lives there).</item>
 /// </list>
 /// Persisted as <c>string</c> so the partial index
 /// <c>ix_overrides_expiry_approved</c> can filter on
@@ -31,4 +37,5 @@ public enum OverrideState
     Approved = 1,
     Revoked = 2,
     Expired = 3,
+    Rejected = 4,
 }

--- a/src/Andy.Policies.Infrastructure/Services/OverrideService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/OverrideService.cs
@@ -302,6 +302,75 @@ public sealed class OverrideService : IOverrideService
         return ToDto(ovr);
     }
 
+    public async Task<OverrideDto> RejectAsync(
+        Guid id,
+        RejectOverrideRequest request,
+        string actorSubjectId,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrEmpty(actorSubjectId);
+
+        var reason = (request.RejectionReason ?? string.Empty).Trim();
+        if (string.IsNullOrEmpty(reason))
+        {
+            throw new ValidationException("RejectionReason is required and may not be empty or whitespace.");
+        }
+        if (reason.Length > MaxRationaleLength)
+        {
+            throw new ValidationException(
+                $"RejectionReason length {reason.Length} exceeds the {MaxRationaleLength}-char limit.");
+        }
+
+        await using var transaction = await _db.Database
+            .BeginTransactionAsync(IsolationLevel.Serializable, ct)
+            .ConfigureAwait(false);
+
+        var ovr = await _db.Overrides
+            .FirstOrDefaultAsync(o => o.Id == id, ct)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException($"Override {id} not found.");
+
+        if (ovr.State != OverrideState.Proposed)
+        {
+            // Reject is the proposal-time termination only. Once
+            // approved, the operator-initiated terminal path is Revoke;
+            // once Expired/Revoked/Rejected the row is already terminal.
+            throw new ConflictException(
+                $"Override {id} is in state {ovr.State}; only Proposed overrides can be rejected.");
+        }
+
+        // RBAC: rejection is a separate permission so admins can
+        // delegate "review proposals" without granting full revoke
+        // authority over already-approved overrides.
+        var rbacResult = await _rbac.CheckAsync(
+            actorSubjectId,
+            permissionCode: "andy-policies:override:reject",
+            groups: Array.Empty<string>(),
+            resourceInstanceId: ovr.ScopeRef,
+            ct).ConfigureAwait(false);
+        if (!rbacResult.Allowed)
+        {
+            throw new RbacDeniedException(
+                actorSubjectId, "andy-policies:override:reject", ovr.ScopeRef, rbacResult.Reason);
+        }
+
+        var now = _clock.GetUtcNow();
+        ovr.State = OverrideState.Rejected;
+        ovr.RevocationReason = reason;
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
+
+        await _events.DispatchAsync(new OverrideRejected(
+            OverrideId: ovr.Id,
+            PolicyVersionId: ovr.PolicyVersionId,
+            ActorSubjectId: actorSubjectId,
+            Reason: reason,
+            At: now), ct).ConfigureAwait(false);
+
+        return ToDto(ovr);
+    }
+
     public async Task<OverrideDto> ExpireAsync(Guid id, CancellationToken ct = default)
     {
         await using var transaction = await _db.Database

--- a/tests/Andy.Policies.Tests.Integration/Api/OverridesControllerTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Api/OverridesControllerTests.cs
@@ -330,6 +330,77 @@ public class OverridesControllerTests : IDisposable
         dto.RevocationReason.Should().Be("withdrawn");
     }
 
+    // ----- Reject (P9 follow-up #201, 2026-05-07) ---------------------
+
+    [Fact]
+    public async Task Reject_HappyPath_FromProposed_Returns200_WithRejectedState()
+    {
+        var client = Client;
+        var version = await CreateActivePolicyVersionAsync(client, Slug("ovr-rj1"));
+        var proposeResp = await client.PostAsJsonAsync("/api/overrides", ExemptRequest(version.Id));
+        proposeResp.EnsureSuccessStatusCode();
+        var proposed = (await proposeResp.Content.ReadFromJsonAsync<OverrideDto>(JsonOptions))!;
+
+        var resp = await client.PostAsJsonAsync(
+            $"/api/overrides/{proposed.Id}/reject", new RejectOverrideRequest("policy mismatch"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await resp.Content.ReadFromJsonAsync<OverrideDto>(JsonOptions);
+        dto!.State.Should().Be(OverrideState.Rejected);
+        dto.RevocationReason.Should().Be("policy mismatch");
+    }
+
+    [Fact]
+    public async Task Reject_BlankReason_Returns400()
+    {
+        var client = Client;
+        var version = await CreateActivePolicyVersionAsync(client, Slug("ovr-rj2"));
+        var proposeResp = await client.PostAsJsonAsync("/api/overrides", ExemptRequest(version.Id));
+        proposeResp.EnsureSuccessStatusCode();
+        var proposed = (await proposeResp.Content.ReadFromJsonAsync<OverrideDto>(JsonOptions))!;
+
+        var resp = await client.PostAsJsonAsync(
+            $"/api/overrides/{proposed.Id}/reject", new RejectOverrideRequest("   "));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Reject_FromApproved_Returns409()
+    {
+        var client = Client;
+        var version = await CreateActivePolicyVersionAsync(client, Slug("ovr-rj3"));
+        var proposeResp = await client.PostAsJsonAsync("/api/overrides", ExemptRequest(version.Id));
+        proposeResp.EnsureSuccessStatusCode();
+        var proposed = (await proposeResp.Content.ReadFromJsonAsync<OverrideDto>(JsonOptions))!;
+
+        // The integration fixture signs all HTTP requests as a single test
+        // user, so to land in Approved we drive the approve transition
+        // directly through the service (under a distinct subject id —
+        // self-approval is rejected before the RBAC stub is consulted).
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var svc = scope.ServiceProvider.GetRequiredService<IOverrideService>();
+            await svc.ApproveAsync(proposed.Id, "user:another-approver");
+        }
+
+        var resp = await client.PostAsJsonAsync(
+            $"/api/overrides/{proposed.Id}/reject", new RejectOverrideRequest("changed mind"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Reject_UnknownId_Returns404()
+    {
+        var client = Client;
+
+        var resp = await client.PostAsJsonAsync(
+            $"/api/overrides/{Guid.NewGuid()}/reject", new RejectOverrideRequest("nope"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
     [Fact]
     public async Task Get_UnknownId_Returns404()
     {

--- a/tests/Andy.Policies.Tests.Unit/Services/OverrideServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/OverrideServiceTests.cs
@@ -425,6 +425,94 @@ public class OverrideServiceTests
         row.RevocationReason.Should().BeNull();
     }
 
+    // ----- RejectAsync (P9 follow-up #201, 2026-05-07) ----------------
+
+    [Fact]
+    public async Task RejectAsync_FromProposed_TransitionsToRejectedAndDispatches()
+    {
+        var (svc, db, events, _, clock) = NewService();
+        var (_, version) = await SeedActiveAsync(db, "rj1");
+        var proposed = await svc.ProposeAsync(
+            ExemptRequest(version.Id, clock.GetUtcNow().AddDays(1)),
+            Proposer);
+
+        var rejected = await svc.RejectAsync(
+            proposed.Id, new RejectOverrideRequest("not justified"), Approver);
+
+        rejected.State.Should().Be(OverrideState.Rejected);
+        rejected.RevocationReason.Should().Be("not justified",
+            "the rejection reason reuses the RevocationReason column to keep the audit-relevant text in one place");
+        events.Events.OfType<OverrideRejected>().Should().ContainSingle();
+        events.Events.OfType<OverrideRevoked>().Should().BeEmpty(
+            "rejection emits OverrideRejected, not OverrideRevoked, so audit can distinguish the two terminal paths");
+    }
+
+    [Fact]
+    public async Task RejectAsync_BlankReason_ThrowsValidation()
+    {
+        var (svc, db, _, _, clock) = NewService();
+        var (_, version) = await SeedActiveAsync(db, "rj2");
+        var proposed = await svc.ProposeAsync(
+            ExemptRequest(version.Id, clock.GetUtcNow().AddDays(1)),
+            Proposer);
+
+        await FluentActions.Invoking(() => svc.RejectAsync(
+                proposed.Id, new RejectOverrideRequest("   "), Approver))
+            .Should().ThrowAsync<ValidationException>()
+            .WithMessage("*RejectionReason is required*");
+    }
+
+    [Fact]
+    public async Task RejectAsync_FromApproved_ThrowsConflict()
+    {
+        var (svc, db, _, _, clock) = NewService();
+        var (_, version) = await SeedActiveAsync(db, "rj3");
+        var proposed = await svc.ProposeAsync(
+            ExemptRequest(version.Id, clock.GetUtcNow().AddDays(1)),
+            Proposer);
+        await svc.ApproveAsync(proposed.Id, Approver);
+
+        await FluentActions.Invoking(() => svc.RejectAsync(
+                proposed.Id, new RejectOverrideRequest("too late"), Approver))
+            .Should().ThrowAsync<ConflictException>()
+            .WithMessage("*only Proposed overrides can be rejected*");
+    }
+
+    [Fact]
+    public async Task RejectAsync_RbacDenied_LeavesStateUnchanged()
+    {
+        var db = InMemoryDbFixture.Create();
+        var events = new RecordingDispatcher();
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 5, 7, 12, 0, 0, TimeSpan.Zero));
+
+        var allowingSvc = new OverrideService(db, new StubRbac { Allow = true }, events, clock);
+        var (_, version) = await SeedActiveAsync(db, "rj4");
+        var proposed = await allowingSvc.ProposeAsync(
+            ExemptRequest(version.Id, clock.GetUtcNow().AddDays(1)),
+            Proposer);
+
+        var denyingSvc = new OverrideService(db, new StubRbac { Allow = false }, events, clock);
+
+        await FluentActions.Invoking(() => denyingSvc.RejectAsync(
+                proposed.Id, new RejectOverrideRequest("nope"), "user:not-allowed"))
+            .Should().ThrowAsync<RbacDeniedException>();
+
+        var row = await db.Overrides.AsNoTracking().FirstAsync(o => o.Id == proposed.Id);
+        row.State.Should().Be(OverrideState.Proposed,
+            "an RBAC denial must not transition the row");
+        row.RevocationReason.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RejectAsync_UnknownId_ThrowsNotFound()
+    {
+        var (svc, _, _, _, _) = NewService();
+
+        await FluentActions.Invoking(() => svc.RejectAsync(
+                Guid.NewGuid(), new RejectOverrideRequest("missing"), Approver))
+            .Should().ThrowAsync<NotFoundException>();
+    }
+
     // ----- GetActiveAsync / ListAsync ---------------------------------
 
     [Fact]


### PR DESCRIPTION
## Summary
Adds the missing **Reject** transition to the Override state machine. Resolves the taxonomy ambiguity flagged in #201 — option 1 from the issue (a distinct `Rejected` state).

State machine grows to five states. New `Rejected = 4` is reachable only from `Proposed` — `Approved` overrides continue to terminate via Revoke. The `RevocationReason` column is reused so the audit-relevant text lives in one place regardless of which terminal state was reached. The audit chain can now tell "this proposal was declined" from "this active override was pulled."

### New surfaces
- `OverrideState.Rejected = 4`
- `RejectOverrideRequest { RejectionReason }` DTO
- `OverrideRejected` domain event
- `IOverrideService.RejectAsync` + `OverrideService.RejectAsync`
- `POST /api/overrides/{id}/reject` REST endpoint
- New RBAC permission `andy-policies:override:reject` (registered in `registration.json` + `rbac-seed.json` + `Program.cs`; granted to the `approver` role)

### Out of scope
- gRPC + MCP parity is intentionally deferred — REST is the surface the Angular follow-up (#200) consumes.
- Frontend Reject button on `OverridesManagerComponent` ships in a follow-up PR.

## Test plan
- [x] `dotnet build` clean
- [x] 5 new unit tests on `OverrideService.RejectAsync` (happy path, blank reason, conflict from Approved, RBAC denial leaves state unchanged, unknown id)
- [x] 4 new integration tests on `POST /api/overrides/{id}/reject` (happy path, 400 blank, 409 from Approved, 404 unknown)
- [x] Full integration suite — 621/621 (only known-flaky perf tests excluded)
- [x] `OverrideExpiryReaper` already filters `State == Approved`; Rejected rows are correctly skipped without changes
- [x] OpenAPI export refreshed
- [x] RBAC permission catalog regenerated

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)