### PR TITLE
Wire Monaco editor for the rules JSON field (#192)

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -22,7 +22,13 @@
             "browser": "src/main.ts",
             "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
-            "assets": [],
+            "assets": [
+              {
+                "glob": "**/*",
+                "input": "node_modules/monaco-editor/min/vs",
+                "output": "/assets/monaco/vs"
+              }
+            ],
             "styles": ["src/styles.scss"],
             "scripts": []
           },

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,6 +17,8 @@
         "@angular/platform-browser-dynamic": "^18.2.0",
         "@angular/router": "^18.2.0",
         "angular-auth-oidc-client": "^18.0.2",
+        "monaco-editor": "^0.50.0",
+        "ngx-monaco-editor-v2": "^18.1.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.10"
@@ -8733,6 +8735,12 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.50.0.tgz",
+      "integrity": "sha512-8CclLCmrRRh+sul7C08BmPBP3P8wVWfBHomsTcndxg5NRCEPfu/mc2AGU8k37ajjDVXcXFc12ORAMUkmk+lkFA==",
+      "license": "MIT"
+    },
     "node_modules/mrmime": {
       "version": "2.0.0",
       "dev": true,
@@ -8852,6 +8860,20 @@
       "version": "2.6.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ngx-monaco-editor-v2": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/ngx-monaco-editor-v2/-/ngx-monaco-editor-v2-18.1.0.tgz",
+      "integrity": "sha512-e/TaZ8lf8CauzVtPvKZhYLq8YKdZwCgbV23foDV2rMRTP2htFwmNUieJXetoqWjdZPmuqrMB3+PDZhrMvBGvug==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^18.1.0",
+        "@angular/core": "^18.1.0",
+        "monaco-editor": "^0.50.0"
+      }
     },
     "node_modules/nice-napi": {
       "version": "1.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,8 @@
     "@angular/platform-browser-dynamic": "^18.2.0",
     "@angular/router": "^18.2.0",
     "angular-auth-oidc-client": "^18.0.2",
+    "monaco-editor": "^0.50.0",
+    "ngx-monaco-editor-v2": "^18.1.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.10"

--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -4,6 +4,7 @@ import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { provideAuth } from 'angular-auth-oidc-client';
+import { provideMonacoEditor } from 'ngx-monaco-editor-v2';
 import { routes } from './app.routes';
 import { authInterceptor } from './core/interceptors/auth.interceptor';
 import { environment } from '../environments/environment';
@@ -25,6 +26,15 @@ export const appConfig: ApplicationConfig = {
         useRefreshToken: true,
         autoUserInfo: true,
       },
+    }),
+    // #192 — Monaco editor wraps the rules-JSON editor in PolicyEditor.
+    // Assets are copied into /assets/monaco/vs by angular.json's assets
+    // glob, so the AMD loader resolves modules from there at runtime.
+    // The editor itself is only instantiated when /policies/new or
+    // /policies/:id/versions/:vId/edit lazy-loads PolicyEditorComponent —
+    // the initial bundle stays unaffected.
+    provideMonacoEditor({
+      baseUrl: '/assets/monaco/vs',
     }),
   ],
 };

--- a/client/src/app/features/policies/policy-editor.component.html
+++ b/client/src/app/features/policies/policy-editor.component.html
@@ -106,13 +106,22 @@
 
       <label class="field rules">
         <span>Rules JSON</span>
-        <textarea
-          formControlName="rulesJson"
-          class="input rules-editor"
-          rows="14"
-          spellcheck="false"
-          autocomplete="off"
-          data-testid="rules"></textarea>
+        <!--
+          #192 — Monaco editor with JSON-mode + schema-aware diagnostics
+          (squiggles for shape violations, hover, completions). The
+          underlying form value is still bound by formControlName — the
+          editor implements ControlValueAccessor — so the existing
+          jsonValidator + save flow is unchanged. Schema is fetched
+          on (onInit) and wired into monaco.languages.json.jsonDefaults.
+        -->
+        <div class="monaco-host" data-testid="rules">
+          <ngx-monaco-editor
+            formControlName="rulesJson"
+            class="monaco-editor-host"
+            [options]="monacoOptions"
+            (onInit)="onMonacoEditorInit()">
+          </ngx-monaco-editor>
+        </div>
         <small *ngIf="rulesJsonError() as msg" class="hint error" data-testid="rules-error">
           {{ msg }}
         </small>

