### PR TITLE
Wire andy.policies.auditRetentionDays per ADR 0006.1

### DIFF
--- a/config/registration.json
+++ b/config/registration.json
@@ -189,7 +189,7 @@
       {
         "key": "andy.policies.auditRetentionDays",
         "displayName": "Audit Retention Days",
-        "description": "Audit log retention in days. Use 0 for indefinite.",
+        "description": "Metadata-only retention window (ADR 0006.1). Sets the default `from` filter on GET /api/audit list queries and flags older events with `stale: true` in NDJSON exports. Use 0 for unbounded (the shipped default). The audit chain is append-only — this setting NEVER deletes, archives, or moves rows, and /api/audit/verify always reads the full chain.",
         "category": "Audit",
         "dataType": "Integer",
         "defaultValue": "0",

--- a/docs/adr/0006.1-audit-retention.md
+++ b/docs/adr/0006.1-audit-retention.md
@@ -1,0 +1,74 @@
+# ADR 0006.1 — Audit retention clarification
+
+## Status
+
+**Accepted** — 2026-05-11. Amends [ADR 0006 §6](0006-audit-hash-chain.md) per its own §191 follow-up convention. Tracking: rivoli-ai/andy-policies#110. Does NOT change canonicalization, hash, or chain semantics — existing chains produced under ADR 0006 remain valid.
+
+Related: ADR 0006 audit-hash-chain (clarifies §6 retention behavior).
+
+## Context
+
+ADR 0006 §6 states `andy.policies.auditRetentionDays` defaults to `0` (forever), MUST NOT truncate the chain (truncation breaks verifiability), and "governs export staleness warnings and future cold-storage tiering." That paragraph is load-bearing for the immutability guarantee but leaves the consumer-facing behavior ambiguous in three ways flagged on #110:
+
+1. Does the setting affect what `GET /api/audit` returns by default?
+2. Does it physically relocate rows (cold-storage tiering — already named in §6 as "future")?
+3. Does it drive an external export schedule?
+
+Without a decision, the P6 retention story (#110) is blocked: P6.2 ships the chain, P6.6 ships the list endpoint, P6.7 ships NDJSON export — but no component currently *consumes* the setting. The risk of writing the implementation against an unstated interpretation is that consumers (P9.7 audit timeline, compliance officers running export tooling) bind to it before the contract is settled.
+
+## Decision
+
+`andy.policies.auditRetentionDays` governs **two** behaviors, both metadata-only. It NEVER moves, deletes, archives, or otherwise alters `audit_events` rows.
+
+### 1. Export staleness flag (already in ADR 0006 §6 — restated for completeness)
+
+P6.7 `policy.audit.export` NDJSON output annotates each event whose `timestamp` is older than `now() - retentionDays` with `"stale": true`. When the setting is `0`, no event is ever flagged stale. The flag is advisory — consumers decide what to do with it. Hashes and chain links are unchanged.
+
+### 2. Default list-query window
+
+P6.6 `GET /api/audit` (and the MCP / gRPC / CLI equivalents) defaults its `from` filter to `now() - retentionDays` when the caller omits `from`. Callers MAY pass an explicit `?from=<ISO-8601>` to retrieve older events; explicit `from` always overrides the default. When the setting is `0`, the default `from` is unset (full history returned).
+
+This is filter-on-read only. The underlying rows remain. Pagination, ordering, and cursor semantics are unchanged.
+
+### 3. Verification ignores retention
+
+`GET /api/audit/verify` and the offline `andy-policies-cli audit verify` MUST always read the full chain (from `Seq = 1` to tail) regardless of the setting. Verification scope is the integrity contract; narrowing it would defeat the chain's purpose. The setting has no effect on verification cost or behavior.
+
+### 4. Implementation shape
+
+- One settings consumer: `IAuditService` (or a thin `AuditRetentionPolicy` collaborator) resolves `retentionDays` via `IAndySettingsClient` on each call. No background sweep, no hosted service, no migration.
+- Setting changes take effect on next call (the andy-settings client already refreshes; no in-app caching beyond what the client provides).
+- Default behavior with `retentionDays = 0` is identical to the pre-amendment behavior (full history, no stale flag). Existing API consumers see no observable change.
+
+## Rejected alternatives
+
+| Alternative | Rejected because |
+|---|---|
+| **Physical archival** to a cold-storage table or NDJSON file | Reintroduces a non-trivial infrastructure surface (storage location, retention of the archive itself, restore path) that ADR 0006 §6 explicitly defers to a future ADR. The original issue body's preferred shape; deliberately deferred. |
+| **Hard deletion** of rows past the threshold | Forbidden by ADR 0006 §6 ("truncation would break verifiability"). Not seriously considered. |
+| **Background hosted service** sweeping the table | No work to do — there are no rows to move, archive, or update. The setting is read-on-call by the two consumers (export, list). A hosted service would be a no-op. |
+| **Verify also honors retention** | Defeats the integrity guarantee. Verification scope MUST be the full chain. |
+| **`stale: true` propagates to `GET /api/audit` list results** | Pollutes the list response with a flag whose semantics duplicate the `?from=` filter the caller already controls. Keep the flag scoped to export, where downstream tooling consumes it. |
+| **Background NDJSON-to-disk export on a cron** | Out of scope per ADR 0006 §138 ("Real-time streaming of audit events to external systems… Event-bus streaming is a future concern"). Export is operator-pull via P6.7, not service-push. |
+
+## Consequences
+
+### Positive
+
+- Resolves #110 without expanding ADR 0006's threat model or invalidating any existing chain.
+- Default-window behavior gives operators a knob for "the timeline view is too noisy" without touching storage.
+- Implementation is one method on `IAuditService` plus a one-line export-builder change. No migration, no new table, no hosted service.
+
+### Negative / accepted trade-offs
+
+- Operators expecting `auditRetentionDays` to free disk space will be disappointed. The setting documentation in `config/registration.json` and `docs/runbooks/audit-compliance.md` MUST clarify that the chain is append-only by design.
+- Cold-storage tiering remains deferred. If catalog volume grows beyond practical single-table scale (10s of millions of events), a follow-up ADR will introduce a tiered store. Current scale (governance-grade, 10s of events per minute peak per ADR 0006 §101) makes that deferral safe for years.
+
+### Follow-ups (tracked elsewhere)
+
+- #110 unblocked: implementation lands `AuditRetentionPolicy` consumer + the two read-paths above. Tests cover (a) `retentionDays = 0` returns full history with no `stale` flags, (b) `retentionDays = 30` defaults list `from` to `now() - 30d`, (c) explicit `from` overrides, (d) `verify` ignores the setting.
+- A future ADR will introduce cold-storage tiering if and when scale demands it — at which point this ADR's "metadata-only" framing supersedes naturally.
+
+---
+
+**Authors**: drafted by Claude 2026-05-11; accepted the same day. Unblocks #110.

--- a/docs/runbooks/audit-compliance.md
+++ b/docs/runbooks/audit-compliance.md
@@ -139,16 +139,23 @@ What the chain *cannot* prove:
 
 ## 5. How long are events kept?
 
-**Forever, in v1.** The chain is never truncated. The setting
-`andy.policies.auditRetentionDays` exists in andy-settings but
-governs *export-freshness warnings* (P6.7) — whether the operator
-console flags a chain that hasn't been exported in N days. It
-does **not** delete rows.
+**Forever.** The chain is never truncated. The setting
+`andy.policies.auditRetentionDays` is **metadata-only** per
+[ADR 0006.1](../adr/0006.1-audit-retention.md):
 
-If retention enforcement (true row removal) is required for a
-specific deployment, raise it as an ADR amendment to ADR 0006.
-The current design's chain-as-source-of-truth invariant
-explicitly excludes retention truncation.
+- Sets the default `from` window on `GET /api/audit` list queries.
+  Callers may pass an explicit `?from=` to retrieve older events.
+- Flags events older than `now() - retentionDays` with
+  `"stale": true` in P6.7 NDJSON exports.
+- Has **no effect** on `/api/audit/verify` — verification always
+  reads the full chain (narrowing scope would defeat the
+  integrity contract).
+- Does **not** delete, archive, or relocate rows. Increasing
+  retention does not free disk space.
+
+The shipped default is `0` (unbounded). Cold-storage tiering for
+deployments where catalog volume outgrows a single table is
+deferred to a future ADR.
 
 ## 6. PII in audit diffs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
     - 0004 Scope hierarchy: adr/0004-scope-hierarchy.md
     - 0005 Overrides: adr/0005-overrides.md
     - 0006 Audit hash chain: adr/0006-audit-hash-chain.md
+    - 0006.1 Audit retention: adr/0006.1-audit-retention.md
     - 0007 Edit RBAC: adr/0007-edit-rbac.md
     - 0008 Bundle pinning: adr/0008-bundle-pinning.md
     - 0010 Embedded mode: adr/0010-embedded-mode.md

--- a/src/Andy.Policies.Api/Controllers/AuditController.cs
+++ b/src/Andy.Policies.Api/Controllers/AuditController.cs
@@ -45,11 +45,19 @@ public sealed class AuditController : ControllerBase
 
     private readonly IAuditChain _chain;
     private readonly IAuditQuery _query;
+    private readonly IAuditRetentionPolicy _retention;
+    private readonly TimeProvider _clock;
 
-    public AuditController(IAuditChain chain, IAuditQuery query)
+    public AuditController(
+        IAuditChain chain,
+        IAuditQuery query,
+        IAuditRetentionPolicy retention,
+        TimeProvider clock)
     {
         _chain = chain;
         _query = query;
+        _retention = retention;
+        _clock = clock;
     }
 
     /// <summary>
@@ -172,8 +180,15 @@ public sealed class AuditController : ControllerBase
                 code: "audit.list.invalid_cursor");
         }
 
