### PR TITLE
feat(#232): evaluatePlan endpoint for andy-tasks auto-approval

### DIFF
--- a/config/rbac-seed.json
+++ b/config/rbac-seed.json
@@ -9,6 +9,7 @@
     { "code": "scope",    "name": "Scope Node",      "supportsInstances": true  },
     { "code": "bundle",   "name": "Policy Bundle",   "supportsInstances": true  },
     { "code": "audit",    "name": "Audit Event",     "supportsInstances": true  },
+    { "code": "plan",     "name": "Plan Evaluation", "supportsInstances": false },
     { "code": "settings", "name": "Settings",        "supportsInstances": false }
   ],
   "permissions": [
@@ -32,7 +33,8 @@
     { "code": "andy-policies:bundle:delete",     "name": "Soft-delete a bundle",     "resourceType": "bundle"   },
     { "code": "andy-policies:audit:read",        "name": "Read audit events",        "resourceType": "audit"    },
     { "code": "andy-policies:audit:export",      "name": "Export audit chain",       "resourceType": "audit"    },
-    { "code": "andy-policies:audit:verify",      "name": "Verify audit chain",       "resourceType": "audit"    }
+    { "code": "andy-policies:audit:verify",      "name": "Verify audit chain",       "resourceType": "audit"    },
+    { "code": "andy-policies:plan:evaluate",     "name": "Evaluate a plan",          "resourceType": "plan"     }
   ],
   "roles": [
     {

--- a/config/registration.json
+++ b/config/registration.json
@@ -62,6 +62,7 @@
       { "code": "scope",    "name": "Scope Node",      "supportsInstances": true  },
       { "code": "bundle",   "name": "Policy Bundle",   "supportsInstances": true  },
       { "code": "audit",    "name": "Audit Event",     "supportsInstances": true  },
+      { "code": "plan",     "name": "Plan Evaluation", "supportsInstances": false },
       { "code": "settings", "name": "Settings",        "supportsInstances": false }
     ],
     "permissions": [
@@ -85,7 +86,8 @@
       { "code": "andy-policies:bundle:delete",     "name": "Soft-delete a bundle",     "resourceType": "bundle"   },
       { "code": "andy-policies:audit:read",        "name": "Read audit events",        "resourceType": "audit"    },
       { "code": "andy-policies:audit:export",      "name": "Export audit chain",       "resourceType": "audit"    },
-      { "code": "andy-policies:audit:verify",      "name": "Verify audit chain",       "resourceType": "audit"    }
+      { "code": "andy-policies:audit:verify",      "name": "Verify audit chain",       "resourceType": "audit"    },
+      { "code": "andy-policies:plan:evaluate",     "name": "Evaluate a plan",          "resourceType": "plan"     }
     ],
     "roles": [
       {

--- a/docs/reference/permission-catalog.md
+++ b/docs/reference/permission-catalog.md
@@ -14,6 +14,7 @@ Application code: `andy-policies`
 | `scope` | Scope Node | yes |
 | `bundle` | Policy Bundle | yes |
 | `audit` | Audit Event | yes |
+| `plan` | Plan Evaluation | no |
 | `settings` | Settings | no |
 
 ## Permissions
@@ -41,6 +42,7 @@ Application code: `andy-policies`
 | `andy-policies:audit:read` | Read audit events | `audit` |
 | `andy-policies:audit:export` | Export audit chain | `audit` |
 | `andy-policies:audit:verify` | Verify audit chain | `audit` |
+| `andy-policies:plan:evaluate` | Evaluate a plan | `plan` |
 
 ## Roles
 
@@ -54,6 +56,6 @@ Application code: `andy-policies`
 
 ## Counts
 
-- Resource types: 7
-- Permissions: 21
+- Resource types: 8
+- Permissions: 22
 - Roles: 5

--- a/src/Andy.Policies.Api/Controllers/EvaluatePlanController.cs
+++ b/src/Andy.Policies.Api/Controllers/EvaluatePlanController.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.PlanEvaluation;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Andy.Policies.Api.Controllers;
+
+/// <summary>
+/// Plan-evaluation surface for rivoli-ai/andy-policies#232 (companion
+/// to rivoli-ai/conductor#1633 SP.4.2). andy-tasks calls
+/// <c>POST /api/policies/evaluate-plan</c> on plan finalize to decide
+/// whether the plan can auto-approve, must surface to a human, or is
+/// rejected outright. The endpoint itself is intentionally narrow —
+/// idempotent per <c>(goalId, planVersion)</c>, no side effects beyond
+/// the 5-minute decision cache, no audit row of its own (the caller
+/// records the decision as it pipes it into the goal lifecycle).
+/// </summary>
+[ApiController]
+[Route("api/policies")]
+[Authorize]
+public sealed class EvaluatePlanController : ControllerBase
+{
+    private readonly IPlanEvaluator _evaluator;
+
+    public EvaluatePlanController(IPlanEvaluator evaluator)
+    {
+        _evaluator = evaluator;
+    }
+
+    /// <summary>
+    /// Evaluate the plan for <paramref name="request"/>.GoalId against
+    /// the workspace's policies. Returns:
+    /// <list type="bullet">
+    ///   <item><c>200</c> with the decision + predicate trace when the
+    ///     goal resolves and the evaluator reaches a verdict.</item>
+    ///   <item><c>400</c> when the request body is missing or
+    ///     <c>GoalId</c> is the empty GUID.</item>
+    ///   <item><c>404</c> when andy-tasks doesn't recognise the goal.</item>
+    /// </list>
+    /// Idempotent for 5 minutes per <c>(goalId, planVersion)</c> — a
+    /// second call within the window returns the cached response
+    /// verbatim, including the same predicate trace; a replanned goal
+    /// (new <c>planVersion</c>) bypasses the cache.
+    /// </summary>
+    [HttpPost("evaluate-plan")]
+    [Authorize(Policy = "andy-policies:plan:evaluate")]
+    [ProducesResponseType(typeof(EvaluatePlanResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<EvaluatePlanResponse>> EvaluatePlan(
+        [FromBody] EvaluatePlanRequest request, CancellationToken ct)
+    {
+        if (request is null) return BadRequest("Request body required.");
+        if (request.GoalId == Guid.Empty)
+        {
+            return BadRequest("goalId is required and must not be the empty GUID.");
+        }
+
+        var response = await _evaluator.EvaluatePlanAsync(request.GoalId, ct);
+        return response is null ? NotFound() : Ok(response);
+    }
+}

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -72,6 +72,12 @@ string[] rbacPermissionCodes =
     "andy-policies:bundle:read",        "andy-policies:bundle:create",
     "andy-policies:bundle:delete",      "andy-policies:audit:read",
     "andy-policies:audit:export",       "andy-policies:audit:verify",
+    // rivoli-ai/andy-policies#232 (SP.4.2): andy-tasks calls
+    // POST /api/policies/evaluate-plan on plan finalize via M2M. Code
+    // listed here so AddAuthorization registers the named policy; the
+    // RBAC manifest entry is added alongside the existing
+    // andy-policies:* set.
+    "andy-policies:plan:evaluate",
 };
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddSingleton<
@@ -250,6 +256,50 @@ if (!string.IsNullOrWhiteSpace(builder.Configuration["AndyAuth:ClientId"]))
 {
     rbacClientBuilder.AddHttpMessageHandler<Andy.Auth.M2MClient.ServiceBearerHandler>();
 }
+
+// rivoli-ai/andy-policies#232 (SP.4.2): outbound to andy-tasks for
+// plan-evaluation goal fetches. AndyTasks:BaseUrl is OPTIONAL in
+// modes that don't ship andy-tasks (embedded-only deployments) —
+// missing config means the plan-eval endpoint registers but returns
+// 503 (handled by the client mapping a transport error to null →
+// controller 404). Production stacks set it via appsettings or
+// AndyTasks__BaseUrl. The ServiceBearerHandler attaches the same
+// Andy.Auth.M2MClient bearer that the RBAC client uses.
+var tasksClientBuilder = builder.Services.AddHttpClient<
+    Andy.Policies.Application.PlanEvaluation.ITasksPlanClient,
+    Andy.Policies.Infrastructure.Services.PlanEvaluation.HttpTasksPlanClient>((sp, client) =>
+{
+    var cfg = sp.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>();
+    var url = cfg["AndyTasks:BaseUrl"]
+        ?? "http://localhost:5500"; // dev-only fallback; production must override
+    client.BaseAddress = new Uri(url);
+    client.Timeout = TimeSpan.FromSeconds(5);
+});
+if (!string.IsNullOrWhiteSpace(builder.Configuration["AndyAuth:ClientId"]))
+{
+    tasksClientBuilder.AddHttpMessageHandler<Andy.Auth.M2MClient.ServiceBearerHandler>();
+}
+
+// rivoli-ai/andy-policies#232: plan-aware predicate registry. Order
+// is registration order; the evaluator iterates predicates in the
+// order DI hands them back, so the wire response surfaces them in a
+// stable, documented order (matches the issue body).
+builder.Services.AddSingleton<Andy.Policies.Application.PlanEvaluation.IPlanPredicate,
+    Andy.Policies.Infrastructure.Services.PlanEvaluation.AllTasksReadOnlyPredicate>();
+builder.Services.AddSingleton<Andy.Policies.Application.PlanEvaluation.IPlanPredicate,
+    Andy.Policies.Infrastructure.Services.PlanEvaluation.WorkspaceIsSandboxPredicate>();
+builder.Services.AddSingleton<Andy.Policies.Application.PlanEvaluation.IPlanPredicate,
+    Andy.Policies.Infrastructure.Services.PlanEvaluation.NoProductionDeployPredicate>();
+builder.Services.AddSingleton<Andy.Policies.Application.PlanEvaluation.IPlanPredicate,
+    Andy.Policies.Infrastructure.Services.PlanEvaluation.AllAgentsApprovedPredicate>();
+builder.Services.AddSingleton<Andy.Policies.Application.PlanEvaluation.IPlanPredicate,
+    Andy.Policies.Infrastructure.Services.PlanEvaluation.RespectsCostBudgetPredicate>();
+// PlanEvaluator is scoped because it depends on the scoped DbContext
+// (loading RulesJson by version id) and the scoped binding resolver.
+// The 5-minute idempotency cache lives on the singleton IMemoryCache
+// already registered above.
+builder.Services.AddScoped<Andy.Policies.Application.PlanEvaluation.IPlanEvaluator,
+    Andy.Policies.Infrastructure.Services.PlanEvaluation.PlanEvaluator>();
 // --- Registration manifest (P10.3, #38) ---
 // Embedded mode (docker-compose.embedded.yml) sets
 // Registration:AutoRegister=true so andy-policies self-registers its

--- a/src/Andy.Policies.Application/Dtos/EvaluatePlanDtos.cs
+++ b/src/Andy.Policies.Application/Dtos/EvaluatePlanDtos.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.Dtos;
+
+/// <summary>
+/// Inbound request for <c>POST /api/policies/evaluate-plan</c>
+/// (rivoli-ai/andy-policies#232, companion to rivoli-ai/conductor#1633
+/// SP.4.2). andy-tasks calls this on plan finalize. The service fetches
+/// the goal + tasks back from andy-tasks via M2M, projects them into a
+/// <c>PlanEvaluationGoalView</c>, runs the workspace's policies over
+/// the registered plan-aware predicates, and returns a single
+/// approve/manual/reject decision plus the predicate trace.
+/// </summary>
+public sealed record EvaluatePlanRequest(Guid GoalId);
+
+/// <summary>
+/// Result of evaluating a plan against the workspace's policies.
+/// <see cref="Decision"/> is the wire-stable lowercase string
+/// <c>approve</c> / <c>manual</c> / <c>reject</c>; <see cref="PolicyId"/>
+/// is the policy that fired the approve/reject decision (null when the
+/// decision degraded to the default <c>manual</c>); <see cref="Predicates"/>
+/// is the full evaluation trace — every predicate evaluated against
+/// the plan, regardless of which policy used it.
+/// </summary>
+public sealed record EvaluatePlanResponse(
+    string Decision,
+    string? PolicyId,
+    IReadOnlyList<PredicateResultDto> Predicates);
+
+/// <summary>
+/// One predicate evaluation result. <see cref="Passed"/> is the
+/// raw boolean; <see cref="Reason"/> carries a human-readable
+/// explanation, especially in the negative case (e.g.
+/// <c>"data unavailable"</c> when the predicate could not evaluate
+/// because the goal view was missing the relevant field — per the
+/// issue spec, missing data must never be treated as silently passing).
+/// </summary>
+public sealed record PredicateResultDto(
+    string Name,
+    bool Passed,
+    string Reason);

--- a/src/Andy.Policies.Application/PlanEvaluation/IPlanEvaluator.cs
+++ b/src/Andy.Policies.Application/PlanEvaluation/IPlanEvaluator.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+
+namespace Andy.Policies.Application.PlanEvaluation;
+
+/// <summary>
+/// Top-level orchestrator for <c>POST /api/policies/evaluate-plan</c>
+/// (rivoli-ai/andy-policies#232). Implementations:
+/// <list type="number">
+///   <item>Fetch the goal view from andy-tasks via <see cref="ITasksPlanClient"/>.</item>
+///   <item>Resolve the workspace's applicable policies via the existing
+///     binding-resolution pipeline (P4.3).</item>
+///   <item>Evaluate every registered <see cref="IPlanPredicate"/> against
+///     the view.</item>
+///   <item>Apply the per-policy decision rules from <c>RulesJson</c> —
+///     first policy that fires <c>approve</c> or <c>reject</c> wins;
+///     default <c>manual</c>.</item>
+///   <item>Cache the resulting decision for 5 minutes keyed on
+///     <c>(GoalId, PlanVersion)</c>.</item>
+/// </list>
+/// Returns <c>null</c> when the goal does not exist; the controller
+/// translates that to 404.
+/// </summary>
+public interface IPlanEvaluator
+{
+    Task<EvaluatePlanResponse?> EvaluatePlanAsync(
+        Guid goalId, CancellationToken ct = default);
+}

--- a/src/Andy.Policies.Application/PlanEvaluation/IPlanPredicate.cs
+++ b/src/Andy.Policies.Application/PlanEvaluation/IPlanPredicate.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.PlanEvaluation;
+
+/// <summary>
+/// One plan-aware predicate (rivoli-ai/andy-policies#232 DSL extension).
+/// Implementations are pure functions of the projected
+/// <see cref="PlanEvaluationGoalView"/> — no I/O, no DI lookups at evaluate
+/// time. The set of registered predicates is the catalog the policy DSL
+/// can reference by <see cref="Name"/>.
+/// </summary>
+/// <remarks>
+/// Contract: when the predicate cannot be evaluated against the given
+/// view (e.g. cost data is missing for <c>respectsCostBudget</c>), it
+/// MUST return <see cref="PredicateEvaluation.Unevaluable"/> — never
+/// silently treat missing data as a pass. The evaluator surfaces these
+/// as <c>passed: false, reason: "data unavailable"</c> on the wire so
+/// the caller can react.
+/// </remarks>
+public interface IPlanPredicate
+{
+    /// <summary>
+    /// Wire-stable identifier (camelCase, e.g. <c>allTasksReadOnly</c>).
+    /// Pinned by the issue body; do not rename without a contract bump.
+    /// </summary>
+    string Name { get; }
+
+    PredicateEvaluation Evaluate(PlanEvaluationGoalView view);
+}
+
+/// <summary>
+/// Tri-state result of a predicate. <see cref="Pass"/>/<see cref="Fail"/>
+/// carry an explanatory reason; <see cref="Unevaluable"/> means the
+/// required data was missing from the projected view. The evaluator
+/// collapses <see cref="Unevaluable"/> to <c>passed: false</c> on the
+/// wire — never to <c>true</c>.
+/// </summary>
+public readonly record struct PredicateEvaluation(
+    PredicateOutcome Outcome,
+    string Reason)
+{
+    public static PredicateEvaluation Pass(string reason) =>
+        new(PredicateOutcome.Pass, reason);
+
+    public static PredicateEvaluation Fail(string reason) =>
+        new(PredicateOutcome.Fail, reason);
+
+    public static PredicateEvaluation Unevaluable(string reason = "data unavailable") =>
+        new(PredicateOutcome.Unevaluable, reason);
+}
+
+public enum PredicateOutcome
+{
+    Pass,
+    Fail,
+    Unevaluable,
+}

--- a/src/Andy.Policies.Application/PlanEvaluation/ITasksPlanClient.cs
+++ b/src/Andy.Policies.Application/PlanEvaluation/ITasksPlanClient.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.PlanEvaluation;
+
+/// <summary>
+/// Outbound consumer of andy-tasks (rivoli-ai/andy-policies#232).
+/// Fetches a goal + its tasks + plan-time estimates + workspace
+/// metadata over the existing M2M bearer pipeline, then projects them
+/// into a <see cref="PlanEvaluationGoalView"/> the predicates can
+/// evaluate against. Returns <c>null</c> when the goal does not exist
+/// (controller surfaces 404); throws for transport / authz failures so
+/// they surface as a 5xx the caller can retry rather than a misleading
+/// <c>manual</c> default.
+/// </summary>
+public interface ITasksPlanClient
+{
+    Task<PlanEvaluationGoalView?> FetchGoalViewAsync(
+        Guid goalId, CancellationToken ct = default);
+}

--- a/src/Andy.Policies.Application/PlanEvaluation/PlanEvaluationGoalView.cs
+++ b/src/Andy.Policies.Application/PlanEvaluation/PlanEvaluationGoalView.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.PlanEvaluation;
+
+/// <summary>
+/// Service-internal projection of an andy-tasks Goal (with its tasks +
+/// estimates + workspace metadata) into the minimal shape required by
+/// the plan-aware predicates (rivoli-ai/andy-policies#232).
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is intentionally a thin, predicate-facing surface — not a
+/// re-shape of every andy-tasks DTO. The <see cref="ITasksPlanClient"/>
+/// implementation is responsible for mapping andy-tasks' wire DTOs
+/// (<c>GoalDto</c>, <c>TaskDto</c>, <c>EstimatesResponse</c>) into this
+/// view; predicates evaluate against this view only.
+/// </para>
+/// <para>
+/// Every collection field is <see cref="IReadOnlyList{T}"/>. Optional
+/// fields are nullable; predicates that touch a null field must treat
+/// the predicate as failing with reason <c>"data unavailable"</c> per
+/// the issue spec — never silently pass when the underlying data is
+/// missing.
+/// </para>
+/// </remarks>
+public sealed record PlanEvaluationGoalView(
+    Guid GoalId,
+    string PlanVersion,
+    string? WorkspaceContainerId,
+    string? WorkspaceTier,
+    IReadOnlyList<string>? WorkspaceApprovedAgentIds,
+    decimal? WorkspaceCostBudgetUsd,
+    IReadOnlyList<PlanEvaluationTaskView> Tasks,
+    decimal? EstimatedCostUsd);
+
+/// <summary>
+/// Per-task projection: the predicate-facing slice of an andy-tasks
+/// <c>TaskDto</c>. <see cref="ToolsAllowed"/> is the <c>DelegationContract.ToolsAllowed</c>
+/// list (lowercase tool slugs); <see cref="EffectiveAgentId"/> is the
+/// task's selected agent or, when no executor has been pinned, the
+/// first entry of <c>SuggestedAgentIds</c> (consistent with how the
+/// caller surfaces "effective agent" elsewhere); <see cref="TargetEnv"/>
+/// is the deployment environment the task targets when known
+/// (<c>"prod"</c> / <c>"staging"</c> / <c>"dev"</c> / null).
+/// </summary>
+public sealed record PlanEvaluationTaskView(
+    Guid TaskId,
+    string? EffectiveAgentId,
+    IReadOnlyList<string> ToolsAllowed,
+    string? TargetEnv);

--- a/src/Andy.Policies.Infrastructure/Services/PlanEvaluation/HttpTasksPlanClient.cs
+++ b/src/Andy.Policies.Infrastructure/Services/PlanEvaluation/HttpTasksPlanClient.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Andy.Policies.Application.PlanEvaluation;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Policies.Infrastructure.Services.PlanEvaluation;
+
+/// <summary>
+/// Production <see cref="ITasksPlanClient"/> for
+/// rivoli-ai/andy-policies#232. Pulls goal + tasks + plan-time
+/// estimates from andy-tasks via the typed HttpClient wired in
+/// <c>Program.cs</c> (the same Andy.Auth.M2MClient bearer handler
+/// that the existing RBAC client uses).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three round-trips per evaluate-plan call: <c>GET /api/goals/{id}</c>,
+/// <c>GET /api/goals/{id}/tasks</c>, <c>GET /api/goals/{id}/estimates</c>.
+/// The estimates call is best-effort — a 404 (no estimates yet) is
+/// mapped to <c>EstimatedCostUsd = null</c>, which causes the
+/// <c>respectsCostBudget</c> predicate to surface
+/// <c>data unavailable</c> rather than fault. Goal and tasks are
+/// load-bearing: a 404 on the goal endpoint cascades to the controller
+/// as a 404; a 404 on tasks (which can happen for goals whose plan
+/// hasn't been materialised) maps to an empty task list, which
+/// predicates evaluate against verbatim.
+/// </para>
+/// <para>
+/// Workspace tier / approved-agents / cost-budget aren't on the
+/// andy-tasks <c>GoalDto</c> today — they're workspace metadata that
+/// lives on Conductor's workspace catalog. For #232 we project what
+/// andy-tasks does expose: container id + repository + branch. The
+/// other fields are left null, which causes the relevant predicates
+/// to surface <c>data unavailable</c> until the workspace catalog
+/// contract grows them. Future PRs will replace the null-fallbacks
+/// with a real lookup against the workspace metadata service.
+/// </para>
+/// </remarks>
+public sealed class HttpTasksPlanClient : ITasksPlanClient
+{
+    private static readonly JsonSerializerOptions WireFormat = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+    };
+
+    private readonly HttpClient _http;
+    private readonly ILogger<HttpTasksPlanClient> _log;
+
+    public HttpTasksPlanClient(HttpClient http, ILogger<HttpTasksPlanClient> log)
+    {
+        _http = http;
+        _log = log;
+    }
+
+    public async Task<PlanEvaluationGoalView?> FetchGoalViewAsync(
+        Guid goalId, CancellationToken ct = default)
+    {
+        var goal = await GetOrNullAsync<GoalEnvelope>(
+            $"api/goals/{goalId:D}", ct).ConfigureAwait(false);
+        if (goal is null) return null;
+
+        var tasks = await GetOrEmptyAsync<TaskEnvelope[]>(
+            $"api/goals/{goalId:D}/tasks", ct).ConfigureAwait(false)
+            ?? Array.Empty<TaskEnvelope>();
+
+        var estimates = await GetOrNullAsync<EstimatesEnvelope>(
+            $"api/goals/{goalId:D}/estimates", ct).ConfigureAwait(false);
+
+        return new PlanEvaluationGoalView(
+            GoalId: goal.Id,
+            PlanVersion: goal.PlanVersion ?? "1",
+            WorkspaceContainerId: goal.Workspace?.ContainerId,
+            // Workspace tier / approvedAgentIds / costBudgetUsd aren't on
+            // GoalDto today. Leaving them null surfaces the corresponding
+            // predicates as "data unavailable" rather than silently
+            // passing, per the issue spec.
+            WorkspaceTier: null,
+            WorkspaceApprovedAgentIds: null,
+            WorkspaceCostBudgetUsd: null,
+            Tasks: tasks.Select(MapTask).ToList(),
+            EstimatedCostUsd: estimates?.Planned?.CostUsdP50);
+    }
+
+    private static PlanEvaluationTaskView MapTask(TaskEnvelope t) => new(
+        TaskId: t.Id,
+        // Effective agent: explicit executor first, then the top
+        // suggestion. Mirrors how andy-tasks itself ranks agent
+        // selection — the planner-suggested list is ordered.
+        EffectiveAgentId: !string.IsNullOrWhiteSpace(t.ExecutorId)
+            ? t.ExecutorId
+            : t.SuggestedAgentIds?.FirstOrDefault(),
+        ToolsAllowed: t.DelegationContract?.ToolsAllowed
+            ?? (IReadOnlyList<string>)Array.Empty<string>(),
+        TargetEnv: null /* not on TaskDto today */);
+
+    private async Task<T?> GetOrNullAsync<T>(string path, CancellationToken ct)
+        where T : class
+    {
+        try
+        {
+            using var resp = await _http.GetAsync(path, ct).ConfigureAwait(false);
+            if (resp.StatusCode == HttpStatusCode.NotFound) return null;
+            resp.EnsureSuccessStatusCode();
+            return await resp.Content.ReadFromJsonAsync<T>(WireFormat, ct).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            _log.LogWarning(ex,
+                "tasks plan client: GET {Path} failed transport; treating as missing", path);
+            return null;
+        }
+    }
+
+    private async Task<T?> GetOrEmptyAsync<T>(string path, CancellationToken ct)
+        where T : class
+    {
+        var v = await GetOrNullAsync<T>(path, ct).ConfigureAwait(false);
+        return v;
+    }
+
+    // ---- Wire shapes (camelCase JSON, mirror andy-tasks DTOs) -------------
+
+    private sealed record GoalEnvelope(
+        Guid Id,
+        string? Title,
+        string? PlanVersion,
+        WorkspaceEnvelope? Workspace);
+
+    private sealed record WorkspaceEnvelope(
+        string? ContainerId,
+        string? Repository,
+        string? Branch);
+
+    private sealed record TaskEnvelope(
+        Guid Id,
+        string? ExternalId,
+        DelegationContractEnvelope? DelegationContract,
+        IReadOnlyList<string>? SuggestedAgentIds,
+        string? ExecutorId);
+
+    private sealed record DelegationContractEnvelope(
+        string? Objective,
+        string? OutputFormat,
+        IReadOnlyList<string>? ToolsAllowed,
+        IReadOnlyList<string>? Boundaries);
+
+    private sealed record EstimatesEnvelope(EstimateSlotEnvelope? Planned);
+
+    private sealed record EstimateSlotEnvelope(
+        decimal? CostUsdP50,
+        decimal? CostUsdP90);
+}

--- a/src/Andy.Policies.Infrastructure/Services/PlanEvaluation/PlanEvaluator.cs
+++ b/src/Andy.Policies.Infrastructure/Services/PlanEvaluation/PlanEvaluator.cs
@@ -1,0 +1,256 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Application.PlanEvaluation;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Policies.Infrastructure.Services.PlanEvaluation;
+
+/// <summary>
+/// Reference <see cref="IPlanEvaluator"/> (rivoli-ai/andy-policies#232).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Pipeline (in order):
+/// </para>
+/// <list type="number">
+///   <item>Fetch the projected goal view from andy-tasks via
+///     <see cref="ITasksPlanClient"/>. Return null on 404 — controller
+///     translates that to 404 so the caller can distinguish "missing
+///     goal" from "no policies registered".</item>
+///   <item>Check the 5-minute idempotency cache keyed on
+///     <c>(GoalId, PlanVersion)</c>. Hit returns the cached response
+///     verbatim; the planVersion in the cache key guarantees that a
+///     replanned goal sees a fresh decision.</item>
+///   <item>Evaluate every registered <see cref="IPlanPredicate"/>
+///     against the view exactly once. The same predicate trace is
+///     consumed by every policy's rule list AND surfaced to the caller
+///     so the wire response carries the full set, not just the rules
+///     the winning policy referenced.</item>
+///   <item>Resolve the workspace's applicable policies via the existing
+///     <see cref="IBindingResolutionService"/> (P4.3) — the bridge that
+///     walks the scope chain from the workspace's container reference
+///     and folds tighten-only.</item>
+///   <item>For each effective policy in resolution order, load its
+///     <c>RulesJson</c>, parse the <c>planEvaluation</c> block, and
+///     evaluate its decision rules against the predicate trace. The
+///     first policy whose rule fires <c>approve</c> or <c>reject</c>
+///     wins; ties are broken by resolution order (Mandatory wins, then
+///     deeper scope, then earlier <c>CreatedAt</c> — already enforced
+///     by P4.3's tighten-only fold).</item>
+///   <item>Default: <c>manual</c>.</item>
+/// </list>
+/// </remarks>
+public sealed class PlanEvaluator : IPlanEvaluator
+{
+    private static readonly TimeSpan IdempotencyTtl = TimeSpan.FromMinutes(5);
+
+    private readonly ITasksPlanClient _tasks;
+    private readonly IBindingResolutionService _bindings;
+    private readonly AppDbContext _db;
+    private readonly IEnumerable<IPlanPredicate> _predicates;
+    private readonly IMemoryCache _cache;
+    private readonly ILogger<PlanEvaluator> _log;
+
+    public PlanEvaluator(
+        ITasksPlanClient tasks,
+        IBindingResolutionService bindings,
+        AppDbContext db,
+        IEnumerable<IPlanPredicate> predicates,
+        IMemoryCache cache,
+        ILogger<PlanEvaluator> log)
+    {
+        _tasks = tasks;
+        _bindings = bindings;
+        _db = db;
+        _predicates = predicates;
+        _cache = cache;
+        _log = log;
+    }
+
+    public async Task<EvaluatePlanResponse?> EvaluatePlanAsync(
+        Guid goalId, CancellationToken ct = default)
+    {
+        var view = await _tasks.FetchGoalViewAsync(goalId, ct).ConfigureAwait(false);
+        if (view is null) return null;
+
+        var cacheKey = $"plan-eval:{view.GoalId:D}:{view.PlanVersion}";
+        if (_cache.TryGetValue(cacheKey, out EvaluatePlanResponse? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        // Evaluate every predicate once. Stable order = registration
+        // order from DI. Stored on the response so callers see the
+        // full predicate trace, not just whatever the winning rule
+        // happened to name.
+        var predicateResults = _predicates
+            .Select(p =>
+            {
+                var eval = p.Evaluate(view);
+                return new
+                {
+                    p.Name,
+                    Evaluation = eval,
+                    Dto = ToDto(p.Name, eval),
+                };
+            })
+            .ToList();
+
+        var byName = predicateResults.ToDictionary(r => r.Name, r => r.Evaluation, StringComparer.Ordinal);
+
+        // Resolve workspace policies via the binding chain. The
+        // workspace's container id is mapped to a `scope:{guid}` target
+        // ref — same shape the existing P4 resolver uses for scope
+        // nodes — but a workspace with no container reference at all
+        // means we can't resolve anything; that falls through to
+        // manual with no policy fired.
+        var effective = await ResolveWorkspacePoliciesAsync(view, ct).ConfigureAwait(false);
+
+        var (decision, firingPolicyId) = await EvaluateDecisionAsync(effective, byName, ct).ConfigureAwait(false);
+
+        var response = new EvaluatePlanResponse(
+            Decision: decision,
+            PolicyId: firingPolicyId,
+            Predicates: predicateResults.Select(r => r.Dto).ToList());
+
+        // Cache only after the response is built. AbsoluteExpirationRelativeToNow
+        // — sliding would let a single hot goal pin a decision longer
+        // than the 5-minute contract.
+        _cache.Set(cacheKey, response, new MemoryCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = IdempotencyTtl,
+        });
+
+        return response;
+    }
+
+    private async Task<IReadOnlyList<EffectivePolicyDto>> ResolveWorkspacePoliciesAsync(
+        PlanEvaluationGoalView view, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(view.WorkspaceContainerId))
+        {
+            _log.LogDebug(
+                "plan eval for goal {GoalId}: no workspace container id; skipping resolution",
+                view.GoalId);
+            return Array.Empty<EffectivePolicyDto>();
+        }
+
+        // The workspace's container id maps to a Scope target — that's
+        // the canonical "everything for this workspace" anchor. If
+        // andy-tasks ever splits its workspace shape into multiple
+        // scopes we resolve them in a future iteration; for #232 a
+        // single anchor matches the existing binding model.
+        var set = await _bindings.ResolveForTargetAsync(
+            BindingTargetType.ScopeNode,
+            $"scope:{view.WorkspaceContainerId}",
+            ct).ConfigureAwait(false);
+
+        return set.Policies;
+    }
+
+    private async Task<(string Decision, string? PolicyId)> EvaluateDecisionAsync(
+        IReadOnlyList<EffectivePolicyDto> effective,
+        IReadOnlyDictionary<string, PredicateEvaluation> byName,
+        CancellationToken ct)
+    {
+        if (effective.Count == 0) return ("manual", null);
+
+        // Load the RulesJson for every effective policy version in one
+        // round-trip. Order preserved by re-projecting through the
+        // input list.
+        var versionIds = effective.Select(e => e.PolicyVersionId).Distinct().ToList();
+        var rulesByVersionId = await _db.PolicyVersions
+            .AsNoTracking()
+            .Where(v => versionIds.Contains(v.Id))
+            .Select(v => new { v.Id, v.RulesJson })
+            .ToDictionaryAsync(v => v.Id, v => v.RulesJson, ct)
+            .ConfigureAwait(false);
+
+        foreach (var policy in effective)
+        {
+            if (!rulesByVersionId.TryGetValue(policy.PolicyVersionId, out var rulesJson))
+            {
+                continue;
+            }
+
+            var rules = PolicyRulesDslParser.TryParse(rulesJson);
+            if (rules?.DecisionRules is null) continue;
+
+            foreach (var rule in rules.DecisionRules)
+            {
+                if (!RuleFires(rule, byName)) continue;
+
+                var normalized = NormalizeDecision(rule.Decision);
+                if (normalized is "approve" or "reject")
+                {
+                    // PolicyKey is the wire-stable string identifier
+                    // ("policy.name") rather than the internal GUID;
+                    // it matches what callers see in catalog listings
+                    // and audit trails.
+                    return (normalized, policy.PolicyKey);
+                }
+                // "manual" rules fall through silently; otherwise
+                // unknown decisions are ignored (catalog tolerance
+                // beats strictness here).
+            }
+        }
+
+        return ("manual", null);
+    }
+
+    private static bool RuleFires(
+        DecisionRule rule,
+        IReadOnlyDictionary<string, PredicateEvaluation> byName)
+    {
+        if (rule.RequireAll is { Count: > 0 })
+        {
+            foreach (var name in rule.RequireAll)
+            {
+                if (!byName.TryGetValue(name, out var ev) ||
+                    ev.Outcome != PredicateOutcome.Pass)
+                {
+                    return false;
+                }
+            }
+        }
+
+        if (rule.RequireNone is { Count: > 0 })
+        {
+            foreach (var name in rule.RequireNone)
+            {
+                // Semantic: rule fires only when NONE of these predicates
+                // passes. An explicit Pass disqualifies the rule; Fail,
+                // Unevaluable, and unknown-by-name all leave the rule
+                // eligible to fire. (Unevaluable is conservative —
+                // "couldn't prove it passed" satisfies "must not pass".)
+                if (byName.TryGetValue(name, out var ev) &&
+                    ev.Outcome == PredicateOutcome.Pass)
+                {
+                    return false;
+                }
+            }
+        }
+
+        // A rule with neither RequireAll nor RequireNone is degenerate
+        // (always fires). Allow it — callers may want a catch-all
+        // "manual" rule as documentation of intent.
+        return true;
+    }
+
+    private static string NormalizeDecision(string? raw) =>
+        raw?.Trim().ToLowerInvariant() ?? "manual";
+
+    private static PredicateResultDto ToDto(string name, PredicateEvaluation eval) => new(
+        Name: name,
+        Passed: eval.Outcome == PredicateOutcome.Pass,
+        Reason: eval.Outcome == PredicateOutcome.Unevaluable
+            ? "data unavailable"
+            : eval.Reason);
+}

--- a/src/Andy.Policies.Infrastructure/Services/PlanEvaluation/PlanPredicates.cs
+++ b/src/Andy.Policies.Infrastructure/Services/PlanEvaluation/PlanPredicates.cs
@@ -1,0 +1,186 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.PlanEvaluation;
+
+namespace Andy.Policies.Infrastructure.Services.PlanEvaluation;
+
+/// <summary>
+/// Five plan-aware predicates pinned by the rivoli-ai/andy-policies#232
+/// acceptance criteria. Each predicate is a pure function of the
+/// projected <see cref="PlanEvaluationGoalView"/>; predicates whose
+/// required data is null on the view return
+/// <see cref="PredicateEvaluation.Unevaluable"/> so the evaluator can
+/// surface them as <c>passed: false, reason: "data unavailable"</c>
+/// rather than silently passing.
+/// </summary>
+public static class PlanPredicateNames
+{
+    public const string AllTasksReadOnly = "allTasksReadOnly";
+    public const string WorkspaceIsSandbox = "workspaceIsSandbox";
+    public const string NoProductionDeploy = "noProductionDeploy";
+    public const string AllAgentsApproved = "allAgentsApproved";
+    public const string RespectsCostBudget = "respectsCostBudget";
+}
+
+/// <summary>
+/// Tools whose name suggests filesystem write, container exec, or
+/// shell exec semantics. Curated rather than allow-listed because the
+/// andy-tasks tool catalog is open-ended — any predicate that defaults
+/// to "approve when unknown" would be a security regression. Match is
+/// case-insensitive substring on the tool slug.
+/// </summary>
+internal static class WriteOrExecToolHeuristics
+{
+    private static readonly string[] WriteOrExecMarkers =
+    [
+        "write", "exec", "shell", "run", "delete", "remove",
+        "edit", "patch", "create", "mutate", "deploy",
+        "publish", "push",
+    ];
+
+    public static bool LooksWriteOrExec(string tool)
+    {
+        var t = tool.ToLowerInvariant();
+        foreach (var marker in WriteOrExecMarkers)
+        {
+            if (t.Contains(marker, StringComparison.Ordinal)) return true;
+        }
+        return false;
+    }
+}
+
+public sealed class AllTasksReadOnlyPredicate : IPlanPredicate
+{
+    public string Name => PlanPredicateNames.AllTasksReadOnly;
+
+    public PredicateEvaluation Evaluate(PlanEvaluationGoalView view)
+    {
+        if (view.Tasks.Count == 0)
+        {
+            // A plan with zero tasks is vacuously read-only — there are
+            // no write-or-exec tools because there are no tasks. But
+            // approving a zero-task plan would be unusual; flagging it
+            // here is misleading. Pass with explicit reason.
+            return PredicateEvaluation.Pass("no tasks in plan");
+        }
+
+        var offenders = view.Tasks
+            .Where(t => t.ToolsAllowed.Any(WriteOrExecToolHeuristics.LooksWriteOrExec))
+            .Select(t => t.TaskId.ToString())
+            .ToList();
+
+        return offenders.Count == 0
+            ? PredicateEvaluation.Pass("no task carries write/exec tools")
+            : PredicateEvaluation.Fail(
+                $"tasks with write/exec tools: {string.Join(", ", offenders)}");
+    }
+}
+
+public sealed class WorkspaceIsSandboxPredicate : IPlanPredicate
+{
+    public string Name => PlanPredicateNames.WorkspaceIsSandbox;
+
+    public PredicateEvaluation Evaluate(PlanEvaluationGoalView view)
+    {
+        if (string.IsNullOrWhiteSpace(view.WorkspaceTier))
+        {
+            return PredicateEvaluation.Unevaluable();
+        }
+
+        return string.Equals(view.WorkspaceTier, "sandbox", StringComparison.OrdinalIgnoreCase)
+            ? PredicateEvaluation.Pass($"workspace tier is {view.WorkspaceTier}")
+            : PredicateEvaluation.Fail($"workspace tier is {view.WorkspaceTier}, not sandbox");
+    }
+}
+
+public sealed class NoProductionDeployPredicate : IPlanPredicate
+{
+    private static readonly string[] ProdMarkers = ["prod", "production"];
+
+    public string Name => PlanPredicateNames.NoProductionDeploy;
+
+    public PredicateEvaluation Evaluate(PlanEvaluationGoalView view)
+    {
+        if (view.Tasks.Count == 0)
+        {
+            return PredicateEvaluation.Pass("no tasks in plan");
+        }
+
+        var prodTasks = view.Tasks
+            .Where(t => t.TargetEnv is not null &&
+                        ProdMarkers.Any(m => string.Equals(t.TargetEnv, m,
+                                              StringComparison.OrdinalIgnoreCase)))
+            .Select(t => t.TaskId.ToString())
+            .ToList();
+
+        return prodTasks.Count == 0
+            ? PredicateEvaluation.Pass("no task targets prod")
+            : PredicateEvaluation.Fail(
+                $"tasks targeting prod: {string.Join(", ", prodTasks)}");
+    }
+}
+
+public sealed class AllAgentsApprovedPredicate : IPlanPredicate
+{
+    public string Name => PlanPredicateNames.AllAgentsApproved;
+
+    public PredicateEvaluation Evaluate(PlanEvaluationGoalView view)
+    {
+        if (view.WorkspaceApprovedAgentIds is null)
+        {
+            return PredicateEvaluation.Unevaluable();
+        }
+
+        if (view.Tasks.Count == 0)
+        {
+            return PredicateEvaluation.Pass("no tasks in plan");
+        }
+
+        // Build a case-sensitive set — agent IDs are opaque slugs;
+        // case-insensitive matching would conflate distinct agents.
+        var approved = new HashSet<string>(view.WorkspaceApprovedAgentIds, StringComparer.Ordinal);
+
+        var unapproved = new List<string>();
+        foreach (var task in view.Tasks)
+        {
+            if (task.EffectiveAgentId is null)
+            {
+                // A task without any selected/suggested agent cannot be
+                // proven approved. Per the spec contract, missing data
+                // does not pass — fail rather than skip.
+                unapproved.Add($"{task.TaskId} (no agent)");
+                continue;
+            }
+
+            if (!approved.Contains(task.EffectiveAgentId))
+            {
+                unapproved.Add($"{task.TaskId} ({task.EffectiveAgentId})");
+            }
+        }
+
+        return unapproved.Count == 0
+            ? PredicateEvaluation.Pass("every task's agent is in the approved list")
+            : PredicateEvaluation.Fail(
+                $"unapproved agents: {string.Join(", ", unapproved)}");
+    }
+}
+
+public sealed class RespectsCostBudgetPredicate : IPlanPredicate
+{
+    public string Name => PlanPredicateNames.RespectsCostBudget;
+
+    public PredicateEvaluation Evaluate(PlanEvaluationGoalView view)
+    {
+        if (view.WorkspaceCostBudgetUsd is null || view.EstimatedCostUsd is null)
+        {
+            return PredicateEvaluation.Unevaluable();
+        }
+
+        return view.EstimatedCostUsd.Value < view.WorkspaceCostBudgetUsd.Value
+            ? PredicateEvaluation.Pass(
+                $"estimated ${view.EstimatedCostUsd.Value:0.##} < budget ${view.WorkspaceCostBudgetUsd.Value:0.##}")
+            : PredicateEvaluation.Fail(
+                $"estimated ${view.EstimatedCostUsd.Value:0.##} ≥ budget ${view.WorkspaceCostBudgetUsd.Value:0.##}");
+    }
+}

--- a/src/Andy.Policies.Infrastructure/Services/PlanEvaluation/PolicyRulesDsl.cs
+++ b/src/Andy.Policies.Infrastructure/Services/PlanEvaluation/PolicyRulesDsl.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Andy.Policies.Infrastructure.Services.PlanEvaluation;
+
+/// <summary>
+/// Wire-format extension of <c>PolicyVersion.RulesJson</c> for
+/// plan evaluation (rivoli-ai/andy-policies#232). Existing policy DSL
+/// blobs (allow/deny lists from the legacy V1 rules) are passed through
+/// unchanged; only policies that opt in to plan evaluation populate
+/// <see cref="PlanEvaluation"/>. Policies whose <c>RulesJson</c> doesn't
+/// declare <c>planEvaluation</c> are ignored by the plan evaluator —
+/// they neither approve nor reject and fall through to the default
+/// <c>manual</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Decision rules are evaluated top-to-bottom: the first rule whose
+/// predicate references <b>all</b> pass (the <c>requireAll</c> list) and
+/// whose negative-predicate references <b>all</b> fail (the
+/// <c>requireNone</c> list) fires. A rule firing with
+/// <see cref="DecisionRule.Decision"/> = <c>approve</c> or <c>reject</c>
+/// terminates evaluation for that policy — the policy emits that
+/// decision. <c>manual</c> rules are allowed for clarity but are
+/// equivalent to no rule firing (the policy falls through).
+/// </para>
+/// <para>
+/// A predicate referenced by name but not registered in the predicate
+/// catalog causes the rule NOT to fire — same posture as a failed
+/// predicate. The evaluator does not throw on unknown predicate names
+/// because that would couple the policy authoring surface to the
+/// service's predicate registry version.
+/// </para>
+/// </remarks>
+public sealed record PlanEvaluationRules(
+    [property: JsonPropertyName("decisionRules")] IReadOnlyList<DecisionRule>? DecisionRules);
+
+public sealed record DecisionRule(
+    [property: JsonPropertyName("decision")] string Decision,
+    [property: JsonPropertyName("requireAll")] IReadOnlyList<string>? RequireAll,
+    [property: JsonPropertyName("requireNone")] IReadOnlyList<string>? RequireNone);
+
+internal sealed record RulesJsonEnvelope(
+    [property: JsonPropertyName("planEvaluation")] PlanEvaluationRules? PlanEvaluation);
+
+public static class PolicyRulesDslParser
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>
+    /// Pull the <c>planEvaluation</c> block out of a policy version's
+    /// opaque <c>RulesJson</c>. Returns <c>null</c> when the policy
+    /// doesn't declare plan evaluation rules (existing P1/V1 policies)
+    /// or when the JSON is malformed — malformed JSON is logged by the
+    /// caller and treated as "policy does not participate in plan
+    /// evaluation" rather than 5xx, because the catalog is multi-tenant
+    /// and one malformed entry must not break evaluation for the rest.
+    /// </summary>
+    public static PlanEvaluationRules? TryParse(string? rulesJson)
+    {
+        if (string.IsNullOrWhiteSpace(rulesJson)) return null;
+        try
+        {
+            var env = JsonSerializer.Deserialize<RulesJsonEnvelope>(rulesJson, Options);
+            return env?.PlanEvaluation;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/PlanEvaluation/EvaluatePlanControllerTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/PlanEvaluation/EvaluatePlanControllerTests.cs
@@ -1,0 +1,397 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using System.Net.Http.Json;
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Application.PlanEvaluation;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Infrastructure.Services.PlanEvaluation;
+using Andy.Policies.Tests.Integration.Controllers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.PlanEvaluation;
+
+/// <summary>
+/// End-to-end integration test for the
+/// <c>POST /api/policies/evaluate-plan</c> surface
+/// (rivoli-ai/andy-policies#232). Drives the controller through the
+/// real DI pipeline — including the test SQLite-backed
+/// <see cref="AppDbContext"/>, the real binding resolution service,
+/// the real predicate registry, and the real
+/// <see cref="PlanEvaluator"/>. Only <see cref="ITasksPlanClient"/> is
+/// stubbed (otherwise the test would need a live andy-tasks).
+/// </summary>
+public sealed class EvaluatePlanControllerTests : IClassFixture<EvaluatePlanFactory>
+{
+    private readonly EvaluatePlanFactory _factory;
+    private readonly HttpClient _client;
+
+    public EvaluatePlanControllerTests(EvaluatePlanFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Returns_400_when_goalId_is_empty_guid()
+    {
+        var resp = await _client.PostAsJsonAsync(
+            "/api/policies/evaluate-plan",
+            new EvaluatePlanRequest(Guid.Empty));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Returns_404_when_andy_tasks_does_not_recognise_the_goal()
+    {
+        var goalId = Guid.NewGuid();
+        // Default stub: returns null for unknown goals.
+
+        var resp = await _client.PostAsJsonAsync(
+            "/api/policies/evaluate-plan", new EvaluatePlanRequest(goalId));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Returns_manual_when_no_policies_are_bound_to_workspace()
+    {
+        var goalId = Guid.NewGuid();
+        _factory.TasksStub.Add(goalId, AReadOnlyPlan(goalId, "ctr-unbound"));
+
+        var resp = await _client.PostAsJsonAsync(
+            "/api/policies/evaluate-plan", new EvaluatePlanRequest(goalId));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<EvaluatePlanResponse>();
+        body!.Decision.Should().Be("manual");
+        body.PolicyId.Should().BeNull();
+        body.Predicates.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public async Task Returns_approve_when_workspace_policy_rule_fires()
+    {
+        var goalId = Guid.NewGuid();
+        var container = $"ctr-approve-{Guid.NewGuid():N}";
+
+        var view = new PlanEvaluationGoalView(
+            GoalId: goalId,
+            PlanVersion: "1",
+            WorkspaceContainerId: container,
+            WorkspaceTier: "sandbox",
+            WorkspaceApprovedAgentIds: new[] { "coder" },
+            WorkspaceCostBudgetUsd: 100m,
+            Tasks: new List<PlanEvaluationTaskView>
+            {
+                new(Guid.NewGuid(), "coder", new[] { "read-file" }, null),
+            },
+            EstimatedCostUsd: 1m);
+        _factory.TasksStub.Add(goalId, view);
+
+        // Seed a published policy + binding that targets the
+        // workspace's container ID via the scope:{guid} canonical ref.
+        await SeedApprovePolicyAsync(container, policyKey: "sandbox-auto-approve");
+
+        var resp = await _client.PostAsJsonAsync(
+            "/api/policies/evaluate-plan", new EvaluatePlanRequest(goalId));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<EvaluatePlanResponse>();
+        body!.Decision.Should().Be("approve");
+        body.PolicyId.Should().Be("sandbox-auto-approve");
+    }
+
+    [Fact]
+    public async Task Returns_reject_when_workspace_policy_negative_rule_fires()
+    {
+        var goalId = Guid.NewGuid();
+        var container = $"ctr-reject-{Guid.NewGuid():N}";
+
+        var view = new PlanEvaluationGoalView(
+            GoalId: goalId,
+            PlanVersion: "1",
+            WorkspaceContainerId: container,
+            WorkspaceTier: "production",
+            WorkspaceApprovedAgentIds: new[] { "coder" },
+            WorkspaceCostBudgetUsd: 100m,
+            Tasks: new List<PlanEvaluationTaskView>
+            {
+                new(Guid.NewGuid(), "coder", new[] { "write-file" }, null),
+            },
+            EstimatedCostUsd: 1m);
+        _factory.TasksStub.Add(goalId, view);
+
+        await SeedRejectPolicyAsync(container, policyKey: "no-writes");
+
+        var resp = await _client.PostAsJsonAsync(
+            "/api/policies/evaluate-plan", new EvaluatePlanRequest(goalId));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<EvaluatePlanResponse>();
+        body!.Decision.Should().Be("reject");
+        body.PolicyId.Should().Be("no-writes");
+    }
+
+    [Fact]
+    public async Task Predicate_trace_carries_data_unavailable_for_missing_inputs()
+    {
+        var goalId = Guid.NewGuid();
+        var view = new PlanEvaluationGoalView(
+            GoalId: goalId,
+            PlanVersion: "1",
+            WorkspaceContainerId: "ctr-x",
+            WorkspaceTier: null,                 // → workspaceIsSandbox unevaluable
+            WorkspaceApprovedAgentIds: null,     // → allAgentsApproved unevaluable
+            WorkspaceCostBudgetUsd: null,        // → respectsCostBudget unevaluable
+            Tasks: new List<PlanEvaluationTaskView>
+            {
+                new(Guid.NewGuid(), "coder", new[] { "read-file" }, null),
+            },
+            EstimatedCostUsd: null);
+        _factory.TasksStub.Add(goalId, view);
+
+        var resp = await _client.PostAsJsonAsync(
+            "/api/policies/evaluate-plan", new EvaluatePlanRequest(goalId));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<EvaluatePlanResponse>();
+        body!.Predicates.Single(p => p.Name == PlanPredicateNames.WorkspaceIsSandbox)
+            .Reason.Should().Be("data unavailable");
+        body.Predicates.Single(p => p.Name == PlanPredicateNames.AllAgentsApproved)
+            .Reason.Should().Be("data unavailable");
+        body.Predicates.Single(p => p.Name == PlanPredicateNames.RespectsCostBudget)
+            .Reason.Should().Be("data unavailable");
+    }
+
+    // ---- helpers ----------------------------------------------------------
+
+    private static PlanEvaluationGoalView AReadOnlyPlan(Guid goalId, string container) => new(
+        GoalId: goalId,
+        PlanVersion: "1",
+        WorkspaceContainerId: container,
+        WorkspaceTier: "sandbox",
+        WorkspaceApprovedAgentIds: new[] { "coder" },
+        WorkspaceCostBudgetUsd: 10m,
+        Tasks: new List<PlanEvaluationTaskView>
+        {
+            new(Guid.NewGuid(), "coder", new[] { "read-file" }, null),
+        },
+        EstimatedCostUsd: 1m);
+
+    private async Task SeedApprovePolicyAsync(string container, string policyKey)
+    {
+        var rules = """
+        { "planEvaluation": {
+            "decisionRules": [
+              { "decision": "approve",
+                "requireAll": ["allTasksReadOnly", "workspaceIsSandbox"] }
+            ] } }
+        """;
+        await SeedPolicyAndBindingAsync(container, policyKey, rules);
+    }
+
+    private async Task SeedRejectPolicyAsync(string container, string policyKey)
+    {
+        var rules = """
+        { "planEvaluation": {
+            "decisionRules": [
+              { "decision": "reject",
+                "requireNone": ["allTasksReadOnly"] }
+            ] } }
+        """;
+        await SeedPolicyAndBindingAsync(container, policyKey, rules);
+    }
+
+    private async Task SeedPolicyAndBindingAsync(string container, string policyKey, string rulesJson)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var policy = new Policy
+        {
+            Id = Guid.NewGuid(),
+            Name = policyKey,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBySubjectId = "integration",
+        };
+        var version = new PolicyVersion
+        {
+            Id = Guid.NewGuid(),
+            PolicyId = policy.Id,
+            Version = 1,
+            State = LifecycleState.Active,
+            Enforcement = EnforcementLevel.Should,
+            Severity = Severity.Moderate,
+            Scopes = new List<string>(),
+            Summary = "fixture",
+            RulesJson = rulesJson,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBySubjectId = "integration",
+            ProposerSubjectId = "integration",
+            PublishedAt = DateTimeOffset.UtcNow,
+            PublishedBySubjectId = "integration",
+        };
+        var binding = new Binding
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = version.Id,
+            TargetType = BindingTargetType.ScopeNode,
+            TargetRef = $"scope:{container}",
+            BindStrength = BindStrength.Mandatory,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+        db.Policies.Add(policy);
+        db.PolicyVersions.Add(version);
+        db.Bindings.Add(binding);
+        await db.SaveChangesAsync();
+    }
+}
+
+/// <summary>
+/// Factory variant for <see cref="EvaluatePlanControllerTests"/>. Swaps
+/// the registered <see cref="ITasksPlanClient"/> for an in-memory stub
+/// (<see cref="StubTasksPlanClient"/>) so tests don't need a live
+/// andy-tasks. Everything else mirrors <see cref="PoliciesApiFactory"/>'s
+/// SQLite + TestAuth wiring so the test client can post against the
+/// authenticated endpoint with no extra ceremony.
+/// </summary>
+public sealed class EvaluatePlanFactory : WebApplicationFactory<Program>
+{
+    public StubTasksPlanClient TasksStub { get; } = new();
+
+    // Same lifetime pattern as PoliciesApiFactory: one shared connection
+    // keeps the :memory: database alive for the factory's lifetime.
+    private readonly SqliteConnection _connection = new("DataSource=:memory:");
+
+    public EvaluatePlanFactory() => _connection.Open();
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Database:Provider"] = "Sqlite",
+                ["AndyAuth:Authority"] = "https://test-auth.invalid",
+                ["AndySettings:ApiBaseUrl"] = "https://test-settings.invalid",
+                ["AndyRbac:BaseUrl"] = "https://test-rbac.invalid",
+                ["AndyTasks:BaseUrl"] = "https://test-tasks.invalid",
+            });
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            var ctxDescriptor = services.SingleOrDefault(d =>
+                d.ServiceType == typeof(DbContextOptions<AppDbContext>));
+            if (ctxDescriptor is not null) services.Remove(ctxDescriptor);
+            services.AddDbContext<AppDbContext>(opts => opts.UseSqlite(_connection));
+
+            services.AddAuthentication(TestAuthHandler.SchemeName)
+                .AddScheme<Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions, TestAuthHandler>(
+                    TestAuthHandler.SchemeName, _ => { });
+            services.PostConfigure<Microsoft.AspNetCore.Authorization.AuthorizationOptions>(opts =>
+            {
+                opts.DefaultPolicy = new Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder(
+                        TestAuthHandler.SchemeName)
+                    .RequireAuthenticatedUser()
+                    .Build();
+            });
+
+            // Allow-all RBAC stub so the [Authorize(Policy = "andy-policies:plan:evaluate")]
+            // gate doesn't 403 every test. The wiring of the policy itself is asserted
+            // via Program.cs's rbacPermissionCodes list (manifest test).
+            var rbacDescriptors = services
+                .Where(d => d.ServiceType == typeof(IRbacChecker))
+                .ToList();
+            foreach (var d in rbacDescriptors) services.Remove(d);
+            services.AddSingleton<IRbacChecker>(new AllowAllRbacChecker());
+
+            // Pinning + rationale gates default-off (same posture as PoliciesApiFactory).
+            var pinDescriptors = services
+                .Where(d => d.ServiceType == typeof(Andy.Policies.Application.Interfaces.IPinningPolicy))
+                .ToList();
+            foreach (var d in pinDescriptors) services.Remove(d);
+            services.AddSingleton<Andy.Policies.Application.Interfaces.IPinningPolicy>(
+                new StaticPinning(required: false));
+
+            var ratDescriptors = services
+                .Where(d => d.ServiceType == typeof(Andy.Policies.Application.Interfaces.IRationalePolicy))
+                .ToList();
+            foreach (var d in ratDescriptors) services.Remove(d);
+            services.AddSingleton<Andy.Policies.Application.Interfaces.IRationalePolicy>(
+                new StaticRationale(required: false));
+
+            // Swap the real HttpTasksPlanClient for the in-memory stub.
+            var clientDescriptors = services
+                .Where(d => d.ServiceType == typeof(ITasksPlanClient))
+                .ToList();
+            foreach (var d in clientDescriptors) services.Remove(d);
+            services.AddSingleton<ITasksPlanClient>(TasksStub);
+
+            using var sp = services.BuildServiceProvider();
+            using var scope = sp.CreateScope();
+            scope.ServiceProvider.GetRequiredService<AppDbContext>().Database.EnsureCreated();
+        });
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing) _connection.Dispose();
+        base.Dispose(disposing);
+    }
+
+    private sealed class AllowAllRbacChecker : IRbacChecker
+    {
+        public Task<RbacDecision> CheckAsync(
+            string subjectId, string permissionCode, IReadOnlyList<string> groups,
+            string? resourceInstanceId, CancellationToken ct)
+            => Task.FromResult(new RbacDecision(true, "test-allow"));
+    }
+
+    private sealed class StaticPinning : Andy.Policies.Application.Interfaces.IPinningPolicy
+    {
+        public StaticPinning(bool required) => IsPinningRequired = required;
+        public bool IsPinningRequired { get; }
+    }
+
+    private sealed class StaticRationale : Andy.Policies.Application.Interfaces.IRationalePolicy
+    {
+        public StaticRationale(bool required) => IsRequired = required;
+        public bool IsRequired { get; }
+        public string? ValidateRationale(string? rationale)
+            => IsRequired && string.IsNullOrWhiteSpace(rationale)
+                ? "Rationale is required for this operation."
+                : null;
+    }
+}
+
+/// <summary>
+/// Stub <see cref="ITasksPlanClient"/> driven by the test (no HTTP).
+/// Tests <see cref="Add"/> a goal view; the controller's call to
+/// <see cref="FetchGoalViewAsync"/> looks it up by id. Unknown ids
+/// return null, which the controller surfaces as 404.
+/// </summary>
+public sealed class StubTasksPlanClient : ITasksPlanClient
+{
+    private readonly Dictionary<Guid, PlanEvaluationGoalView> _byId = new();
+
+    public void Add(Guid goalId, PlanEvaluationGoalView view) => _byId[goalId] = view;
+
+    public Task<PlanEvaluationGoalView?> FetchGoalViewAsync(Guid goalId, CancellationToken ct = default)
+        => Task.FromResult(_byId.TryGetValue(goalId, out var v) ? v : null);
+}

--- a/tests/Andy.Policies.Tests.Integration/PlanEvaluation/HttpTasksPlanClientContractTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/PlanEvaluation/HttpTasksPlanClientContractTests.cs
@@ -1,0 +1,244 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Net;
+using Andy.Policies.Infrastructure.Services.PlanEvaluation;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.PlanEvaluation;
+
+/// <summary>
+/// Contract test (rivoli-ai/andy-policies#232): drives
+/// <see cref="HttpTasksPlanClient"/> against a WireMock stub that mimics
+/// the andy-tasks wire DTOs (GoalDto, TaskDto, EstimatesResponse).
+/// Pins the field names the policy service consumes — if andy-tasks
+/// renames any of these, the stubbed responses here will diverge
+/// from the real service and this test will fail.
+/// </summary>
+public sealed class HttpTasksPlanClientContractTests : IDisposable
+{
+    private readonly WireMockServer _server = WireMockServer.Start();
+
+    public void Dispose() => _server.Stop();
+
+    private HttpTasksPlanClient NewClient()
+    {
+        var http = new HttpClient { BaseAddress = new Uri(_server.Url!) };
+        return new HttpTasksPlanClient(http, NullLogger<HttpTasksPlanClient>.Instance);
+    }
+
+    [Fact]
+    public async Task Returns_null_when_andy_tasks_returns_404_on_goal()
+    {
+        var goalId = Guid.NewGuid();
+        _server
+            .Given(Request.Create().WithPath($"/api/goals/{goalId:D}").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode((int)HttpStatusCode.NotFound));
+
+        var result = await NewClient().FetchGoalViewAsync(goalId);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Projects_goal_tasks_and_planned_cost_into_view()
+    {
+        var goalId = Guid.NewGuid();
+        var taskId = Guid.NewGuid();
+
+        _server
+            .Given(Request.Create().WithPath($"/api/goals/{goalId:D}").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody($$"""
+                {
+                  "id": "{{goalId}}",
+                  "title": "Refactor X",
+                  "planVersion": "3",
+                  "workspace": {
+                    "containerId": "ctr-42",
+                    "repository": "rivoli-ai/conductor",
+                    "branch": "main"
+                  }
+                }
+                """));
+
+        _server
+            .Given(Request.Create().WithPath($"/api/goals/{goalId:D}/tasks").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody($$"""
+                [
+                  {
+                    "id": "{{taskId}}",
+                    "externalId": "T-1",
+                    "delegationContract": {
+                      "objective": "Read code",
+                      "outputFormat": "text",
+                      "toolsAllowed": ["read-file", "search-code"],
+                      "boundaries": []
+                    },
+                    "suggestedAgentIds": ["coder", "reviewer"],
+                    "executorId": null
+                  }
+                ]
+                """));
+
+        _server
+            .Given(Request.Create().WithPath($"/api/goals/{goalId:D}/estimates").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""
+                {
+                  "schemaVersion": 1,
+                  "target": { "kind": "goal", "id": "00000000-0000-0000-0000-000000000000" },
+                  "planned": {
+                    "costUsdP50": 2.45,
+                    "costUsdP90": 4.10,
+                    "durationSecP50": null,
+                    "durationSecP90": null,
+                    "estimatedBy": "planner-v1",
+                    "at": "2026-05-19T00:00:00Z",
+                    "schemaVersion": 1,
+                    "includesProjections": false
+                  },
+                  "initial": null,
+                  "actual": null,
+                  "varianceState": null,
+                  "lastUpdatedAt": "2026-05-19T00:00:00Z"
+                }
+                """));
+
+        var view = await NewClient().FetchGoalViewAsync(goalId);
+
+        view.Should().NotBeNull();
+        view!.GoalId.Should().Be(goalId);
+        view.PlanVersion.Should().Be("3");
+        view.WorkspaceContainerId.Should().Be("ctr-42");
+        view.EstimatedCostUsd.Should().Be(2.45m);
+
+        view.Tasks.Should().HaveCount(1);
+        view.Tasks[0].TaskId.Should().Be(taskId);
+        view.Tasks[0].EffectiveAgentId.Should().Be("coder",
+            "with no executor pinned, the top suggested agent wins");
+        view.Tasks[0].ToolsAllowed.Should().BeEquivalentTo("read-file", "search-code");
+    }
+
+    [Fact]
+    public async Task Executor_pin_beats_suggested_list_for_effective_agent()
+    {
+        var goalId = Guid.NewGuid();
+        var taskId = Guid.NewGuid();
+
+        StubGoal(goalId, planVersion: "1");
+        _server
+            .Given(Request.Create().WithPath($"/api/goals/{goalId:D}/tasks").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody($$"""
+                [
+                  {
+                    "id": "{{taskId}}",
+                    "delegationContract": { "objective": "", "outputFormat": "", "toolsAllowed": [], "boundaries": [] },
+                    "suggestedAgentIds": ["fallback"],
+                    "executorId": "primary"
+                  }
+                ]
+                """));
+        StubEstimates(goalId, null);
+
+        var view = await NewClient().FetchGoalViewAsync(goalId);
+
+        view!.Tasks[0].EffectiveAgentId.Should().Be("primary");
+    }
+
+    [Fact]
+    public async Task Estimates_404_maps_to_null_cost()
+    {
+        var goalId = Guid.NewGuid();
+        StubGoal(goalId, planVersion: "1");
+        _server
+            .Given(Request.Create().WithPath($"/api/goals/{goalId:D}/tasks").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+        _server
+            .Given(Request.Create().WithPath($"/api/goals/{goalId:D}/estimates").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(404));
+
+        var view = await NewClient().FetchGoalViewAsync(goalId);
+
+        view!.EstimatedCostUsd.Should().BeNull(
+            "missing estimates → null cost → respectsCostBudget surfaces 'data unavailable'");
+    }
+
+    [Fact]
+    public async Task Default_plan_version_when_andy_tasks_omits_the_field()
+    {
+        var goalId = Guid.NewGuid();
+        // Older andy-tasks shapes that don't carry planVersion.
+        _server
+            .Given(Request.Create().WithPath($"/api/goals/{goalId:D}").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody($$"""{ "id": "{{goalId}}", "title": "X" }"""));
+        _server
+            .Given(Request.Create().WithPath($"/api/goals/{goalId:D}/tasks").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(404));
+        _server
+            .Given(Request.Create().WithPath($"/api/goals/{goalId:D}/estimates").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(404));
+
+        var view = await NewClient().FetchGoalViewAsync(goalId);
+
+        view!.PlanVersion.Should().Be("1");
+        view.Tasks.Should().BeEmpty();
+    }
+
+    private void StubGoal(Guid goalId, string planVersion)
+    {
+        _server
+            .Given(Request.Create().WithPath($"/api/goals/{goalId:D}").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody($$"""
+                {
+                  "id": "{{goalId}}",
+                  "title": "X",
+                  "planVersion": "{{planVersion}}",
+                  "workspace": { "containerId": "ctr-1", "repository": "r", "branch": "b" }
+                }
+                """));
+    }
+
+    private void StubEstimates(Guid goalId, decimal? plannedCost)
+    {
+        if (plannedCost is null)
+        {
+            _server
+                .Given(Request.Create().WithPath($"/api/goals/{goalId:D}/estimates").UsingGet())
+                .RespondWith(Response.Create().WithStatusCode(404));
+            return;
+        }
+
+        _server
+            .Given(Request.Create().WithPath($"/api/goals/{goalId:D}/estimates").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody($$"""
+                { "schemaVersion": 1,
+                  "target": { "kind": "goal", "id": "00000000-0000-0000-0000-000000000000" },
+                  "planned": { "costUsdP50": {{plannedCost}}, "estimatedBy": "p", "at": "2026-05-19T00:00:00Z", "schemaVersion": 1 } }
+                """));
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Services/PlanEvaluation/PlanEvaluatorTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/PlanEvaluation/PlanEvaluatorTests.cs
@@ -1,0 +1,426 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Application.PlanEvaluation;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Services.PlanEvaluation;
+using Andy.Policies.Tests.Unit.Fixtures;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Services.PlanEvaluation;
+
+/// <summary>
+/// Unit tests for <see cref="PlanEvaluator"/> — the orchestrator that
+/// stitches the andy-tasks client, the binding-resolution chain, the
+/// predicate registry, and the idempotency cache into the wire
+/// response. All collaborators are stubbed; the goal is to assert the
+/// decision logic and the cache contract, not the wire shapes (those
+/// live in the integration tests).
+/// </summary>
+public class PlanEvaluatorTests
+{
+    private static readonly IReadOnlyList<IPlanPredicate> AllPredicates = new IPlanPredicate[]
+    {
+        new AllTasksReadOnlyPredicate(),
+        new WorkspaceIsSandboxPredicate(),
+        new NoProductionDeployPredicate(),
+        new AllAgentsApprovedPredicate(),
+        new RespectsCostBudgetPredicate(),
+    };
+
+    [Fact]
+    public async Task Returns_null_when_andy_tasks_does_not_recognise_the_goal()
+    {
+        var goalId = Guid.NewGuid();
+        var (eval, _) = NewEvaluator(
+            tasks: new StubTasksClient(_ => null),
+            bindings: new StubBindings(Array.Empty<EffectivePolicyDto>()));
+
+        var result = await eval.EvaluatePlanAsync(goalId);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Defaults_to_manual_when_no_policies_are_bound()
+    {
+        var view = AView();
+        var (eval, _) = NewEvaluator(
+            tasks: new StubTasksClient(_ => view),
+            bindings: new StubBindings(Array.Empty<EffectivePolicyDto>()));
+
+        var result = await eval.EvaluatePlanAsync(view.GoalId);
+
+        result.Should().NotBeNull();
+        result!.Decision.Should().Be("manual");
+        result.PolicyId.Should().BeNull();
+        result.Predicates.Should().HaveCount(5,
+            "every registered predicate must show up in the trace");
+    }
+
+    [Fact]
+    public async Task Fires_approve_when_first_policys_rule_passes_all_required_predicates()
+    {
+        // Sandboxed, read-only plan, under budget, agent approved, no prod.
+        var view = AView(
+            tasks: new[] { ATask(tools: new[] { "read-file" }, agentId: "coder") },
+            tier: "sandbox",
+            approved: new[] { "coder" },
+            budget: 10m,
+            estimatedCost: 1m);
+
+        var rules = """
+        { "planEvaluation": {
+            "decisionRules": [
+              { "decision": "approve",
+                "requireAll": ["allTasksReadOnly", "workspaceIsSandbox", "respectsCostBudget"] }
+            ] } }
+        """;
+
+        await using var db = InMemoryDbFixture.Create();
+        var policyKey = "safe-sandbox-autoapprove";
+        var version = SeedPolicyVersion(db, policyKey, rules);
+
+        var (eval, _) = NewEvaluator(
+            db: db,
+            tasks: new StubTasksClient(_ => view),
+            bindings: new StubBindings(new[]
+            {
+                Effective(version, policyKey),
+            }));
+
+        var result = await eval.EvaluatePlanAsync(view.GoalId);
+
+        result!.Decision.Should().Be("approve");
+        result.PolicyId.Should().Be(policyKey);
+    }
+
+    [Fact]
+    public async Task Fires_reject_when_a_negative_rule_matches()
+    {
+        var view = AView(
+            tasks: new[] { ATask(env: "prod") },
+            tier: "production",
+            approved: new[] { "coder" });
+
+        var rules = """
+        { "planEvaluation": {
+            "decisionRules": [
+              { "decision": "reject",
+                "requireNone": ["noProductionDeploy"] }
+            ] } }
+        """;
+
+        await using var db = InMemoryDbFixture.Create();
+        var key = "no-prod-deploy";
+        var version = SeedPolicyVersion(db, key, rules);
+
+        var (eval, _) = NewEvaluator(
+            db: db,
+            tasks: new StubTasksClient(_ => view),
+            bindings: new StubBindings(new[] { Effective(version, key) }));
+
+        var result = await eval.EvaluatePlanAsync(view.GoalId);
+
+        result!.Decision.Should().Be("reject");
+        result.PolicyId.Should().Be(key);
+    }
+
+    [Fact]
+    public async Task First_matching_policy_wins_across_resolved_set()
+    {
+        // Two policies bound; first rejects, second would approve. The
+        // evaluator must surface the reject and not look further.
+        var view = AView(
+            tasks: new[] { ATask(env: "prod", tools: new[] { "read-file" }, agentId: "coder") },
+            tier: "sandbox",
+            approved: new[] { "coder" },
+            budget: 100m,
+            estimatedCost: 1m);
+
+        var rejectRules = """
+        { "planEvaluation": {
+            "decisionRules": [
+              { "decision": "reject", "requireNone": ["noProductionDeploy"] }
+            ] } }
+        """;
+
+        var approveRules = """
+        { "planEvaluation": {
+            "decisionRules": [
+              { "decision": "approve", "requireAll": ["workspaceIsSandbox"] }
+            ] } }
+        """;
+
+        await using var db = InMemoryDbFixture.Create();
+        var rejectVersion = SeedPolicyVersion(db, "no-prod", rejectRules);
+        var approveVersion = SeedPolicyVersion(db, "sandbox-ok", approveRules);
+
+        var (eval, _) = NewEvaluator(
+            db: db,
+            tasks: new StubTasksClient(_ => view),
+            bindings: new StubBindings(new[]
+            {
+                Effective(rejectVersion, "no-prod"),
+                Effective(approveVersion, "sandbox-ok"),
+            }));
+
+        var result = await eval.EvaluatePlanAsync(view.GoalId);
+
+        result!.Decision.Should().Be("reject");
+        result.PolicyId.Should().Be("no-prod");
+    }
+
+    [Fact]
+    public async Task Surfaces_data_unavailable_on_predicates_with_missing_inputs()
+    {
+        // No tier, no approved list, no budget — three predicates
+        // surface "data unavailable". The fourth and fifth still
+        // evaluate. The wire response must reflect this verbatim.
+        var view = AView(
+            tasks: new[] { ATask(tools: new[] { "read-file" }) },
+            tier: null,
+            approved: null,
+            budget: null,
+            estimatedCost: null);
+
+        var (eval, _) = NewEvaluator(
+            tasks: new StubTasksClient(_ => view),
+            bindings: new StubBindings(Array.Empty<EffectivePolicyDto>()));
+
+        var result = await eval.EvaluatePlanAsync(view.GoalId);
+
+        var byName = result!.Predicates.ToDictionary(p => p.Name);
+        byName[PlanPredicateNames.WorkspaceIsSandbox].Passed.Should().BeFalse();
+        byName[PlanPredicateNames.WorkspaceIsSandbox].Reason.Should().Be("data unavailable");
+        byName[PlanPredicateNames.AllAgentsApproved].Passed.Should().BeFalse();
+        byName[PlanPredicateNames.AllAgentsApproved].Reason.Should().Be("data unavailable");
+        byName[PlanPredicateNames.RespectsCostBudget].Passed.Should().BeFalse();
+        byName[PlanPredicateNames.RespectsCostBudget].Reason.Should().Be("data unavailable");
+
+        // The other two evaluate normally.
+        byName[PlanPredicateNames.AllTasksReadOnly].Passed.Should().BeTrue();
+        byName[PlanPredicateNames.NoProductionDeploy].Passed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Caches_decision_for_5_minutes_per_goal_and_plan_version()
+    {
+        var view = AView();
+        var stub = new StubTasksClient(_ => view);
+        var (eval, _) = NewEvaluator(
+            tasks: stub,
+            bindings: new StubBindings(Array.Empty<EffectivePolicyDto>()));
+
+        var first = await eval.EvaluatePlanAsync(view.GoalId);
+        var second = await eval.EvaluatePlanAsync(view.GoalId);
+
+        first.Should().NotBeNull();
+        second.Should().BeSameAs(first,
+            "the cache must return the same response instance within the TTL");
+        // The tasks client is still hit twice — the cache key is built
+        // from the GoalView, so the projected view drives idempotency,
+        // not the request envelope. This is the desired contract: a
+        // replanned goal (new PlanVersion) bypasses the cache.
+        stub.CallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Cache_key_includes_plan_version_so_replan_bypasses_cache()
+    {
+        var goalId = Guid.NewGuid();
+        var calls = 0;
+        var stub = new StubTasksClient(_ =>
+        {
+            calls++;
+            return AView(goalId: goalId, planVersion: calls.ToString());
+        });
+
+        var (eval, _) = NewEvaluator(
+            tasks: stub,
+            bindings: new StubBindings(Array.Empty<EffectivePolicyDto>()));
+
+        var first = await eval.EvaluatePlanAsync(goalId);
+        var second = await eval.EvaluatePlanAsync(goalId);
+
+        first.Should().NotBeNull();
+        second.Should().NotBeNull();
+        first.Should().NotBeSameAs(second,
+            "different plan versions must produce distinct cache entries");
+    }
+
+    [Fact]
+    public async Task Malformed_RulesJson_is_skipped_silently_and_evaluation_continues()
+    {
+        var view = AView(tier: "sandbox", tasks: new[] { ATask(tools: new[] { "read-file" }) });
+
+        await using var db = InMemoryDbFixture.Create();
+        var bad = SeedPolicyVersion(db, "malformed", "{ not valid json");
+        var goodRules = """
+        { "planEvaluation": {
+            "decisionRules": [
+              { "decision": "approve", "requireAll": ["workspaceIsSandbox"] }
+            ] } }
+        """;
+        var good = SeedPolicyVersion(db, "good", goodRules);
+
+        var (eval, _) = NewEvaluator(
+            db: db,
+            tasks: new StubTasksClient(_ => view),
+            bindings: new StubBindings(new[]
+            {
+                Effective(bad, "malformed"),
+                Effective(good, "good"),
+            }));
+
+        var result = await eval.EvaluatePlanAsync(view.GoalId);
+
+        result!.Decision.Should().Be("approve");
+        result.PolicyId.Should().Be("good");
+    }
+
+    [Fact]
+    public async Task Unknown_predicate_in_rule_does_not_fire_the_rule()
+    {
+        var view = AView(tier: "sandbox");
+
+        var rules = """
+        { "planEvaluation": {
+            "decisionRules": [
+              { "decision": "approve",
+                "requireAll": ["thisPredicateDoesNotExist", "workspaceIsSandbox"] }
+            ] } }
+        """;
+
+        await using var db = InMemoryDbFixture.Create();
+        var version = SeedPolicyVersion(db, "p", rules);
+
+        var (eval, _) = NewEvaluator(
+            db: db,
+            tasks: new StubTasksClient(_ => view),
+            bindings: new StubBindings(new[] { Effective(version, "p") }));
+
+        var result = await eval.EvaluatePlanAsync(view.GoalId);
+
+        // Unknown predicate → rule doesn't fire → fall through to manual.
+        result!.Decision.Should().Be("manual");
+    }
+
+    // ---- helpers ----------------------------------------------------------
+
+    private static (PlanEvaluator Eval, IMemoryCache Cache) NewEvaluator(
+        ITasksPlanClient tasks,
+        IBindingResolutionService bindings,
+        Andy.Policies.Infrastructure.Data.AppDbContext? db = null,
+        IReadOnlyList<IPlanPredicate>? predicates = null)
+    {
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var dbCtx = db ?? InMemoryDbFixture.Create();
+        var eval = new PlanEvaluator(
+            tasks, bindings, dbCtx,
+            (predicates ?? AllPredicates), cache, NullLogger<PlanEvaluator>.Instance);
+        return (eval, cache);
+    }
+
+    private static PlanEvaluationGoalView AView(
+        Guid? goalId = null,
+        string planVersion = "1",
+        IEnumerable<PlanEvaluationTaskView>? tasks = null,
+        string? tier = null,
+        IReadOnlyList<string>? approved = null,
+        decimal? budget = null,
+        decimal? estimatedCost = null,
+        string? container = "ctr-1") => new(
+        GoalId: goalId ?? Guid.NewGuid(),
+        PlanVersion: planVersion,
+        WorkspaceContainerId: container,
+        WorkspaceTier: tier,
+        WorkspaceApprovedAgentIds: approved,
+        WorkspaceCostBudgetUsd: budget,
+        Tasks: tasks?.ToList() ?? new List<PlanEvaluationTaskView>(),
+        EstimatedCostUsd: estimatedCost);
+
+    private static PlanEvaluationTaskView ATask(
+        IEnumerable<string>? tools = null,
+        string? agentId = "coder",
+        string? env = null) => new(
+        TaskId: Guid.NewGuid(),
+        EffectiveAgentId: agentId,
+        ToolsAllowed: tools?.ToList() ?? new List<string> { "read-file" },
+        TargetEnv: env);
+
+    private static PolicyVersion SeedPolicyVersion(
+        Andy.Policies.Infrastructure.Data.AppDbContext db, string policyKey, string rulesJson)
+    {
+        var policy = new Policy
+        {
+            Id = Guid.NewGuid(),
+            Name = policyKey,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBySubjectId = "unit",
+        };
+        var version = new PolicyVersion
+        {
+            Id = Guid.NewGuid(),
+            PolicyId = policy.Id,
+            Version = 1,
+            State = LifecycleState.Active,
+            Enforcement = EnforcementLevel.Should,
+            Severity = Severity.Moderate,
+            Scopes = new List<string>(),
+            Summary = "fixture",
+            RulesJson = rulesJson,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBySubjectId = "unit",
+            ProposerSubjectId = "unit",
+        };
+        db.Policies.Add(policy);
+        db.PolicyVersions.Add(version);
+        db.SaveChanges();
+        return version;
+    }
+
+    private static EffectivePolicyDto Effective(PolicyVersion version, string key) => new(
+        PolicyId: version.PolicyId,
+        PolicyVersionId: version.Id,
+        PolicyKey: key,
+        Version: version.Version,
+        BindStrength: BindStrength.Recommended,
+        SourceBindingId: Guid.NewGuid(),
+        SourceScopeNodeId: null,
+        SourceScopeType: null,
+        SourceDepth: 0);
+
+    private sealed class StubTasksClient : ITasksPlanClient
+    {
+        private readonly Func<Guid, PlanEvaluationGoalView?> _project;
+        public int CallCount { get; private set; }
+
+        public StubTasksClient(Func<Guid, PlanEvaluationGoalView?> project) => _project = project;
+
+        public Task<PlanEvaluationGoalView?> FetchGoalViewAsync(Guid goalId, CancellationToken ct = default)
+        {
+            CallCount++;
+            return Task.FromResult(_project(goalId));
+        }
+    }
+
+    private sealed class StubBindings : IBindingResolutionService
+    {
+        private readonly IReadOnlyList<EffectivePolicyDto> _policies;
+        public StubBindings(IReadOnlyList<EffectivePolicyDto> policies) => _policies = policies;
+
+        public Task<EffectivePolicySetDto> ResolveForScopeAsync(Guid scopeNodeId, CancellationToken ct = default)
+            => Task.FromResult(new EffectivePolicySetDto(scopeNodeId, _policies));
+
+        public Task<EffectivePolicySetDto> ResolveForTargetAsync(
+            BindingTargetType targetType, string targetRef, CancellationToken ct = default)
+            => Task.FromResult(new EffectivePolicySetDto(null, _policies));
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Services/PlanEvaluation/PlanPredicateTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/PlanEvaluation/PlanPredicateTests.cs
@@ -1,0 +1,271 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.PlanEvaluation;
+using Andy.Policies.Infrastructure.Services.PlanEvaluation;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Services.PlanEvaluation;
+
+/// <summary>
+/// Unit tests for the five plan-aware predicates pinned by
+/// rivoli-ai/andy-policies#232. Each predicate gets:
+/// <list type="bullet">
+///   <item>A passing case asserting <see cref="PredicateOutcome.Pass"/>.</item>
+///   <item>A failing case asserting <see cref="PredicateOutcome.Fail"/>.</item>
+///   <item>Where applicable, a missing-data case asserting
+///     <see cref="PredicateOutcome.Unevaluable"/> — the issue spec
+///     forbids silently passing when the underlying data is null.</item>
+/// </list>
+/// </summary>
+public class PlanPredicateTests
+{
+    private static PlanEvaluationGoalView View(
+        IEnumerable<PlanEvaluationTaskView>? tasks = null,
+        string? tier = null,
+        IReadOnlyList<string>? approved = null,
+        decimal? budget = null,
+        decimal? estimatedCost = null,
+        string? container = "ctr-1") => new(
+        GoalId: Guid.NewGuid(),
+        PlanVersion: "1",
+        WorkspaceContainerId: container,
+        WorkspaceTier: tier,
+        WorkspaceApprovedAgentIds: approved,
+        WorkspaceCostBudgetUsd: budget,
+        Tasks: tasks?.ToList() ?? new List<PlanEvaluationTaskView>(),
+        EstimatedCostUsd: estimatedCost);
+
+    private static PlanEvaluationTaskView Task(
+        IEnumerable<string>? tools = null,
+        string? agentId = "coder",
+        string? env = null) => new(
+        TaskId: Guid.NewGuid(),
+        EffectiveAgentId: agentId,
+        ToolsAllowed: tools?.ToList() ?? new List<string>(),
+        TargetEnv: env);
+
+    // ---- allTasksReadOnly -------------------------------------------------
+
+    [Fact]
+    public void AllTasksReadOnly_passes_when_every_task_carries_only_read_tools()
+    {
+        var p = new AllTasksReadOnlyPredicate();
+        var v = View(tasks: new[]
+        {
+            Task(tools: new[] { "read-file", "list-dir" }),
+            Task(tools: new[] { "search-code" }),
+        });
+
+        var r = p.Evaluate(v);
+
+        r.Outcome.Should().Be(PredicateOutcome.Pass);
+    }
+
+    [Theory]
+    [InlineData("write-file")]
+    [InlineData("shell-exec")]
+    [InlineData("delete-resource")]
+    [InlineData("deploy")]
+    [InlineData("push-branch")]
+    public void AllTasksReadOnly_fails_for_write_or_exec_tool(string tool)
+    {
+        var p = new AllTasksReadOnlyPredicate();
+        var v = View(tasks: new[]
+        {
+            Task(tools: new[] { "read-file" }),
+            Task(tools: new[] { tool }),
+        });
+
+        var r = p.Evaluate(v);
+
+        r.Outcome.Should().Be(PredicateOutcome.Fail);
+        r.Reason.Should().Contain("write/exec");
+    }
+
+    [Fact]
+    public void AllTasksReadOnly_passes_vacuously_with_zero_tasks()
+    {
+        var p = new AllTasksReadOnlyPredicate();
+        var r = p.Evaluate(View(tasks: Array.Empty<PlanEvaluationTaskView>()));
+        r.Outcome.Should().Be(PredicateOutcome.Pass);
+    }
+
+    // ---- workspaceIsSandbox -----------------------------------------------
+
+    [Theory]
+    [InlineData("sandbox")]
+    [InlineData("SANDBOX")]
+    [InlineData("Sandbox")]
+    public void WorkspaceIsSandbox_passes_for_sandbox_tier_case_insensitive(string tier)
+    {
+        var p = new WorkspaceIsSandboxPredicate();
+        p.Evaluate(View(tier: tier)).Outcome.Should().Be(PredicateOutcome.Pass);
+    }
+
+    [Theory]
+    [InlineData("production")]
+    [InlineData("staging")]
+    [InlineData("free")]
+    public void WorkspaceIsSandbox_fails_for_non_sandbox_tier(string tier)
+    {
+        var p = new WorkspaceIsSandboxPredicate();
+        p.Evaluate(View(tier: tier)).Outcome.Should().Be(PredicateOutcome.Fail);
+    }
+
+    [Fact]
+    public void WorkspaceIsSandbox_is_unevaluable_when_tier_is_null()
+    {
+        var p = new WorkspaceIsSandboxPredicate();
+        p.Evaluate(View(tier: null)).Outcome.Should().Be(PredicateOutcome.Unevaluable);
+    }
+
+    // ---- noProductionDeploy -----------------------------------------------
+
+    [Fact]
+    public void NoProductionDeploy_passes_when_no_task_targets_prod()
+    {
+        var p = new NoProductionDeployPredicate();
+        var v = View(tasks: new[]
+        {
+            Task(env: "dev"),
+            Task(env: "staging"),
+            Task(env: null),
+        });
+
+        p.Evaluate(v).Outcome.Should().Be(PredicateOutcome.Pass);
+    }
+
+    [Theory]
+    [InlineData("prod")]
+    [InlineData("PROD")]
+    [InlineData("production")]
+    [InlineData("Production")]
+    public void NoProductionDeploy_fails_when_any_task_targets_prod(string env)
+    {
+        var p = new NoProductionDeployPredicate();
+        var v = View(tasks: new[] { Task(env: env), Task(env: "dev") });
+
+        var r = p.Evaluate(v);
+
+        r.Outcome.Should().Be(PredicateOutcome.Fail);
+    }
+
+    [Fact]
+    public void NoProductionDeploy_passes_vacuously_with_zero_tasks()
+    {
+        new NoProductionDeployPredicate()
+            .Evaluate(View(tasks: Array.Empty<PlanEvaluationTaskView>()))
+            .Outcome.Should().Be(PredicateOutcome.Pass);
+    }
+
+    // ---- allAgentsApproved ------------------------------------------------
+
+    [Fact]
+    public void AllAgentsApproved_passes_when_every_task_agent_is_in_the_list()
+    {
+        var p = new AllAgentsApprovedPredicate();
+        var v = View(
+            approved: new[] { "coder", "reviewer" },
+            tasks: new[]
+            {
+                Task(agentId: "coder"),
+                Task(agentId: "reviewer"),
+            });
+
+        p.Evaluate(v).Outcome.Should().Be(PredicateOutcome.Pass);
+    }
+
+    [Fact]
+    public void AllAgentsApproved_fails_when_any_task_agent_is_not_approved()
+    {
+        var p = new AllAgentsApprovedPredicate();
+        var v = View(
+            approved: new[] { "coder" },
+            tasks: new[]
+            {
+                Task(agentId: "coder"),
+                Task(agentId: "external-agent"),
+            });
+
+        var r = p.Evaluate(v);
+
+        r.Outcome.Should().Be(PredicateOutcome.Fail);
+        r.Reason.Should().Contain("external-agent");
+    }
+
+    [Fact]
+    public void AllAgentsApproved_fails_when_a_task_has_no_effective_agent()
+    {
+        var p = new AllAgentsApprovedPredicate();
+        var v = View(
+            approved: new[] { "coder" },
+            tasks: new[] { Task(agentId: null) });
+
+        // Issue spec: missing data must not silently pass.
+        p.Evaluate(v).Outcome.Should().Be(PredicateOutcome.Fail);
+    }
+
+    [Fact]
+    public void AllAgentsApproved_is_unevaluable_when_approved_list_is_null()
+    {
+        var p = new AllAgentsApprovedPredicate();
+        p.Evaluate(View(approved: null, tasks: new[] { Task() }))
+            .Outcome.Should().Be(PredicateOutcome.Unevaluable);
+    }
+
+    [Fact]
+    public void AllAgentsApproved_is_case_sensitive_on_agent_slug()
+    {
+        var p = new AllAgentsApprovedPredicate();
+        // Agent slugs are opaque IDs; case-insensitive matching would
+        // conflate distinct agents — guard the contract here.
+        p.Evaluate(View(
+            approved: new[] { "Coder" },
+            tasks: new[] { Task(agentId: "coder") })).Outcome.Should().Be(PredicateOutcome.Fail);
+    }
+
+    // ---- respectsCostBudget -----------------------------------------------
+
+    [Fact]
+    public void RespectsCostBudget_passes_when_estimated_strictly_below_budget()
+    {
+        new RespectsCostBudgetPredicate()
+            .Evaluate(View(budget: 10m, estimatedCost: 4.99m))
+            .Outcome.Should().Be(PredicateOutcome.Pass);
+    }
+
+    [Fact]
+    public void RespectsCostBudget_fails_when_estimated_equals_budget()
+    {
+        // The spec is "< budget"; equality fails.
+        new RespectsCostBudgetPredicate()
+            .Evaluate(View(budget: 10m, estimatedCost: 10m))
+            .Outcome.Should().Be(PredicateOutcome.Fail);
+    }
+
+    [Fact]
+    public void RespectsCostBudget_fails_when_estimated_above_budget()
+    {
+        new RespectsCostBudgetPredicate()
+            .Evaluate(View(budget: 10m, estimatedCost: 15m))
+            .Outcome.Should().Be(PredicateOutcome.Fail);
+    }
+
+    [Fact]
+    public void RespectsCostBudget_is_unevaluable_when_budget_missing()
+    {
+        new RespectsCostBudgetPredicate()
+            .Evaluate(View(budget: null, estimatedCost: 5m))
+            .Outcome.Should().Be(PredicateOutcome.Unevaluable);
+    }
+
+    [Fact]
+    public void RespectsCostBudget_is_unevaluable_when_estimate_missing()
+    {
+        new RespectsCostBudgetPredicate()
+            .Evaluate(View(budget: 10m, estimatedCost: null))
+            .Outcome.Should().Be(PredicateOutcome.Unevaluable);
+    }
+}

--- a/tests/Andy.Policies.Tests.Unit/Services/PlanEvaluation/PolicyRulesDslParserTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/PlanEvaluation/PolicyRulesDslParserTests.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Infrastructure.Services.PlanEvaluation;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Unit.Services.PlanEvaluation;
+
+/// <summary>
+/// Unit tests for the policy <c>RulesJson</c> → <see cref="PlanEvaluationRules"/>
+/// parser. The parser must tolerate malformed JSON and missing
+/// <c>planEvaluation</c> blocks (returning null in both cases) without
+/// throwing, because a single malformed policy in the catalog must
+/// not break evaluation for every other policy.
+/// </summary>
+public class PolicyRulesDslParserTests
+{
+    [Fact]
+    public void Returns_null_for_null_input()
+    {
+        PolicyRulesDslParser.TryParse(null).Should().BeNull();
+    }
+
+    [Fact]
+    public void Returns_null_for_empty_input()
+    {
+        PolicyRulesDslParser.TryParse("   ").Should().BeNull();
+    }
+
+    [Fact]
+    public void Returns_null_for_malformed_json()
+    {
+        PolicyRulesDslParser.TryParse("{ this is not json").Should().BeNull();
+    }
+
+    [Fact]
+    public void Returns_null_when_planEvaluation_block_absent()
+    {
+        // Existing P1/V1 policies have allow/deny shapes but no
+        // planEvaluation; the parser must not throw on them.
+        var legacy = "{\"allow\": [\"read-file\"], \"deny\": []}";
+        PolicyRulesDslParser.TryParse(legacy).Should().BeNull();
+    }
+
+    [Fact]
+    public void Parses_decision_rules_with_requireAll()
+    {
+        var json = """
+        {
+          "planEvaluation": {
+            "decisionRules": [
+              { "decision": "approve", "requireAll": ["allTasksReadOnly", "workspaceIsSandbox"] }
+            ]
+          }
+        }
+        """;
+
+        var rules = PolicyRulesDslParser.TryParse(json);
+
+        rules.Should().NotBeNull();
+        rules!.DecisionRules.Should().HaveCount(1);
+        rules.DecisionRules![0].Decision.Should().Be("approve");
+        rules.DecisionRules[0].RequireAll.Should().BeEquivalentTo("allTasksReadOnly", "workspaceIsSandbox");
+    }
+
+    [Fact]
+    public void Parses_decision_rules_with_requireNone()
+    {
+        var json = """
+        {
+          "planEvaluation": {
+            "decisionRules": [
+              { "decision": "reject", "requireNone": ["workspaceIsSandbox"] }
+            ]
+          }
+        }
+        """;
+
+        var rules = PolicyRulesDslParser.TryParse(json);
+
+        rules!.DecisionRules![0].Decision.Should().Be("reject");
+        rules.DecisionRules[0].RequireNone.Should().ContainSingle().Which.Should().Be("workspaceIsSandbox");
+    }
+
+    [Fact]
+    public void Tolerates_case_insensitive_property_names()
+    {
+        // PascalCase, common when a developer hand-writes policy JSON
+        // from a .NET DTO source. Parser is case-insensitive.
+        var json = """
+        {
+          "PlanEvaluation": {
+            "DecisionRules": [
+              { "Decision": "approve", "RequireAll": ["allTasksReadOnly"] }
+            ]
+          }
+        }
+        """;
+
+        var rules = PolicyRulesDslParser.TryParse(json);
+
+        rules!.DecisionRules!.Should().HaveCount(1);
+    }
+}


### PR DESCRIPTION
## Summary

Closes rivoli-ai/andy-policies#232. Companion to rivoli-ai/conductor#1633 (Epic SP, story SP.4.2) and the caller-side rivoli-ai/andy-tasks#304.

Adds `POST /api/policies/evaluate-plan` — andy-tasks calls it on plan finalize to determine `approve | manual | reject`. Without this, every plan funnels through manual approval and the SP auto-approval loop can't close.

### What ships

- **Endpoint** `POST /api/policies/evaluate-plan` (`andy-policies:plan:evaluate` RBAC) returning `{ decision, policyId, predicates[] }`.
- **Five plan-aware predicates** (DSL extension) pinned by the issue body:
  - `allTasksReadOnly`, `workspaceIsSandbox`, `noProductionDeploy`, `allAgentsApproved`, `respectsCostBudget`.
  - Tri-state output (`Pass`/`Fail`/`Unevaluable`); `Unevaluable` collapses to `passed=false, reason="data unavailable"` on the wire — never silently passes when data is missing (per the issue's hard constraint).
- **`planEvaluation` block** inside `RulesJson` with `requireAll` / `requireNone` decision lists. Legacy P1/V1 `RulesJson` blobs pass through unchanged (their absence of the block means they don't participate in plan evaluation — they fall through to default `manual`).
- **`PlanEvaluator`** orchestrator: pulls goal + tasks + plan-time estimates from andy-tasks, resolves workspace policies via the existing `IBindingResolutionService` chain (P4.3), evaluates predicates once, first matching policy wins `approve` or `reject`; default `manual`. **5-minute idempotency cache** keyed on `(GoalId, PlanVersion)` — replanned goals bypass.
- **`HttpTasksPlanClient`** typed `HttpClient<ITasksPlanClient>` wired with `Andy.Auth.M2MClient.ServiceBearerHandler` (mirrors the existing RBAC client M2M pipeline).
- **Manifest updates**: new `plan` resource + `andy-policies:plan:evaluate` permission across `config/registration.json`, `config/rbac-seed.json`, and the regenerated `docs/reference/permission-catalog.md`.

### Workspace metadata (deliberately deferred)

`GoalDto.Workspace` today carries only `(containerId, repository, branch)`. The plan predicates need workspace tier, approved agent list, and cost budget — none of which exist on the andy-tasks contract yet. The HTTP client leaves those fields `null` on the projected `PlanEvaluationGoalView`, which surfaces the three corresponding predicates as `data unavailable`. The shape is in place; a follow-up wires the real workspace metadata source once the Conductor workspace-catalog contract grows them.

## Test plan

- [x] **Unit (47 tests)**: each predicate evaluator (pass / fail / unevaluable / vacuous-zero-tasks cases), `PolicyRulesDslParser` (case-insensitive, malformed-JSON tolerance, no-block returns null), `PlanEvaluator` (decision logic, cache hit/miss, replan bypasses cache, malformed RulesJson skipped silently, unknown predicate doesn't fire rule).
- [x] **Integration (11 tests)**:
  - WireMock contract on `HttpTasksPlanClient`: pins the andy-tasks DTO wire shapes (camelCase, executor pin beats suggested list, 404 on estimates maps to null cost, optional `planVersion` defaults to `"1"`).
  - End-to-end `WebApplicationFactory` + SQLite controller drive: 400 on empty GUID, 404 on unknown goal, manual when no policies bound, approve when policy fires, reject when negative rule fires, predicate trace surfaces `"data unavailable"` for null fields.
- [x] **Full repo regression**: 651 unit + 653 integration + 11 E2E (1315 total) — all pass; existing `ManifestTests` updated by mirroring the new permission into `config/rbac-seed.json`.