--- a/client/src/app/features/policies/policy-editor.component.scss
+++ b/client/src/app/features/policies/policy-editor.component.scss
@@ -100,6 +100,21 @@
   resize: vertical;
 }
 
+// #192 — Monaco editor host. Fixed height matches the previous
+// 14-row textarea visually so the form layout doesn't shift when
+// the editor mounts.
+.monaco-host {
+  height: 320px;
+  border: 1px solid var(--border, #ddd);
+  border-radius: 4px;
+  overflow: hidden;
+
+  .monaco-editor-host {
+    display: block;
+    height: 100%;
+  }
+}
+
 .hint {
   font-size: 12px;
   color: var(--text-secondary);

--- a/client/src/app/features/policies/policy-editor.component.spec.ts
+++ b/client/src/app/features/policies/policy-editor.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
 import { Subject, of, throwError } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
+import { provideMonacoEditor } from 'ngx-monaco-editor-v2';
 import {
   ApiService,
   CreatePolicyRequest,
@@ -62,6 +63,13 @@ describe('PolicyEditorComponent (P9.2)', () => {
             snapshot: { paramMap: convertToParamMap(routeParams) },
           },
         },
+        // #192 — Monaco's `NGX_MONACO_EDITOR_CONFIG` token is provided
+        // app-wide in app.config.ts; specs need their own copy so the
+        // editor's DI tree resolves. baseUrl doesn't matter here since
+        // Karma doesn't load the AMD chunks (the editor view never
+        // actually renders in jsdom — `automaticLayout` no-ops, and
+        // ControlValueAccessor still works for form binding).
+        provideMonacoEditor({ baseUrl: '/assets/monaco/vs' }),
       ],
     });
 