+        // ADR 0006.1: when the caller omits `from`, default it to the
+        // staleness threshold derived from andy.policies.auditRetentionDays.
+        // An explicit caller-supplied `from` always wins, even when it
+        // predates the threshold — operators routinely need to dig into
+        // older rows for incident response.
+        var effectiveFrom = from ?? _retention.GetStalenessThreshold(_clock.GetUtcNow());
+
         var page = await _query.QueryAsync(
-            new AuditQueryFilter(actor, from, to, entityType, entityId, action, after, size),
+            new AuditQueryFilter(actor, effectiveFrom, to, entityType, entityId, action, after, size),
             ct);
         return Ok(page);
     }

--- a/src/Andy.Policies.Api/GrpcServices/AuditGrpcService.cs
+++ b/src/Andy.Policies.Api/GrpcServices/AuditGrpcService.cs
@@ -48,12 +48,21 @@ public class AuditGrpcService : Andy.Policies.Api.Protos.AuditService.AuditServi
     private readonly IAuditQuery _query;
     private readonly IAuditChain _chain;
     private readonly IAuditExporter _exporter;
+    private readonly IAuditRetentionPolicy _retention;
+    private readonly TimeProvider _clock;
 
-    public AuditGrpcService(IAuditQuery query, IAuditChain chain, IAuditExporter exporter)
+    public AuditGrpcService(
+        IAuditQuery query,
+        IAuditChain chain,
+        IAuditExporter exporter,
+        IAuditRetentionPolicy retention,
+        TimeProvider clock)
     {
         _query = query;
         _chain = chain;
         _exporter = exporter;
+        _retention = retention;
+        _clock = clock;
     }
 
     public override async Task<ListAuditResponse> ListAudit(
@@ -86,10 +95,15 @@ public class AuditGrpcService : Andy.Policies.Api.Protos.AuditService.AuditServi
             throw new RpcException(new Status(StatusCode.InvalidArgument, $"cursor: {ex.Message}"));
         }
 
