### PR TITLE
Grant andy-policies-api the urn:andy-tasks-api scope (plan-evaluation goal-view fetch)

### DIFF
--- a/config/registration.json
+++ b/config/registration.json
@@ -26,7 +26,7 @@
       "displayName": "Andy Policies API",
       "description": "Service-to-service client for Andy Policies",
       "grantTypes": ["authorization_code", "refresh_token", "client_credentials"],
-      "scopes": ["email", "profile", "roles", "scp:urn:andy-policies-api", "scp:urn:andy-rbac-api"]
+      "scopes": ["email", "profile", "roles", "scp:urn:andy-policies-api", "scp:urn:andy-rbac-api", "scp:urn:andy-tasks-api"]
     },
     "webClient": {
       "clientId": "andy-policies-web",


### PR DESCRIPTION
Plan evaluation (`evaluate-plan`/`evaluate-task`) calls back into andy-tasks (`GET /api/goals/{id}` + `/tasks`, `[Authorize]`, audience `urn:andy-tasks-api`) via `HttpTasksPlanClient` with the service M2M bearer. The `apiClient` (andy-policies-api) was granted only `scp:urn:andy-policies-api` + `scp:urn:andy-rbac-api`, so requesting `urn:andy-tasks-api` got **400 invalid_scope** from andy-auth → M2M token mint failed → `evaluate-task` **500** (and broke the inbound RBAC check too).

Add `scp:urn:andy-tasks-api` to the apiClient scopes so andy-auth issues a token andy-tasks accepts. andy-auth re-provisions the client from this manifest on seed (delete-then-create), so a restart applies it.

Companion to conductor#2267 (which injects `AndyTasks__BaseUrl` + the scope request into andy-policies' env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)