### PR TITLE
docs: refresh stale markdown content

### DIFF
--- a/docs/adr/0006-audit-hash-chain.md
+++ b/docs/adr/0006-audit-hash-chain.md
@@ -62,7 +62,7 @@ Rejected: SHA-3-256 (no ecosystem pay-off for the complexity tax); SHA-512 (128 
 
 Authoritative normative reference: [RFC 8785 (March 2020)](https://datatracker.ietf.org/doc/html/rfc8785).
 
-Required properties enforced in `src/Andy.Policies.Infrastructure/Audit/CanonicalJson.cs`:
+Required properties enforced in `src/Andy.Policies.Shared/Auditing/CanonicalJson.cs`:
 
 - **UTF-8 without BOM** (§3.2.1)
 - **Lexicographic key ordering** at every object level (§3.2.3) — sort by UTF-16 code units per ES2015 `Array.prototype.sort`

--- a/docs/adr/0007-edit-rbac.md
+++ b/docs/adr/0007-edit-rbac.md
@@ -23,7 +23,7 @@ The Phase 0 review also flagged a fifth item — **cache invalidation strategy**
 
 ### 1. Delegation: call andy-rbac, don't re-implement locally
 
-`IRbacChecker.CheckAsync(subject, permission, resourceInstanceId, ct)` is implemented by `HttpRbacChecker` in `src/Andy.Policies.Infrastructure/Rbac/`, which:
+`IRbacChecker.CheckAsync(subject, permission, resourceInstanceId, ct)` is implemented by `HttpRbacChecker` in `src/Andy.Policies.Infrastructure/Services/Rbac/`, which:
 
 - Sends `POST {AndyRbac:BaseUrl}/api/check` with body `{SubjectId, Permission, Groups, ResourceInstanceId}`
 - Returns the `{Allowed, Reason}` response body verbatim


### PR DESCRIPTION
## Summary

- Fix two stale source paths in ADRs:
  - `docs/adr/0006-audit-hash-chain.md`: `src/Andy.Policies.Infrastructure/Audit/CanonicalJson.cs` -> `src/Andy.Policies.Shared/Auditing/CanonicalJson.cs` (the canonical-JSON helper now lives in the shared assembly).
  - `docs/adr/0007-edit-rbac.md`: `src/Andy.Policies.Infrastructure/Rbac/` -> `src/Andy.Policies.Infrastructure/Services/Rbac/` (matches `HttpRbacChecker.cs` on disk).

## Test plan

- [ ] `ls` the new paths to confirm.