+        // ADR 0006.1: default `from` to the retention threshold when
+        // the caller omits it (proto unset → from is null). Explicit
+        // `from` always wins.
+        var effectiveFrom = from ?? _retention.GetStalenessThreshold(_clock.GetUtcNow());
+
         var page = await _query.QueryAsync(
             new AuditQueryFilter(
                 Actor: NullIfEmpty(request.Actor),
-                From: from,
+                From: effectiveFrom,
                 To: to,
                 EntityType: NullIfEmpty(request.EntityType),
                 EntityId: NullIfEmpty(request.EntityId),

--- a/src/Andy.Policies.Api/Mcp/AuditTools.cs
+++ b/src/Andy.Policies.Api/Mcp/AuditTools.cs
@@ -59,6 +59,8 @@ public static class AuditTools
         "array; hashes travel as lowercase hex.")]
     public static async Task<string> List(
         IAuditQuery query,
+        IAuditRetentionPolicy retention,
+        TimeProvider clock,
         [Description("Filter by actor subject id (exact match)")] string? actor = null,
         [Description("Filter by entity type, e.g. Policy, Override")] string? entityType = null,
         [Description("Filter by entity id (exact match)")] string? entityId = null,
@@ -106,8 +108,12 @@ public static class AuditTools
             return "policy.audit.invalid_argument: cursor is not a recognised base64-JSON token.";
         }
 
+        // ADR 0006.1: default `from` to the retention threshold when
+        // the caller omits it. Explicit `from` always wins.
+        var effectiveFrom = fromDt ?? retention.GetStalenessThreshold(clock.GetUtcNow());
+
         var page = await query.QueryAsync(
-            new AuditQueryFilter(actor, fromDt, toDt, entityType, entityId, action, cursorAfter, pageSize),
+            new AuditQueryFilter(actor, effectiveFrom, toDt, entityType, entityId, action, cursorAfter, pageSize),
             ct).ConfigureAwait(false);
         return JsonSerializer.Serialize(page, DtoJsonOptions);
     }

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -162,6 +162,11 @@ builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IAuditQuery, And
 // Scoped because AuditExporter depends on the scoped AppDbContext;
 // the exporter itself is read-only (no transactions).
 builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IAuditExporter, Andy.Policies.Infrastructure.Audit.AuditExporter>();
+// ADR 0006.1 / #110: andy.policies.auditRetentionDays consumer.
+// Singleton so the OTel gauge registers once; the underlying
+// ISettingsSnapshot is itself a singleton refreshed by the
+// andy-settings hosted refresh service.
+builder.Services.AddSingleton<Andy.Policies.Application.Interfaces.IAuditRetentionPolicy, Andy.Policies.Infrastructure.Settings.AuditRetentionPolicy>();
 // P6.3 (#43): RFC 6902 JSON Patch diff generator. Singleton
 // because the implementation is pure + caches reflection
 // metadata per type; injected into every mutating service so
@@ -296,6 +301,7 @@ builder.Services.AddOpenTelemetry()
                .AddMeter(Andy.Policies.Infrastructure.Services.AndySettingsRationalePolicy.MeterName)
                .AddMeter(Andy.Policies.Infrastructure.BackgroundServices.OverrideExpiryReaper.MeterName)
                .AddMeter(Andy.Policies.Infrastructure.Settings.ExperimentalOverridesGate.MeterName)
+               .AddMeter(Andy.Policies.Infrastructure.Settings.AuditRetentionPolicy.MeterName)
                .AddMeter(Andy.Policies.Infrastructure.Services.Rbac.HttpRbacChecker.MeterName);
         if (!string.IsNullOrEmpty(otlpEndpoint))
             metrics.AddOtlpExporter(o => o.Endpoint = new Uri(otlpEndpoint));

--- a/src/Andy.Policies.Application/Interfaces/IAuditRetentionPolicy.cs
+++ b/src/Andy.Policies.Application/Interfaces/IAuditRetentionPolicy.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.Interfaces;
+
+/// <summary>
+/// Resolves the <c>andy.policies.auditRetentionDays</c> setting into a
+/// concrete staleness threshold for the two consumers defined by ADR
+/// 0006.1: P6.6 list defaulting and P6.7 export annotation. The
+/// setting is metadata-only — it never causes rows to move or
+/// disappear from <c>audit_events</c>, and <c>/api/audit/verify</c>
+/// MUST NOT consult this policy (verification scope is the integrity
+/// contract).
+/// </summary>
+public interface IAuditRetentionPolicy
+{
+    /// <summary>
+    /// Returns the cut-off timestamp such that events with
+    /// <c>Timestamp &lt; threshold</c> are considered stale, or
+    /// <c>null</c> when retention is disabled
+    /// (<c>auditRetentionDays = 0</c>, the shipped default). Callers
+    /// that pass an explicit <c>from</c> filter must prefer the
+    /// caller-supplied value over this threshold.
+    /// </summary>
+    DateTimeOffset? GetStalenessThreshold(DateTimeOffset now);
+}

