### PR TITLE
fix: attach ServiceBearerHandler to HttpRbacChecker (M2M to andy-rbac)

### DIFF
--- a/config/registration.json
+++ b/config/registration.json
@@ -26,7 +26,7 @@
       "displayName": "Andy Policies API",
       "description": "Service-to-service client for Andy Policies",
       "grantTypes": ["authorization_code", "refresh_token", "client_credentials"],
-      "scopes": ["email", "profile", "roles", "scp:urn:andy-policies-api"]
+      "scopes": ["email", "profile", "roles", "scp:urn:andy-policies-api", "scp:urn:andy-rbac-api"]
     },
     "webClient": {
       "clientId": "andy-policies-web",

--- a/src/Andy.Policies.Api/Andy.Policies.Api.csproj
+++ b/src/Andy.Policies.Api/Andy.Policies.Api.csproj
@@ -14,7 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="Andy.Auth" Version="2025.11.17-rc.1" />
-    <PackageReference Include="Andy.Rbac.Client" Version="1.0.0" />
+    <PackageReference Include="Andy.Auth.M2MClient" Version="2026.5.13-rc.189" />
+    <PackageReference Include="Andy.Rbac.Client" Version="2026.5.15-rc.60" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.62.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.11" />

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -225,7 +225,13 @@ builder.Services.AddMemoryCache();
 // fix in Andy.Rbac.Client for consumers that use IRbacClient).
 builder.Services.AddAndyAuthM2M(builder.Configuration);
 
-builder.Services.AddHttpClient<
+// The bearer handler is only attached when AndyAuth.ClientId is set —
+// in production (embedded mode) Conductor sets it; in tests the
+// WebApplicationFactory only sets Authority. Without ClientId, the
+// ClientCredentialsTokenProvider has nothing to mint and would throw
+// before HttpRbacChecker's transport-error fail-closed branch ran,
+// surfacing 500 on every authorization integration test.
+var rbacClientBuilder = builder.Services.AddHttpClient<
     Andy.Policies.Application.Interfaces.IRbacChecker,
     Andy.Policies.Infrastructure.Services.Rbac.HttpRbacChecker>((sp, client) =>
 {
@@ -235,8 +241,12 @@ builder.Services.AddHttpClient<
             "AndyRbac:BaseUrl is not configured at HttpClient build time.");
     client.BaseAddress = new Uri(url);
     client.Timeout = TimeSpan.FromSeconds(3);
-})
-.AddHttpMessageHandler<Andy.Auth.M2MClient.ServiceBearerHandler>();
+});
+
+if (!string.IsNullOrWhiteSpace(builder.Configuration["AndyAuth:ClientId"]))
+{
+    rbacClientBuilder.AddHttpMessageHandler<Andy.Auth.M2MClient.ServiceBearerHandler>();
+}
 // --- Registration manifest (P10.3, #38) ---
 // Embedded mode (docker-compose.embedded.yml) sets
 // Registration:AutoRegister=true so andy-policies self-registers its

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using Andy.Auth.M2MClient;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Infrastructure.Data;
 using Andy.Policies.Infrastructure.Services;
@@ -213,6 +214,17 @@ if (string.IsNullOrWhiteSpace(builder.Configuration["AndyRbac:BaseUrl"]))
         "before starting the API. There is no production fallback.");
 }
 builder.Services.AddMemoryCache();
+
+// M2M Bearer for outbound /api/check calls. Without this, andy-rbac's
+// [Authorize] middleware rejects the call before HttpRbacChecker's
+// fail-closed path even sees a 401, surfacing 403 on every Conductor
+// panel that gates on [RequirePermission(...)]. The shared
+// Andy.Auth.M2MClient binds AndyAuthM2MOptions from the "AndyAuth"
+// configuration section and registers ServiceBearerHandler +
+// IServiceTokenProvider. Mirrors rivoli-ai/andy-rbac#75 (the same
+// fix in Andy.Rbac.Client for consumers that use IRbacClient).
+builder.Services.AddAndyAuthM2M(builder.Configuration);
+
 builder.Services.AddHttpClient<
     Andy.Policies.Application.Interfaces.IRbacChecker,
     Andy.Policies.Infrastructure.Services.Rbac.HttpRbacChecker>((sp, client) =>
@@ -223,7 +235,8 @@ builder.Services.AddHttpClient<
             "AndyRbac:BaseUrl is not configured at HttpClient build time.");
     client.BaseAddress = new Uri(url);
     client.Timeout = TimeSpan.FromSeconds(3);
-});
+})
+.AddHttpMessageHandler<Andy.Auth.M2MClient.ServiceBearerHandler>();
 // --- Registration manifest (P10.3, #38) ---
 // Embedded mode (docker-compose.embedded.yml) sets
 // Registration:AutoRegister=true so andy-policies self-registers its


### PR DESCRIPTION
## Summary
Mirrors rivoli-ai/andy-rbac#75 for andy-policies' custom `HttpRbacChecker`. That class predates `Andy.Rbac.Client`'s `IRbacClient`, so we can't simply swap to `AddRbacClientWithM2M` (the cleanest path for andy-agents and andy-models). Instead we attach the same `ServiceBearerHandler` directly to its typed `HttpClient`.

Without an M2M Bearer, andy-rbac's `[Authorize]` middleware rejected every outbound `/api/check` call before `HttpRbacChecker` even saw a 401, so its fail-closed branch ran on every request and every Conductor panel that gated on `[RequirePermission(...)]` surfaced 403.

Changes:
- Bump `Andy.Rbac.Client` 1.0.0 → 2026.5.15-rc.60 (for transitive M2MClient parity with andy-agents / andy-models).
- Add explicit `Andy.Auth.M2MClient` 2026.5.13-rc.189 reference.
- `AddAndyAuthM2M(builder.Configuration)` — registers `IServiceTokenProvider` + `ServiceBearerHandler`.
- `.AddHttpMessageHandler<ServiceBearerHandler>()` chained onto the existing typed-HttpClient wiring.
- Grant `scp:urn:andy-rbac-api` to the `andy-policies-api` OAuth client.

Conductor will set `AndyAuth__ClientId` / `__ClientSecretEnvVar` / `__Scope` alongside the existing `AndyRbac__BaseUrl`.

## Test plan
- [ ] `dotnet build` clean (verified locally)
- [ ] Conductor smoke: open Policies tab → policies render without 403
- [ ] andy-policies log: M2M token acquired, outbound `/api/check` returns 200 (not 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)