@@ -204,6 +212,73 @@ describe('PolicyEditorComponent (P9.2)', () => {
       // Update body must NOT carry a name/description (server doesn't accept it).
       expect((req as any).name).toBeUndefined();
       expect((req as any).description).toBeUndefined();
+    });
+  });
+
+  // #192 — Monaco wiring. The editor itself isn't exercised in jsdom
+  // (no AMD loader, no canvas) — we test the `onMonacoEditorInit`
+  // callback in isolation against a fake monaco global.
+  describe('Monaco schema wiring (#192)', () => {
+    let fakeSetDiagnostics: jasmine.Spy;
+
+    beforeEach(() => {
+      build();
+      api.getPolicy.and.returnValue(of(samplePolicy));
+      api.getPolicyVersion.and.returnValue(of(sampleDraftVersion));
+      (api as any).getRulesSchema = jasmine.createSpy('getRulesSchema');
+
+      fakeSetDiagnostics = jasmine.createSpy('setDiagnosticsOptions');
+      // Stand up a minimal `window.monaco` shape so the callback can
+      // call setDiagnosticsOptions without exploding.
+      (window as any).monaco = {
+        languages: {
+          json: {
+            jsonDefaults: { setDiagnosticsOptions: fakeSetDiagnostics },
+          },
+        },
+      };
+
+      fixture = TestBed.createComponent(PolicyEditorComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    afterEach(() => {
+      delete (window as any).monaco;
+    });
+
+    it('fetches the schema and feeds it to monaco.languages.json.jsonDefaults', () => {
+      const fakeSchema = { type: 'object', additionalProperties: true };
+      (api as any).getRulesSchema.and.returnValue(of(fakeSchema));
+
+      component.onMonacoEditorInit();
+
+      expect((api as any).getRulesSchema).toHaveBeenCalledTimes(1);
+      expect(fakeSetDiagnostics).toHaveBeenCalledTimes(1);
+      const arg = fakeSetDiagnostics.calls.mostRecent().args[0];
+      expect(arg.validate).toBeTrue();
+      expect(arg.schemas[0].uri).toBe(
+        'https://andy-policies/schemas/rules.json');
+      expect(arg.schemas[0].schema).toBe(fakeSchema);
+    });
+
+    it('schema fetch failure is non-fatal — setDiagnosticsOptions is not called', () => {
+      const failure = new HttpErrorResponse({ status: 503 });
+      (api as any).getRulesSchema.and.returnValue(throwError(() => failure));
+
+      component.onMonacoEditorInit();
+
+      expect(fakeSetDiagnostics).not.toHaveBeenCalled();
+    });
+
+    it('does nothing if monaco global is missing (defensive guard)', () => {
+      delete (window as any).monaco;
+      const fakeSchema = { type: 'object' };
+      (api as any).getRulesSchema.and.returnValue(of(fakeSchema));
+
+      component.onMonacoEditorInit();
+
+      expect((api as any).getRulesSchema).not.toHaveBeenCalled();
     });
   });
 });

--- a/client/src/app/features/policies/policy-editor.component.ts
+++ b/client/src/app/features/policies/policy-editor.component.ts
@@ -21,6 +21,7 @@ import {
   Validators,
 } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import {
   ApiService,
   CreatePolicyRequest,
@@ -59,7 +60,13 @@ interface EditorForm {
 @Component({
   selector: 'app-policy-editor',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterLink, ScopeChipInputComponent],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    RouterLink,
+    ScopeChipInputComponent,
+    MonacoEditorModule,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './policy-editor.component.html',
   styleUrls: ['./policy-editor.component.scss'],
@@ -83,6 +90,23 @@ export class PolicyEditorComponent {
 
   readonly enforcementOptions: Enforcement[] = ['MUST', 'SHOULD', 'MAY'];
   readonly severityOptions: Severity[] = ['info', 'moderate', 'critical'];
+
+  /** Monaco editor options. `automaticLayout` keeps the editor sized
+   *  to its container even after route changes / fieldset folds; the
+   *  rest is best-fit defaults for editing a small JSON document. */
+  readonly monacoOptions = {
+    theme: 'vs',
+    language: 'json',
+    automaticLayout: true,
+    minimap: { enabled: false },
+    scrollBeyondLastLine: false,
+    fontSize: 13,
+    tabSize: 2,
+  };
+
+  /** Schema id wired into Monaco's diagnostics. Stable URL — the
+   *  server's `$id` matches and Monaco uses it for hover/completions. */
+  private static readonly RulesSchemaId = 'https://andy-policies/schemas/rules.json';
 
   readonly form: FormGroup<EditorForm> = this.fb.group<EditorForm>({
     name: this.fb.control('', [
@@ -202,6 +226,44 @@ export class PolicyEditorComponent {
 
   cancel(): void {
     this.router.navigate(['/policies']);
+  }
+
+  /**
+   * Wire schema-aware diagnostics into Monaco's JSON language service.
+   * Fired by `(onInit)` from the editor wrapper — at that point the
+   * `monaco` global is on `window` (loaded via the AMD loader from
+   * `/assets/monaco/vs`). We fetch the schema lazily; on failure the
+   * editor still works (no schema diagnostics, basic syntax highlight
+   * + JSON.parse-level errors from the form validator).
+   */
+  onMonacoEditorInit(): void {
+    const monaco = (window as unknown as { monaco?: typeof import('monaco-editor') }).monaco;
+    if (!monaco) return; // defensive — should always be present after onInit fires
+
+    this.api
+      .getRulesSchema()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: schema => {
+          monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+            validate: true,
+            allowComments: false,
+            // Bind the schema to any `inmemory://` URI Monaco creates for
+            // unsaved buffers — that covers every model the editor
+            // creates here, since the editor isn't backed by a real file.
+            schemas: [{
+              uri: PolicyEditorComponent.RulesSchemaId,
+              fileMatch: ['*'],
+              schema,
+            }],
+          });
+        },
+        error: () => {
+          // Non-critical — fall back to plain JSON editing without
+          // schema hints. The form-level jsonValidator still catches
+          // syntax errors at save time.
+        },
+      });
   }
 
   private loadForEdit(policyId: string, versionId: string): void {

--- a/client/src/app/shared/services/api.service.ts
+++ b/client/src/app/shared/services/api.service.ts
@@ -508,6 +508,20 @@ export class ApiService {
     return this.http.delete<void>(`${this.baseUrl}/bundles/${id}`, { params });
   }
 
+  // --- Schemas (#191 #192) ---
+
+  /**
+   * Fetch the rules-DSL JSON Schema served at `/api/schemas/rules.json`.
+   * Anonymous endpoint — strong ETag + 5-minute Cache-Control on the
+   * server side, so repeat calls are cheap. Used by the Monaco editor
+   * (#192) to wire schema-aware diagnostics. Type is intentionally
+   * `unknown` because the schema is permissive today (`type: object,
+   * additionalProperties: true`) and Monaco accepts any JSON.
+   */
+  getRulesSchema(): Observable<unknown> {
+    return this.http.get<unknown>(`${this.baseUrl}/schemas/rules.json`);
+  }
+
   // --- Publish workflow (P9.3 #68 / backend #216) ---
 
   /**


### PR DESCRIPTION
## Summary

Replaces the plain textarea in `PolicyEditorComponent` with Monaco configured for JSON, fed schema-aware diagnostics from `GET /api/schemas/rules.json` (#191). Authors get hover / completions / inline shape squiggles instead of waiting for the form-level `JSON.parse` error on save.

### Bundle posture

| Metric | Value |
|---|---|
| `monaco-editor` + `ngx-monaco-editor-v2` | added |
| `angular.json` assets glob | copies `node_modules/monaco-editor/min/vs` → `/assets/monaco/vs` |
| `provideMonacoEditor` | pins `baseUrl: /assets/monaco/vs` in `app.config.ts` |
| Initial bundle (prod) | **477 kB** — under the 500 kB warning |
| `policy-editor` lazy chunk | **17.7 kB raw / 5 kB transfer** |

The heavy Monaco code lives in `/assets/monaco/vs/` and is loaded via the AMD loader at runtime, NOT bundled into the JS chunk. The lazy-route boundary keeps Monaco out of the initial bundle for users who never edit a policy.

### Editor wiring

- `ngx-monaco-editor` implements `ControlValueAccessor`, so the existing `formControlName="rulesJson"` binding + `jsonValidator` + save flow are unchanged. The form-level validator still gates save; Monaco's diagnostics are advisory squiggles.
- `onMonacoEditorInit` fetches the schema lazily, then calls `monaco.languages.json.jsonDefaults.setDiagnosticsOptions` with the schema bound by URI. `fileMatch: ['*']` catches any in-memory model the editor creates.
- Schema fetch failure is non-fatal: editor still works as a JSON editor with syntax-only highlighting.

### `ApiService`

- New `getRulesSchema()` returning the parsed JSON Schema doc.

## Test plan

- [x] **Karma**: 145/145 specs pass (was 142; 3 new for #192).
  - Schema fetched + fed to `setDiagnosticsOptions` with the right URI binding.
  - Schema fetch failure is non-fatal (no `setDiagnosticsOptions` call, no exception).
  - Defensive guard: no-op when `window.monaco` is missing.
- [x] **Existing specs**: needed `provideMonacoEditor()` in TestBed to satisfy the `NGX_MONACO_EDITOR_CONFIG` injection token; the `ControlValueAccessor` binding still works in jsdom.
- [x] **Production build**: clean, under budget (initial 477 kB).
- [x] **Development build**: clean.
- [ ] **Browser-verified**: not driven this session — the editor view itself only renders in a real browser. Karma covers the wiring contract (TestBed-instantiated component + spy-driven schema flow); the visual behaviour (squiggles, hover, completions) needs a manual run.

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)