--- a/src/Andy.Policies.Infrastructure/Audit/AuditExporter.cs
+++ b/src/Andy.Policies.Infrastructure/Audit/AuditExporter.cs
@@ -26,11 +26,13 @@ public sealed class AuditExporter : IAuditExporter
 
     private readonly AppDbContext _db;
     private readonly TimeProvider _clock;
+    private readonly IAuditRetentionPolicy _retention;
 
-    public AuditExporter(AppDbContext db, TimeProvider clock)
+    public AuditExporter(AppDbContext db, TimeProvider clock, IAuditRetentionPolicy retention)
     {
         _db = db;
         _clock = clock;
+        _retention = retention;
     }
 
     public async Task WriteNdjsonAsync(
@@ -45,6 +47,12 @@ public sealed class AuditExporter : IAuditExporter
             if (fromSeq is { } f) query = query.Where(e => e.Seq >= f);
             if (toSeq is { } t) query = query.Where(e => e.Seq <= t);
             query = query.OrderBy(e => e.Seq);
+
+            // ADR 0006.1: events with Timestamp < staleThreshold get
+            // a "stale": true marker on their NDJSON line. When
+            // retention is disabled (setting = 0), threshold is null
+            // and no event is flagged.
+            var staleThreshold = _retention.GetStalenessThreshold(_clock.GetUtcNow());
 
             long count = 0;
             long firstSeq = 0;
@@ -63,7 +71,8 @@ public sealed class AuditExporter : IAuditExporter
                 lastSeq = ev.Seq;
                 terminalHashHex = Convert.ToHexString(ev.Hash).ToLowerInvariant();
 
-                await writer.WriteLineAsync(SerializeEventLine(ev)).ConfigureAwait(false);
+                var stale = staleThreshold is { } threshold && ev.Timestamp < threshold;
+                await writer.WriteLineAsync(SerializeEventLine(ev, stale)).ConfigureAwait(false);
             }
 
             // Always emit a summary line, even on an empty range —
@@ -84,7 +93,7 @@ public sealed class AuditExporter : IAuditExporter
         }
     }
 
-    private static string SerializeEventLine(AuditEvent ev)
+    private static string SerializeEventLine(AuditEvent ev, bool stale)
     {
         // Embed the patch document as parsed JSON, not as a
         // string, so the bundle line-by-line is interchangeable
@@ -92,6 +101,32 @@ public sealed class AuditExporter : IAuditExporter
         // already understands.
         using var diffDoc = JsonDocument.Parse(
             string.IsNullOrEmpty(ev.FieldDiffJson) ? "[]" : ev.FieldDiffJson);
+
+        // Only emit the stale field when true. ADR 0006.1 §1 keeps
+        // the marker advisory; absence reads as "fresh" without
+        // adding a boolean column to every non-retention export.
+        if (stale)
+        {
+            var staleLine = new
+            {
+                type = "event",
+                id = ev.Id,
+                seq = ev.Seq,
+                prevHashHex = Convert.ToHexString(ev.PrevHash).ToLowerInvariant(),
+                hashHex = Convert.ToHexString(ev.Hash).ToLowerInvariant(),
+                timestamp = ev.Timestamp,
+                actorSubjectId = ev.ActorSubjectId,
+                actorRoles = ev.ActorRoles,
+                action = ev.Action,
+                entityType = ev.EntityType,
+                entityId = ev.EntityId,
+                fieldDiff = diffDoc.RootElement,
+                rationale = ev.Rationale,
+                stale = true,
+            };
+            return JsonSerializer.Serialize(staleLine, WireOptions);
+        }
+
         var line = new
         {
             type = "event",

--- a/src/Andy.Policies.Infrastructure/Settings/AuditRetentionPolicy.cs
+++ b/src/Andy.Policies.Infrastructure/Settings/AuditRetentionPolicy.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Diagnostics.Metrics;
+using Andy.Policies.Application.Interfaces;
+using Andy.Settings.Client;
+
+namespace Andy.Policies.Infrastructure.Settings;
+
+/// <summary>
+/// Live <see cref="IAuditRetentionPolicy"/> backed by andy-settings
+/// (ADR 0006.1, story rivoli-ai/andy-policies#110). Mirrors the
+/// shape of <see cref="PinningPolicy"/> + <see cref="ExperimentalOverridesGate"/>:
+/// read fresh from <see cref="ISettingsSnapshot"/> on every call,
+/// with an OTel gauge so operators can confirm the toggle reached the
+/// live process.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Default = 0 (forever).</b> The shipped default in
+/// <c>config/registration.json</c> is <c>0</c>. A negative value is
+/// treated as <c>0</c> (no threshold); a missing observation is also
+/// <c>0</c>. The setting cannot truncate the chain, so a permissive
+/// default under a transient settings outage carries no integrity risk.
+/// </para>
+/// </remarks>
+public sealed class AuditRetentionPolicy : IAuditRetentionPolicy, IDisposable
+{
+    public const string SettingKey = "andy.policies.auditRetentionDays";
+    public const string MeterName = "Andy.Policies.AuditRetentionPolicy";
+
+    private readonly ISettingsSnapshot _snapshot;
+    private readonly Meter _meter;
+
+    public AuditRetentionPolicy(ISettingsSnapshot snapshot)
+    {
+        _snapshot = snapshot;
+        _meter = new Meter(MeterName);
+        _meter.CreateObservableGauge(
+            name: "andy_policies_audit_retention_days",
+            observeValue: () => RetentionDays,
+            description: "Current value of andy.policies.auditRetentionDays (0 = forever).");
+    }
+
+    private int RetentionDays
+    {
+        get
+        {
+            var raw = _snapshot.GetInt(SettingKey) ?? 0;
+            return raw < 0 ? 0 : raw;
+        }
+    }
+
+    public DateTimeOffset? GetStalenessThreshold(DateTimeOffset now)
+    {
+        var days = RetentionDays;
+        return days == 0 ? null : now - TimeSpan.FromDays(days);
+    }
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/tests/Andy.Policies.Tests.Integration/Audit/AuditExporterTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Audit/AuditExporterTests.cs
@@ -43,8 +43,14 @@ public class AuditExporterTests
         var db = new AppDbContext(options);
         db.Database.Migrate();
         var chain = new AuditChain(db, TimeProvider.System);
-        var exporter = new AuditExporter(db, TimeProvider.System);
+        var exporter = new AuditExporter(db, TimeProvider.System, NoRetention.Instance);
         return (db, chain, exporter, conn);
+    }
+
+    private sealed class NoRetention : IAuditRetentionPolicy
+    {
+        public static readonly NoRetention Instance = new();
+        public DateTimeOffset? GetStalenessThreshold(DateTimeOffset now) => null;
     }
 
     private static async Task SeedAsync(IAuditChain chain, int count)

--- a/tests/Andy.Policies.Tests.Integration/Audit/AuditRetentionTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Audit/AuditRetentionTests.cs
@@ -1,0 +1,290 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Tests.Integration.Controllers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Audit;
+
+/// <summary>
+/// ADR 0006.1 (story rivoli-ai/andy-policies#110) — end-to-end
+/// behavior of the audit-retention setting against the real REST
+/// pipeline, with a fixed clock + an injected
+/// <see cref="IAuditRetentionPolicy"/> stub so the test owns the
+/// staleness threshold.
+/// </summary>
+public class AuditRetentionTests : IDisposable
+{
+    private sealed class StubRetentionPolicy : IAuditRetentionPolicy
+    {
+        public DateTimeOffset? Threshold { get; set; }
+        public DateTimeOffset? GetStalenessThreshold(DateTimeOffset now) => Threshold;
+    }
+
+    private sealed class RetentionFactory : WebApplicationFactory<Program>
+    {
+        private readonly SqliteConnection _connection = new("DataSource=:memory:");
+
+        public RetentionFactory()
+        {
+            _connection.Open();
+        }
+
+        public StubRetentionPolicy Retention { get; } = new();
+        public DateTimeOffset NowOverride { get; set; } =
+            new(2026, 5, 11, 12, 0, 0, TimeSpan.Zero);
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Testing");
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Database:Provider"] = "Sqlite",
+                    ["AndyAuth:Authority"] = "https://test-auth.invalid",
+                    ["AndySettings:ApiBaseUrl"] = "https://test-settings.invalid",
+                    ["AndyRbac:BaseUrl"] = "https://test-rbac.invalid",
+                });
+            });
+            builder.ConfigureServices(services =>
+            {
+                var ctxDescriptor = services.SingleOrDefault(d =>
+                    d.ServiceType == typeof(DbContextOptions<AppDbContext>));
+                if (ctxDescriptor is not null) services.Remove(ctxDescriptor);
+                services.AddDbContext<AppDbContext>(opts => opts.UseSqlite(_connection));
+
+                services.ReplaceWithAllowAll();
+
+                services.AddAuthentication(TestAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                        TestAuthHandler.SchemeName, _ => { });
+                services.PostConfigure<AuthorizationOptions>(opts =>
+                {
+                    opts.DefaultPolicy = new AuthorizationPolicyBuilder(TestAuthHandler.SchemeName)
+                        .RequireAuthenticatedUser()
+                        .Build();
+                });
+
+                // Replace the live AuditRetentionPolicy + clock with the
+                // test stubs so each test owns the threshold.
+                var rDescriptors = services
+                    .Where(d => d.ServiceType == typeof(IAuditRetentionPolicy))
+                    .ToList();
+                foreach (var d in rDescriptors) services.Remove(d);
+                services.AddSingleton<IAuditRetentionPolicy>(Retention);
+
+                var clockDescriptors = services
+                    .Where(d => d.ServiceType == typeof(TimeProvider))
+                    .ToList();
+                foreach (var d in clockDescriptors) services.Remove(d);
+                services.AddSingleton<TimeProvider>(new FixedClock(() => NowOverride));
+
+                using var sp = services.BuildServiceProvider();
+                using var scope = sp.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+                db.Database.EnsureCreated();
+            });
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) _connection.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class FixedClock : TimeProvider
+    {
+        private readonly Func<DateTimeOffset> _now;
+        public FixedClock(Func<DateTimeOffset> now) => _now = now;
+        public override DateTimeOffset GetUtcNow() => _now();
+    }
+
+    private readonly RetentionFactory _factory = new();
+    private readonly HttpClient _client;
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    public AuditRetentionTests()
+    {
+        _client = _factory.CreateClient();
+    }
+
+    public void Dispose()
+    {
+        _factory.Dispose();
+        _client.Dispose();
+    }
+
+    /// <summary>
+    /// Inserts an audit event with a custom <c>Timestamp</c> by
+    /// temporarily winding the shared <see cref="TimeProvider"/>
+    /// to the target moment, appending normally so the chain
+    /// hashes the canonical body with that timestamp, then
+    /// restoring the test's "now" override. Keeps chain integrity
+    /// intact (a post-hoc UPDATE would break verification).
+    /// </summary>
+    private async Task SeedAtAsync(DateTimeOffset timestamp, string entityId)
+    {
+        var savedNow = _factory.NowOverride;
+        _factory.NowOverride = timestamp;
+        try
+        {
+            using var scope = _factory.Services.CreateScope();
+            var chain = scope.ServiceProvider.GetRequiredService<IAuditChain>();
+            await chain.AppendAsync(new AuditAppendRequest(
+                Action: "policy.update",
+                EntityType: "Policy",
+                EntityId: entityId,
+                FieldDiffJson: "[]",
+                Rationale: $"seed {entityId}",
+                ActorSubjectId: "user:test",
+                ActorRoles: new[] { "admin" }), CancellationToken.None);
+        }
+        finally
+        {
+            _factory.NowOverride = savedNow;
+        }
+    }
+
+    [Fact]
+    public async Task List_RetentionDisabled_ReturnsAllEvents()
+    {
+        // ADR 0006.1 acceptance criterion (a): retentionDays = 0 →
+        // default `from` is unset, full history visible.
+        _factory.Retention.Threshold = null;
+        await SeedAtAsync(_factory.NowOverride.AddDays(-365), "old");
+        await SeedAtAsync(_factory.NowOverride.AddDays(-1), "recent");
+
+        var resp = await _client.GetAsync("/api/audit");
+
+        resp.EnsureSuccessStatusCode();
+        var page = await resp.Content.ReadFromJsonAsync<AuditPageDto>(JsonOpts);
+        page!.Items.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task List_RetentionPositive_DefaultsFromToThreshold()
+    {
+        // ADR 0006.1 acceptance criterion (b): retentionDays = 30 →
+        // default `from` is now() - 30d. Events older than that are
+        // hidden from the default list result.
+        _factory.Retention.Threshold = _factory.NowOverride - TimeSpan.FromDays(30);
+        await SeedAtAsync(_factory.NowOverride.AddDays(-90), "old");
+        await SeedAtAsync(_factory.NowOverride.AddDays(-10), "fresh");
+
+        var resp = await _client.GetAsync("/api/audit");
+
+        resp.EnsureSuccessStatusCode();
+        var page = await resp.Content.ReadFromJsonAsync<AuditPageDto>(JsonOpts);
+        page!.Items.Should().ContainSingle()
+            .Which.EntityId.Should().Be("fresh");
+    }
+
+    [Fact]
+    public async Task List_ExplicitFrom_OverridesRetentionDefault()
+    {
+        // ADR 0006.1 acceptance criterion (c): explicit ?from=
+        // always wins over the threshold, even when the explicit
+        // value predates it. Operators dig into older rows on
+        // demand for incident response.
+        _factory.Retention.Threshold = _factory.NowOverride - TimeSpan.FromDays(30);
+        await SeedAtAsync(_factory.NowOverride.AddDays(-90), "old");
+        await SeedAtAsync(_factory.NowOverride.AddDays(-10), "fresh");
+
+        var explicitFrom = (_factory.NowOverride - TimeSpan.FromDays(180)).ToString("o");
+        var resp = await _client.GetAsync($"/api/audit?from={Uri.EscapeDataString(explicitFrom)}");
+
+        resp.EnsureSuccessStatusCode();
+        var page = await resp.Content.ReadFromJsonAsync<AuditPageDto>(JsonOpts);
+        page!.Items.Should().HaveCount(2,
+            "explicit ?from earlier than the threshold must surface older rows");
+    }
+
+    [Fact]
+    public async Task Verify_IgnoresRetention_ReadsFullChain()
+    {
+        // ADR 0006.1 acceptance criterion (d): verify scope is the
+        // integrity contract — the setting MUST NOT narrow it.
+        // Threshold is set, but verify still inspects every row.
+        _factory.Retention.Threshold = _factory.NowOverride - TimeSpan.FromDays(1);
+        await SeedAtAsync(_factory.NowOverride.AddDays(-90), "old1");
+        await SeedAtAsync(_factory.NowOverride.AddDays(-90), "old2");
+        await SeedAtAsync(_factory.NowOverride.AddDays(-1), "fresh");
+
+        var resp = await _client.GetAsync("/api/audit/verify");
+
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>(JsonOpts);
+        body.GetProperty("valid").GetBoolean().Should().BeTrue();
+        body.GetProperty("inspectedCount").GetInt64().Should().Be(3,
+            "verify must inspect every row regardless of staleness");
+    }
+
+    [Fact]
+    public async Task Export_StaleEvents_GetStaleFlag()
+    {
+        // ADR 0006.1 acceptance criterion (e): NDJSON export
+        // annotates events older than threshold with "stale": true;
+        // fresh events have no stale field at all.
+        _factory.Retention.Threshold = _factory.NowOverride - TimeSpan.FromDays(30);
+        await SeedAtAsync(_factory.NowOverride.AddDays(-90), "old");
+        await SeedAtAsync(_factory.NowOverride.AddDays(-10), "fresh");
+
+        using var scope = _factory.Services.CreateScope();
+        var exporter = scope.ServiceProvider.GetRequiredService<IAuditExporter>();
+        await using var buffer = new MemoryStream();
+        await exporter.WriteNdjsonAsync(buffer, fromSeq: null, toSeq: null, CancellationToken.None);
+
+        var lines = Encoding.UTF8.GetString(buffer.ToArray())
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var eventLines = lines.Where(l => l.Contains("\"event\"")).ToList();
+        eventLines.Should().HaveCount(2);
+
+        var byEntity = eventLines
+            .Select(l => JsonSerializer.Deserialize<JsonElement>(l))
+            .ToDictionary(e => e.GetProperty("entityId").GetString()!);
+
+        byEntity["old"].TryGetProperty("stale", out var oldStale).Should().BeTrue();
+        oldStale.GetBoolean().Should().BeTrue();
+
+        byEntity["fresh"].TryGetProperty("stale", out _).Should().BeFalse(
+            "fresh events must NOT carry the stale field at all");
+    }
+
+    [Fact]
+    public async Task Export_RetentionDisabled_NoStaleFlag()
+    {
+        // ADR 0006.1: with setting = 0, no event is ever flagged
+        // stale even when older than any specific window.
+        _factory.Retention.Threshold = null;
+        await SeedAtAsync(_factory.NowOverride.AddDays(-365), "old");
+
+        using var scope = _factory.Services.CreateScope();
+        var exporter = scope.ServiceProvider.GetRequiredService<IAuditExporter>();
+        await using var buffer = new MemoryStream();
+        await exporter.WriteNdjsonAsync(buffer, fromSeq: null, toSeq: null, CancellationToken.None);
+
+        var lines = Encoding.UTF8.GetString(buffer.ToArray())
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var eventLine = lines.Single(l => l.Contains("\"event\""));
+        var parsed = JsonSerializer.Deserialize<JsonElement>(eventLine);
+        parsed.TryGetProperty("stale", out _).Should().BeFalse();
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Mcp/AuditToolsTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/AuditToolsTests.cs
@@ -45,7 +45,13 @@ public class AuditToolsTests : IDisposable
         _db.Database.Migrate();
         _chain = new AuditChain(_db, TimeProvider.System);
         _query = new AuditQuery(_db);
-        _exporter = new AuditExporter(_db, TimeProvider.System);
+        _exporter = new AuditExporter(_db, TimeProvider.System, NoRetention.Instance);
+    }
+
+    private sealed class NoRetention : IAuditRetentionPolicy
+    {
+        public static readonly NoRetention Instance = new();
+        public DateTimeOffset? GetStalenessThreshold(DateTimeOffset now) => null;
     }
 
     public void Dispose()
@@ -78,7 +84,7 @@ public class AuditToolsTests : IDisposable
     {
         await SeedAsync(3);
 
-        var output = await AuditTools.List(_query);
+        var output = await AuditTools.List(_query, NoRetention.Instance, TimeProvider.System);
 
         var page = JsonSerializer.Deserialize<AuditPageDto>(output, JsonOpts);
         page!.Items.Should().HaveCount(3);
@@ -89,7 +95,7 @@ public class AuditToolsTests : IDisposable
     [Fact]
     public async Task List_PageSizeOutOfRange_ReturnsInvalidArgument()
     {
-        var output = await AuditTools.List(_query, pageSize: 501);
+        var output = await AuditTools.List(_query, NoRetention.Instance, TimeProvider.System, pageSize: 501);
 
         output.Should().StartWith("policy.audit.invalid_argument:");
         output.Should().Contain("pageSize");
@@ -98,7 +104,7 @@ public class AuditToolsTests : IDisposable
     [Fact]
     public async Task List_BadFromTimestamp_ReturnsInvalidArgument()
     {
-        var output = await AuditTools.List(_query, from: "not-a-date");
+        var output = await AuditTools.List(_query, NoRetention.Instance, TimeProvider.System, from: "not-a-date");
 
         output.Should().StartWith("policy.audit.invalid_argument:");
     }
@@ -106,7 +112,7 @@ public class AuditToolsTests : IDisposable
     [Fact]
     public async Task List_FromGreaterThanTo_ReturnsInvalidArgument()
     {
-        var output = await AuditTools.List(_query,
+        var output = await AuditTools.List(_query, NoRetention.Instance, TimeProvider.System,
             from: "2026-12-31T00:00:00Z",
             to: "2026-01-01T00:00:00Z");
 
@@ -116,7 +122,7 @@ public class AuditToolsTests : IDisposable
     [Fact]
     public async Task List_MalformedCursor_ReturnsInvalidArgument()
     {
-        var output = await AuditTools.List(_query, cursor: "not-base64-content!");
+        var output = await AuditTools.List(_query, NoRetention.Instance, TimeProvider.System, cursor: "not-base64-content!");
 
         output.Should().StartWith("policy.audit.invalid_argument:");
     }
@@ -127,7 +133,7 @@ public class AuditToolsTests : IDisposable
         await SeedAsync(2, actor: "user:alice");
         await SeedAsync(3, actor: "user:bob");
 
-        var output = await AuditTools.List(_query, actor: "user:alice");
+        var output = await AuditTools.List(_query, NoRetention.Instance, TimeProvider.System, actor: "user:alice");
         var page = JsonSerializer.Deserialize<AuditPageDto>(output, JsonOpts);
 
         page!.Items.Should().HaveCount(2);
@@ -155,7 +161,7 @@ public class AuditToolsTests : IDisposable
     {
         await SeedAsync(1);
         var page = JsonSerializer.Deserialize<AuditPageDto>(
-            await AuditTools.List(_query), JsonOpts);
+            await AuditTools.List(_query, NoRetention.Instance, TimeProvider.System), JsonOpts);
         var id = page!.Items[0].Id;
 
         var output = await AuditTools.Get(_query, id.ToString());

--- a/tests/Andy.Policies.Tests.Unit/Settings/AuditRetentionPolicyTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Settings/AuditRetentionPolicyTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Infrastructure.Settings;
+using Andy.Settings.Client;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Settings;
+
+/// <summary>
+/// Unit tests for <see cref="AuditRetentionPolicy"/> (ADR 0006.1,
+/// story rivoli-ai/andy-policies#110). Pins the threshold-math
+/// contract: 0 / negative / missing → no threshold; positive → the
+/// expected past timestamp.
+/// </summary>
+public class AuditRetentionPolicyTests
+{
+    private sealed class StubSnapshot : ISettingsSnapshot
+    {
+        public int? StoredInt { get; set; }
+        public bool? GetBool(string key) => null;
+        public string? GetString(string key) => null;
+        public int? GetInt(string key) =>
+            key == AuditRetentionPolicy.SettingKey ? StoredInt : null;
+        public IReadOnlyCollection<string> Keys => Array.Empty<string>();
+        public DateTimeOffset? LastRefreshedAt => null;
+    }
+
+    private static readonly DateTimeOffset Now =
+        new(2026, 5, 11, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void GetStalenessThreshold_SettingZero_ReturnsNull()
+    {
+        var policy = new AuditRetentionPolicy(new StubSnapshot { StoredInt = 0 });
+        policy.GetStalenessThreshold(Now).Should().BeNull(
+            "0 means 'retain forever' — no event is ever stale, no default cut-off");
+    }
+
+    [Fact]
+    public void GetStalenessThreshold_SettingMissing_ReturnsNull()
+    {
+        var policy = new AuditRetentionPolicy(new StubSnapshot { StoredInt = null });
+        policy.GetStalenessThreshold(Now).Should().BeNull(
+            "a snapshot that has not observed the key is treated as the manifest default (0)");
+    }
+
+    [Fact]
+    public void GetStalenessThreshold_SettingNegative_TreatedAsZero()
+    {
+        var policy = new AuditRetentionPolicy(new StubSnapshot { StoredInt = -7 });
+        policy.GetStalenessThreshold(Now).Should().BeNull(
+            "a negative reading is clamped to 0 — operator error must not silently filter events");
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(30)]
+    [InlineData(365)]
+    public void GetStalenessThreshold_SettingPositive_ReturnsNowMinusDays(int days)
+    {
+        var policy = new AuditRetentionPolicy(new StubSnapshot { StoredInt = days });
+        policy.GetStalenessThreshold(Now).Should().Be(
+            Now - TimeSpan.FromDays(days));
+    }
+
+    [Fact]
+    public void SettingKey_MatchesRegistrationManifestKey()
+    {
+        AuditRetentionPolicy.SettingKey.Should().Be("andy.policies.auditRetentionDays");
+    }
+}


### PR DESCRIPTION
## Summary

- Accepts [ADR 0006.1](https://github.com/rivoli-ai/andy-policies/blob/feat/audit-retention/docs/adr/0006.1-audit-retention.md) — `andy.policies.auditRetentionDays` is metadata-only: it never moves, archives, or deletes rows; `/api/audit/verify` always reads the full chain.
- Adds `IAuditRetentionPolicy` + `AuditRetentionPolicy` (singleton, OTel gauge) reading the setting from `ISettingsSnapshot`. Mirrors the shape of `PinningPolicy` / `ExperimentalOverridesGate`.
- Wires the default `from` filter into three list surfaces: REST `AuditController`, MCP `AuditTools.List`, gRPC `AuditGrpcService.ListAudit`. CLI inherits via REST. Explicit caller-supplied `from` always wins.
- Annotates older events with `"stale": true` in `AuditExporter` NDJSON. Verify path untouched.
- Updates `config/registration.json` setting description and `docs/runbooks/audit-compliance.md` §5 to match.

`Closes #110`

## Test plan

- [x] Unit tests for the policy itself (`AuditRetentionPolicyTests`) — 7 cases covering 0 / negative / missing / positive days.
- [x] Integration tests (`AuditRetentionTests`) — 6 cases covering:
  - retention disabled → full history visible, no stale flags
  - retention positive → list defaults `from` to threshold
  - explicit `?from=` overrides the threshold
  - `/api/audit/verify` ignores the setting (full-chain read)
  - export annotates stale events; fresh events have no field at all
- [x] Updated pre-existing `AuditExporterTests` + `AuditToolsTests` for the new constructor + parameter shape.
- [x] Full suite: 569 unit + 632 integration, all green.
- [x] OpenAPI export run; no wire-shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)