### PR TITLE
Restore policy integrity and resolution guarantees

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Governance policy catalog for the Andy ecosystem. A versioned registry of struct
 - **Bindings as metadata** — policy ↔ story template / repo / scope as structured data; no evaluation.
 - **Experimental scopes** — per-principal or per-cohort overrides with approver + expiry; a periodic reaper transitions approved overrides past their `expiresAt` into the `Expired` state automatically (P5.3, [#53](https://github.com/rivoli-ai/andy-policies/issues/53)). Write operations (propose / approve / revoke) are gated behind the andy-settings toggle `andy.policies.experimentalOverridesEnabled` (default `false`); reads remain available regardless so the resolution algorithm keeps working when the toggle is off (P5.4, [#56](https://github.com/rivoli-ai/andy-policies/issues/56)). See [Override concepts](docs/concepts/overrides.md), [ADR 0005 — Overrides](docs/adr/0005-overrides.md), and the [approver](docs/runbooks/override-approver.md) + [operator](docs/runbooks/override-operator.md) runbooks.
 - **Edit RBAC** — who may author, who must approve a publish. Subject→permission checks delegate to [Andy RBAC](https://github.com/rivoli-ai/andy-rbac); the edit matrix itself lives here.
-- **Catalog change audit** — every edit, publish, transition, binding, and override recorded with actor, timestamp, structured field-level diff, required rationale, and tamper-evident chain. Reads are not audited. See the [audit envelope spec](docs/audit-envelope.md), [ADR 0006 — Audit hash chain](docs/adr/0006-audit-hash-chain.md), and the [compliance officer runbook](docs/runbooks/audit-compliance.md).
+- **Catalog change audit** — every policy, lifecycle, binding, scope, override, bundle, and item mutation is committed atomically with actor, timestamp, structured diff, rationale, and a tamper-evident chain. Reads are not audited. See the [audit envelope spec](docs/audit-envelope.md), [ADR 0006 — Audit hash chain](docs/adr/0006-audit-hash-chain.md), and the [compliance officer runbook](docs/runbooks/audit-compliance.md).
 - **Bundle pinning** — consumers pin a bundle version for reproducibility. See [ADR 0008](docs/adr/0008-bundle-pinning.md) for the architectural commitments and the [consumer integration guide](docs/guides/consumer-integration-bundles.md) for the adoption recipe.
 
 ## What this service does NOT own
@@ -84,6 +84,12 @@ and rationale is empty, the API returns
 `400` with `type=/problems/rationale-required` and `errors.rationale`
 populated; the current toggle value is exported as the OpenTelemetry gauge
 `andy_policies_rationale_required_toggle_value` (1 = on, 0 = off).
+
+Rationale enforcement lives at the application-service boundary, so REST,
+gRPC, MCP, CLI, and direct service callers share it for every catalog
+mutation. Reads are exempt. Automatic override expiry uses its system reason;
+override rejection/revocation use their required reason fields as the
+rationale. When the toggle is disabled, mutation rationale may be omitted.
 
 The same lifecycle operations are exposed to LLM agents through the MCP
 endpoint at `/mcp` (P2.5,
@@ -227,7 +233,7 @@ endpoints sit on top of the `IScopeService` (P4.2,
 GET    /api/scopes?type=Tenant                       # list (optional type filter)
 GET    /api/scopes/tree                              # full forest, nested
 GET    /api/scopes/{id}                              # single node
-GET    /api/scopes/{id}/effective-policies            # tighten-only resolved set
+GET    /api/scopes/{id}/effective-policies?bundleId=&principalSubjectId=&cohort= # live/pinned resolved set
 POST   /api/scopes                                    # create (canonical ladder enforced)
 DELETE /api/scopes/{id}                               # leaf-only delete
 ```
@@ -245,6 +251,13 @@ validation (P4.4,
 commit a `Recommended` binding that would shadow an upstream
 `Mandatory`; the `409` response carries `offendingAncestorBindingId`
 and `offendingScopeNodeId` so admins can triage from the error.
+
+Effective resolution applies Approved, unexpired principal/cohort overrides
+after the tighten-only fold. Principal matches beat cohort matches; `Exempt`
+removes a policy and `Replace` substitutes its referenced version. The response
+includes `appliedOverrides` for explanation. Supplying `bundleId` runs the same
+scope-node and Org/Tenant/Repo/Template bridge walk entirely against the frozen
+snapshot, including its captured overrides.
 
 The same scope operations are exposed across MCP, gRPC, and CLI
 (P4.6, [#34](https://github.com/rivoli-ai/andy-policies/issues/34)),

--- a/docs/adr/0005-overrides.md
+++ b/docs/adr/0005-overrides.md
@@ -190,6 +190,15 @@ CHECK constraint `ck_overrides_effect_replacement` keeps
 `(Effect=Replace ↔ ReplacementPolicyVersionId IS NOT NULL)`
 true at the row level.
 
+Resolution applies effects after the tighten-only binding fold. Callers provide
+the principal subject plus zero or more cohort refs. A principal match has
+strict precedence over cohort matches; the most recently approved grant wins
+within a level, followed by stable scope/id tie-breakers. `Exempt` removes the
+baseline policy and `Replace` substitutes its referenced version. Both live and
+pinned responses expose the applied grant metadata. A bundle freezes only
+Approved, unexpired grants and embeds replacement content, so its decision is
+reproducible after the live grant expires or is revoked.
+
 ### 6. Storage shape
 
 ```sql

--- a/docs/adr/0008-bundle-pinning.md
+++ b/docs/adr/0008-bundle-pinning.md
@@ -137,7 +137,7 @@ Two invocations on the same `(fromId, toId)` pair produce byte-identical patch J
 
 - **Storage grows linearly with deliberate bundle count.** Each row carries the full snapshot bytes — typical 100-policy catalog ≈ 30–60 KB; 1000-policy catalog ≈ 300–600 KB. Cold-storage tiering is a future ADR.
 - **No bundle-against-live diff.** The diff RPC compares two stored bundles; consumers wanting "bundle vs. now" must create a fresh bundle and diff against it. Adding a live-diff RPC would tempt consumers to use the service as a drift detector, which is Conductor's job.
-- **Bridge-binding hierarchy walk deferred on snapshot effective-policies.** `IBundleResolver.ResolveEffectiveForScopeAsync` matches only `TargetType=ScopeNode` bindings keyed by `scope:{nodeId}`; `Repo` / `Tenant` / etc. bridges to scope-node refs are deferred. Consumers using bridge-typed bindings should keep `bundleVersionPinning=false` until the follow-up lands.
+- **Snapshot schema remains intentionally denormalized.** Scope entries carry parent ids, types, and external refs, allowing pinned resolution to match explicit `ScopeNode` bindings and `Org` / `Tenant` / `Repo` / `Template` bridge bindings without consulting live tables.
 
 ## Considered alternatives
 
@@ -153,7 +153,6 @@ Two invocations on the same `(fromId, toId)` pair produce byte-identical patch J
 ## Future work
 
 - **Cold-storage tiering** for very-old bundles. Same row id; bytes move out-of-band. Filed as a follow-up; no ETA.
-- **Snapshot-backed effective-policies bridge resolution.** P8.4's deferred case — handle `Repo` / `Tenant` / `Org` / `Template` target types against the snapshot scope chain, mirroring the live `BindingResolutionService` more completely.
 - **1000-policy nightly perf sweep** against a Postgres testcontainer enforcing the strict epic SLOs (500 ms create-p95, 50 ms resolve-p99). The 100-policy budgets in `BundlePerfTests` (P8.7) catch large regressions; the strict budgets need a dedicated runner.
 
 ---

--- a/docs/audit-envelope.md
+++ b/docs/audit-envelope.md
@@ -28,8 +28,17 @@ Schema lives at [`schemas/audit-event.schema.json`](schemas/audit-event.schema.j
 | `action` | string | yes | Dotted action code (`policy.version.publish`, `override.approve`, …). |
 | `entityType` | string | yes | Canonical type of the mutated entity (`Policy`, `Override`, `Binding`, …). |
 | `entityId` | string | yes | String form of the row's primary key — usually a GUID, occasionally a composite ref. |
-| `fieldDiff` | parsed JSON Patch (RFC 6902) | yes | Embedded as a JSON value, **not** as a JSON-encoded string. Defaults to `[]` for create/delete events. |
+| `fieldDiff` | parsed JSON Patch (RFC 6902) | yes | Embedded as a JSON value, **not** as a JSON-encoded string. Catalog mutation adapters always emit a populated patch; lower-level audit callers may use `[]` when no mutation diff exists. |
 | `rationale` | string \| null | yes | Free-text rationale; null permitted only when `andy.policies.rationaleRequired` is off (P6.4). |
+
+## Mutation atomicity
+
+Catalog services save their state change and append the audit envelope through
+the same scoped `AppDbContext` transaction. The chain joins an ambient
+transaction instead of opening a nested one. An audit failure therefore rolls
+back the policy, lifecycle, binding, scope, override, bundle, or item mutation;
+a state change without its expected audit row cannot commit. This contract is
+the same on SQLite and PostgreSQL (with provider-specific serialization locks).
 
 ## Canonical JSON rules (pinned by ADR 0006)
 

--- a/docs/concepts/overrides.md
+++ b/docs/concepts/overrides.md
@@ -135,6 +135,18 @@ Implications:
 - Override storage is a flat table; the hierarchy walk is the
   scope chain. Overrides are not themselves hierarchical — there
   is no "parent override" or scope-walk for the override layer.
+- Effective-resolution callers supply a principal subject and zero or
+  more cohort refs. A matching principal override wins over every cohort
+  match. Within the same level, the latest `ApprovedAt` wins, with stable
+  scope/id ordering as the deterministic tie-breaker.
+- `Exempt` removes the baseline policy. `Replace` substitutes the referenced
+  Active or WindingDown version while preserving binding provenance. Responses
+  include `appliedOverrides`, so consumers can explain both decisions.
+- Pinned resolution uses only overrides captured in the bundle. Bundle creation
+  freezes Approved rows with `expiresAt > capturedAt`, including replacement
+  policy content and approval ordering; later approvals, revocations, or expiry
+  do not rewrite the snapshot. Older snapshots without override metadata retain
+  their baseline behavior.
 
 ## Firewalls (epic recap)
 

--- a/docs/design/edit-matrix.md
+++ b/docs/design/edit-matrix.md
@@ -86,10 +86,10 @@ applies the same self-approval domain invariant before the RBAC call:
 | Surface | Enforcement seam | Implemented in |
 |---|---|---|
 | REST | `[Authorize(Policy = "andy-policies:…")]` per controller action; `RbacAuthorizationHandler` extracts subject + groups + route-derived resource instance and delegates. | P7.4 (#57) |
-| MCP | `McpRbacGuard.EnsureAsync` invoked at the top of every mutating tool body; denials translate to a typed `policy.<area>.forbidden: <reason>` tool result. `[RbacGuard]` attribute pins the contract for review + reflective coverage tests. | P7.6 (#64) |
-| gRPC | Global `RbacServerInterceptor` consults `GrpcMethodPermissionMap`; unmapped RPCs on enforced services hard-fail with `RpcException(Internal)` (fail-closed, never silent allow). `ItemsService` is the one allow-listed bypass (template scaffolding). | P7.6 (#64) |
+| MCP | `McpRbacGuard.EnsureAsync` guards every business tool, reads and writes; denials translate to a typed `policy.<area>.forbidden: <reason>` result. `[RbacGuard]` plus reflection coverage prevents unguarded additions. Public help tools are the sole explicit allowlist. | P7.6 (#64) |
+| gRPC | Global `RbacServerInterceptor` consults `GrpcMethodPermissionMap`; unmapped RPCs on every business service, including `ItemsService`, hard-fail closed. | P7.6 (#64) |
 
-A reflection-driven coverage test
-(`GrpcPermissionMapCoverageTests`) walks every RPC on the proto-generated
-`*ServiceBase` classes and asserts a permission code is mapped — adding a new
-RPC without a mapping fails CI rather than the runtime.
+Reflection-driven coverage walks every proto-generated `*ServiceBase` RPC and
+every `[McpServerTool]`, asserting a valid permission code. Adding a new RPC or
+business tool without a mapping fails CI rather than silently allowing runtime
+access.

--- a/docs/design/policy-document-core.md
+++ b/docs/design/policy-document-core.md
@@ -116,7 +116,7 @@ stateDiagram-v2
     note left of Retired : Tombstoned
 ```
 
-P1's resolution rule is "highest non-Draft version is active." P2 tightens to "exactly one row with `State == Active` per policy" via the partial unique index `ix_policy_versions_one_active_per_policy`.
+The canonical active-version rule is exactly `State == Active`; `Draft`, `WindingDown`, and `Retired` are never returned by active-version queries or captured as active bundle policies. The partial unique index `ix_policy_versions_one_active_per_policy` guarantees at most one such row per policy.
 
 ## Versioning invariants
 

--- a/docs/guides/consumer-integration-bundles.md
+++ b/docs/guides/consumer-integration-bundles.md
@@ -293,6 +293,13 @@ effective; an `Expired` override has been swept by the reaper
 genuinely was approved + unexpired at bundle-create time —
 review with the override author.
 
+Pinned effective-policy resolution accepts the same principal/cohort context
+as live resolution. Principal matches take precedence over cohort matches;
+`Exempt` removes a policy and `Replace` substitutes the replacement embedded in
+the snapshot. Inspect `appliedOverrides` in the response for the exact grant.
+All explicit scope-node and Org/Tenant/Repo/Template bridge bindings are walked
+against the frozen scope hierarchy.
+
 ### "The diff is empty but I changed a policy"
 
 The two bundles you're diffing were both taken before the

--- a/docs/openapi/andy-policies-v1.yaml
+++ b/docs/openapi/andy-policies-v1.yaml
@@ -13,7 +13,7 @@ paths:
   /health:
     get:
       tags:
-        - 'Andy.Policies.Api, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'
+        - Andy.Policies.Api
       operationId: health
       responses:
         '200':
@@ -1071,6 +1071,17 @@ paths:
           schema:
             type: string
             format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteItemMutationRequest'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/DeleteItemMutationRequest'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/DeleteItemMutationRequest'
       responses:
         '200':
           description: OK
@@ -1193,6 +1204,17 @@ paths:
           schema:
             type: string
             format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApproveOverrideRequest'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/ApproveOverrideRequest'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/ApproveOverrideRequest'
       responses:
         '200':
           description: OK
@@ -1718,7 +1740,7 @@ paths:
     get:
       tags:
         - Policies
-      summary: "Resolves the active version per ADR 0001 (highest `Version` with\r\n`State != Draft` in P1; `State == Active` after P2 lands).\r\nRoute literal \"active\" sits before `{versionId:guid}` in match precedence,\r\nand the GUID constraint makes the two routes unambiguous regardless."
+      summary: "Resolves the active version per ADR 0001/P2: the highest\r\n`Version` whose lifecycle `State == Active`.\r\nRoute literal \"active\" sits before `{versionId:guid}` in match precedence,\r\nand the GUID constraint makes the two routes unambiguous regardless."
       operationId: Policies_GetActiveVersion
       parameters:
         - name: id
@@ -1852,6 +1874,17 @@ paths:
           schema:
             type: string
             format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BumpPolicyVersionRequest'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/BumpPolicyVersionRequest'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/BumpPolicyVersionRequest'
       responses:
         '200':
           description: OK
@@ -2333,6 +2366,17 @@ paths:
           schema:
             type: string
             format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteScopeNodeRequest'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/DeleteScopeNodeRequest'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/DeleteScopeNodeRequest'
       responses:
         '204':
           description: No Content
@@ -2373,6 +2417,16 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: principalSubjectId
+          in: query
+          schema:
+            type: string
+        - name: cohort
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
       responses:
         '200':
           description: OK
@@ -2395,6 +2449,35 @@ paths:
                 $ref: '#/components/schemas/ProblemDetails'
 components:
   schemas:
+    AppliedOverrideDto:
+      type: object
+      properties:
+        overrideId:
+          type: string
+          format: uuid
+        effect:
+          $ref: '#/components/schemas/OverrideEffect'
+        scopeKind:
+          $ref: '#/components/schemas/OverrideScopeKind'
+        scopeRef:
+          type: string
+          nullable: true
+        originalPolicyVersionId:
+          type: string
+          format: uuid
+        replacementPolicyVersionId:
+          type: string
+          format: uuid
+          nullable: true
+      additionalProperties: false
+    ApproveOverrideRequest:
+      type: object
+      properties:
+        rationale:
+          type: string
+          nullable: true
+      additionalProperties: false
+      description: Audit rationale supplied by the override approver.
     AuditEventDto:
       type: object
       properties:
@@ -2512,6 +2595,14 @@ components:
         - Org
         - Agent
       type: string
+    BumpPolicyVersionRequest:
+      type: object
+      properties:
+        rationale:
+          type: string
+          nullable: true
+      additionalProperties: false
+      description: Audit rationale for creating a new Draft from a source version.
     BundleContentsBindingDto:
       type: object
       properties:
@@ -2934,6 +3025,9 @@ components:
         description:
           type: string
           nullable: true
+        rationale:
+          type: string
+          nullable: true
       additionalProperties: false
     CreatePolicyRequest:
       type: object
@@ -2989,6 +3083,9 @@ components:
         displayName:
           type: string
           nullable: true
+        rationale:
+          type: string
+          nullable: true
       additionalProperties: false
       description: "Request payload for `IScopeService.CreateAsync` (P4.2, story\r\nrivoli-ai/andy-policies#29). Andy.Policies.Application.Dtos.CreateScopeNodeRequest.ParentId is null for a\r\nroot Andy.Policies.Domain.Enums.ScopeType.Org node; non-null for any other type.\r\nThe service enforces the canonical Org→Tenant→Team→Repo→Template→Run\r\nladder."
     DeleteBindingBody:
@@ -2999,6 +3096,21 @@ components:
           nullable: true
       additionalProperties: false
       description: "Optional body for `DELETE /api/bindings/{id}`. New canonical\r\nshape — the existing `?rationale=` query parameter still\r\nworks (P9.5 follow-up #197)."
+    DeleteItemMutationRequest:
+      type: object
+      properties:
+        rationale:
+          type: string
+          nullable: true
+      additionalProperties: false
+    DeleteScopeNodeRequest:
+      type: object
+      properties:
+        rationale:
+          type: string
+          nullable: true
+      additionalProperties: false
+      description: Audit rationale for deleting a leaf scope node.
     EffectivePolicyDto:
       type: object
       properties:
@@ -3041,6 +3153,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EffectivePolicyDto'
+          nullable: true
+        appliedOverrides:
+          type: array
+          items:
+            $ref: '#/components/schemas/AppliedOverrideDto'
+          description: "Deterministic explanation of every override that changed\r\n            the baseline set, including Exempt entries whose policy is absent\r\n            from Andy.Policies.Application.Dtos.EffectivePolicySetDto.Policies."
           nullable: true
       additionalProperties: false
       description: "Envelope for `IBindingResolutionService` results (P4.3, story\r\nrivoli-ai/andy-policies#30). Andy.Policies.Application.Dtos.EffectivePolicySetDto.ScopeNodeId is null when\r\nthe resolver was called with a target that does not map to a known\r\n`ScopeNode` — the service then degrades to P3 exact-match\r\nsemantics rather than returning 404."

--- a/docs/reference/evaluate-task.md
+++ b/docs/reference/evaluate-task.md
@@ -84,6 +84,12 @@ the plan-finalize path (`RuleFires`' "couldn't prove it passed" semantics), an
 violation with `"outcome": "unevaluable"` and `"reason": "data unavailable"`,
 and is scored identically to a `fail`. Missing data can never reduce risk.
 
+Task fields preserve wire-level nullability. Missing or explicit-null
+`delegationContract.toolsAllowed` makes `allTasksReadOnly` unevaluable; an
+explicit empty array is valid and means no tools are allowed. Missing, null, or
+blank `targetEnv` makes `noProductionDeploy` unevaluable. Values such as
+`dev`, `staging`, and `prod` are evaluated as supplied by andy-tasks.
+
 ## Failure modes
 
 | Status | When |

--- a/scripts/export-openapi.sh
+++ b/scripts/export-openapi.sh
@@ -12,37 +12,15 @@ cd "$REPO_ROOT"
 
 OUTPUT_DIR="docs/openapi"
 OUTPUT_FILE="$OUTPUT_DIR/andy-policies-v1.yaml"
-API_PROJECT="src/Andy.Policies.Api"
-API_DLL="$API_PROJECT/bin/Release/net8.0/Andy.Policies.Api.dll"
 
 mkdir -p "$OUTPUT_DIR"
 
-# Restore the locally-pinned Swashbuckle.AspNetCore.Cli tool. Idempotent.
-dotnet tool restore >/dev/null
-
-# Build Release once so the resolved DLL has the production Swagger config.
-dotnet build "$API_PROJECT" -c Release --nologo --verbosity minimal
-
-# AndyAuth__Authority, AndySettings__ApiBaseUrl, and AndyRbac__BaseUrl are
-# required at startup (#103, #108, #51 — no silent dev bypass). Provide
-# placeholders for the document generator; nothing reaches over the network
-# because Swashbuckle only walks the controller graph in-process.
-# Database:Provider=Sqlite + an in-memory data source keeps the boot-time
-# stock-policy seeder (#73) happy without needing a live Postgres. The temp
-# file path is wiped on each run so the seed never carries over.
-TMP_DB="$(mktemp -t andy-policies-export-openapi-XXXXXX.db)"
-trap 'rm -f "$TMP_DB"' EXIT
-# P10.1 (#31): use Development env so Program.cs runs MigrateAsync
-# against the empty temp SQLite — the boot-time seeder needs a
-# schema. The "Testing" env is reserved for integration tests
-# whose own factories own schema initialisation.
-ASPNETCORE_ENVIRONMENT="Development" \
-AndyAuth__Authority="https://export.invalid" \
-AndyAuth__Audience="urn:andy-policies-api" \
-AndySettings__ApiBaseUrl="https://export.invalid" \
-AndyRbac__BaseUrl="https://export.invalid" \
-Database__Provider="Sqlite" \
-ConnectionStrings__DefaultConnection="Data Source=$TMP_DB" \
-    dotnet tool run swagger tofile --yaml --output "$OUTPUT_FILE" "$API_DLL" v1
+# Resolve the live Swagger provider through the integration-test host. This
+# uses the same Program.cs/controller graph as production while keeping hosted
+# dependency refreshers and seed/migration ownership under the tested factory.
+UPDATE_OPENAPI=1 dotnet test \
+    tests/Andy.Policies.Tests.Integration/Andy.Policies.Tests.Integration.csproj \
+    --filter 'FullyQualifiedName~OpenApiSnapshotExportTests.ExportYaml_WhenExplicitlyRequested' \
+    --no-restore --nologo --verbosity minimal
 
 echo "Wrote $OUTPUT_FILE"

--- a/scripts/export-openapi.sh
+++ b/scripts/export-openapi.sh
@@ -21,6 +21,6 @@ mkdir -p "$OUTPUT_DIR"
 UPDATE_OPENAPI=1 dotnet test \
     tests/Andy.Policies.Tests.Integration/Andy.Policies.Tests.Integration.csproj \
     --filter 'FullyQualifiedName~OpenApiSnapshotExportTests.ExportYaml_WhenExplicitlyRequested' \
-    --no-restore --nologo --verbosity minimal
+    --nologo --verbosity minimal
 
 echo "Wrote $OUTPUT_FILE"

--- a/src/Andy.Policies.Api/Authorization/ActorSubjectResolver.cs
+++ b/src/Andy.Policies.Api/Authorization/ActorSubjectResolver.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Claims;
+
+namespace Andy.Policies.Api.Authorization;
+
+/// <summary>
+/// Canonical subject extraction for every authenticated API surface.
+/// The JWT subject is stable; display-name claims are only a legacy
+/// fallback for test and older identity providers.
+/// </summary>
+public static class ActorSubjectResolver
+{
+    public static string? Resolve(ClaimsPrincipal? user)
+    {
+        if (user is null) return null;
+        var candidates = new[]
+        {
+            user.FindFirstValue(ClaimTypes.NameIdentifier),
+            user.FindFirstValue("sub"),
+            user.Identity?.Name,
+        };
+        return candidates.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))?.Trim();
+    }
+
+    public static string Require(ClaimsPrincipal? user) =>
+        Resolve(user) ?? throw new MissingActorSubjectException();
+}
+
+/// <summary>Authenticated principal did not contain a stable subject.</summary>
+public sealed class MissingActorSubjectException : Exception
+{
+    public MissingActorSubjectException()
+        : base("Authentication succeeded but the caller has no resolvable subject claim.")
+    {
+    }
+}

--- a/src/Andy.Policies.Api/Authorization/RbacAuthorizationHandler.cs
+++ b/src/Andy.Policies.Api/Authorization/RbacAuthorizationHandler.cs
@@ -64,7 +64,7 @@ public sealed class RbacAuthorizationHandler : AuthorizationHandler<RbacRequirem
             return;
         }
 
-        var subjectId = ResolveSubjectId(context.User);
+        var subjectId = ActorSubjectResolver.Resolve(context.User);
         if (string.IsNullOrWhiteSpace(subjectId))
         {
             // Authentication ran but no subject claim — let the
@@ -95,8 +95,4 @@ public sealed class RbacAuthorizationHandler : AuthorizationHandler<RbacRequirem
             subjectId, requirement.PermissionCode, resourceInstanceId ?? "(none)", decision.Reason);
     }
 
-    private static string? ResolveSubjectId(ClaimsPrincipal user)
-        => user.FindFirstValue(ClaimTypes.NameIdentifier)
-        ?? user.FindFirstValue("sub")
-        ?? user.Identity?.Name;
 }

--- a/src/Andy.Policies.Api/Controllers/AuthController.cs
+++ b/src/Andy.Policies.Api/Controllers/AuthController.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Security.Claims;
+using Andy.Policies.Api.Authorization;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Application.Manifest;
 using Microsoft.AspNetCore.Authorization;
@@ -66,8 +67,7 @@ public sealed class AuthController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
     public async Task<ActionResult<IReadOnlyList<string>>> Permissions(CancellationToken ct)
     {
-        var subjectId = User.FindFirstValue(ClaimTypes.NameIdentifier)
-            ?? User.Identity?.Name;
+        var subjectId = ActorSubjectResolver.Resolve(User);
         if (string.IsNullOrEmpty(subjectId))
         {
             // [Authorize] should have already returned 401; belt to the

--- a/src/Andy.Policies.Api/Controllers/BindingsController.cs
+++ b/src/Andy.Policies.Api/Controllers/BindingsController.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-using System.Security.Claims;
+using Andy.Policies.Api.Authorization;
 using Andy.Policies.Api.Filters;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
@@ -235,7 +235,6 @@ public sealed class BindingsController : ControllerBase
         // maps `sub` to NameIdentifier; TestAuthHandler sets the Name
         // claim. If neither is present, [Authorize] should already have
         // returned 401 — this is the belt to the framework's braces.
-        var sub = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? User.Identity?.Name;
-        return string.IsNullOrEmpty(sub) ? null : sub;
+        return ActorSubjectResolver.Resolve(User);
     }
 }

--- a/src/Andy.Policies.Api/Controllers/BundlesController.cs
+++ b/src/Andy.Policies.Api/Controllers/BundlesController.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-using System.Security.Claims;
+using Andy.Policies.Api.Authorization;
 using Andy.Policies.Application.Exceptions;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Domain.Enums;
@@ -152,8 +152,7 @@ public sealed class BundlesController : ControllerBase
 
     private string? ResolveActor()
     {
-        var sub = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? User.Identity?.Name;
-        return string.IsNullOrEmpty(sub) ? null : sub;
+        return ActorSubjectResolver.Resolve(User);
     }
 
     /// <summary>

--- a/src/Andy.Policies.Api/Controllers/ItemsController.cs
+++ b/src/Andy.Policies.Api/Controllers/ItemsController.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using Andy.Policies.Api.Authorization;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Andy.Policies.Api.Controllers;
 
@@ -21,6 +23,7 @@ public class ItemsController : ControllerBase
     }
 
     [HttpGet]
+    [Authorize(Policy = "andy-policies:policy:read")]
     public async Task<ActionResult<IEnumerable<ItemDto>>> GetAll(CancellationToken ct)
     {
         var items = await _itemService.GetAllAsync(ct);
@@ -28,6 +31,7 @@ public class ItemsController : ControllerBase
     }
 
     [HttpGet("{id:guid}")]
+    [Authorize(Policy = "andy-policies:policy:read")]
     public async Task<ActionResult<ItemDto>> GetById(Guid id, CancellationToken ct)
     {
         var item = await _itemService.GetByIdAsync(id, ct);
@@ -36,26 +40,36 @@ public class ItemsController : ControllerBase
     }
 
     [HttpPost]
+    [Authorize(Policy = "andy-policies:policy:author")]
     public async Task<ActionResult<ItemDto>> Create([FromBody] CreateItemRequest request, CancellationToken ct)
     {
-        var userId = User.Identity?.Name ?? "anonymous";
+        var userId = ActorSubjectResolver.Require(User);
         var item = await _itemService.CreateAsync(request, userId, ct);
         return CreatedAtAction(nameof(GetById), new { id = item.Id }, item);
     }
 
     [HttpPut("{id:guid}")]
+    [Authorize(Policy = "andy-policies:policy:author")]
     public async Task<ActionResult<ItemDto>> Update(Guid id, [FromBody] CreateItemRequest request, CancellationToken ct)
     {
-        var item = await _itemService.UpdateAsync(id, request, ct);
+        var item = await _itemService.UpdateAsync(
+            id, request, ActorSubjectResolver.Require(User), ct);
         if (item is null) return NotFound();
         return Ok(item);
     }
 
     [HttpDelete("{id:guid}")]
-    public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
+    [Authorize(Policy = "andy-policies:policy:author")]
+    public async Task<IActionResult> Delete(
+        Guid id,
+        [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] DeleteItemMutationRequest? request,
+        CancellationToken ct)
     {
-        var deleted = await _itemService.DeleteAsync(id, ct);
+        var deleted = await _itemService.DeleteAsync(
+            id, ActorSubjectResolver.Require(User), request?.Rationale, ct);
         if (!deleted) return NotFound();
         return NoContent();
     }
+
+    public sealed record DeleteItemMutationRequest(string? Rationale);
 }

--- a/src/Andy.Policies.Api/Controllers/OverridesController.cs
+++ b/src/Andy.Policies.Api/Controllers/OverridesController.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-using System.Security.Claims;
+using Andy.Policies.Api.Authorization;
 using Andy.Policies.Api.Filters;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
@@ -97,12 +97,15 @@ public sealed class OverridesController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
-    public async Task<ActionResult<OverrideDto>> Approve(Guid id, CancellationToken ct)
+    public async Task<ActionResult<OverrideDto>> Approve(
+        Guid id,
+        [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] ApproveOverrideRequest? request,
+        CancellationToken ct)
     {
         var subject = ResolveSubjectId();
         if (subject is null) return Unauthorized();
 
-        return Ok(await _service.ApproveAsync(id, subject, ct));
+        return Ok(await _service.ApproveAsync(id, subject, request?.Rationale, ct));
     }
 
     /// <summary>
@@ -220,8 +223,6 @@ public sealed class OverridesController : ControllerBase
         // `sub` to NameIdentifier; TestAuthHandler sets the Name claim.
         // [Authorize] should already have returned 401 before we get
         // here — this is the belt to the framework's braces.
-        var subject = User.FindFirstValue(ClaimTypes.NameIdentifier)
-                      ?? User.Identity?.Name;
-        return string.IsNullOrEmpty(subject) ? null : subject;
+        return ActorSubjectResolver.Resolve(User);
     }
 }

--- a/src/Andy.Policies.Api/Controllers/PoliciesController.cs
+++ b/src/Andy.Policies.Api/Controllers/PoliciesController.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using Andy.Policies.Api.Authorization;
 using Andy.Policies.Api.Filters;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Application.Queries;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Andy.Policies.Api.Controllers;
 
@@ -127,8 +129,8 @@ public class PoliciesController : ControllerBase
     }
 
     /// <summary>
-    /// Resolves the active version per ADR 0001 (highest <c>Version</c> with
-    /// <c>State != Draft</c> in P1; <c>State == Active</c> after P2 lands).
+    /// Resolves the active version per ADR 0001/P2: the highest
+    /// <c>Version</c> whose lifecycle <c>State == Active</c>.
     /// Route literal "active" sits before <c>{versionId:guid}</c> in match precedence,
     /// and the GUID constraint makes the two routes unambiguous regardless.
     /// </summary>
@@ -167,7 +169,7 @@ public class PoliciesController : ControllerBase
     public async Task<ActionResult<PolicyVersionDto>> Create(
         [FromBody] CreatePolicyRequest request, CancellationToken ct)
     {
-        var subjectId = User.Identity?.Name ?? "anonymous";
+        var subjectId = ActorSubjectResolver.Require(User);
         var version = await _policies.CreateDraftAsync(request, subjectId, ct);
         return CreatedAtAction(
             nameof(GetVersion),
@@ -183,7 +185,7 @@ public class PoliciesController : ControllerBase
         [FromBody] UpdatePolicyVersionRequest request,
         CancellationToken ct)
     {
-        var subjectId = User.Identity?.Name ?? "anonymous";
+        var subjectId = ActorSubjectResolver.Require(User);
         var updated = await _policies.UpdateDraftAsync(id, versionId, request, subjectId, ct);
         return Ok(updated);
     }
@@ -191,10 +193,14 @@ public class PoliciesController : ControllerBase
     [HttpPost("{id:guid}/versions/{sourceVersionId:guid}/bump")]
     [Authorize(Policy = "andy-policies:policy:author")]
     public async Task<ActionResult<PolicyVersionDto>> Bump(
-        Guid id, Guid sourceVersionId, CancellationToken ct)
+        Guid id,
+        Guid sourceVersionId,
+        [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] BumpPolicyVersionRequest? request,
+        CancellationToken ct)
     {
-        var subjectId = User.Identity?.Name ?? "anonymous";
-        var next = await _policies.BumpDraftFromVersionAsync(id, sourceVersionId, subjectId, ct);
+        var subjectId = ActorSubjectResolver.Require(User);
+        var next = await _policies.BumpDraftFromVersionAsync(
+            id, sourceVersionId, subjectId, request?.Rationale, ct);
         return CreatedAtAction(
             nameof(GetVersion),
             new { id = next.PolicyId, versionId = next.Id },

--- a/src/Andy.Policies.Api/Controllers/PolicyVersionsLifecycleController.cs
+++ b/src/Andy.Policies.Api/Controllers/PolicyVersionsLifecycleController.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-using System.Security.Claims;
+using Andy.Policies.Api.Authorization;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Domain.Enums;
@@ -108,12 +108,7 @@ public sealed class PolicyVersionsLifecycleController : ControllerBase
         [FromBody] LifecycleTransitionRequest? body,
         CancellationToken ct)
     {
-        var subjectId = User.FindFirstValue(ClaimTypes.NameIdentifier)
-            ?? User.Identity?.Name;
-        if (string.IsNullOrEmpty(subjectId))
-        {
-            return Unauthorized();
-        }
+        var subjectId = ActorSubjectResolver.Require(User);
 
         var dto = await _policies.ProposeDraftAsync(
             id, versionId, body?.Rationale, subjectId, ct);
@@ -139,12 +134,7 @@ public sealed class PolicyVersionsLifecycleController : ControllerBase
         [FromBody] LifecycleTransitionRequest body,
         CancellationToken ct)
     {
-        var subjectId = User.FindFirstValue(ClaimTypes.NameIdentifier)
-            ?? User.Identity?.Name;
-        if (string.IsNullOrEmpty(subjectId))
-        {
-            return Unauthorized();
-        }
+        var subjectId = ActorSubjectResolver.Require(User);
 
         var dto = await _policies.RejectDraftAsync(
             id, versionId, body?.Rationale ?? string.Empty, subjectId, ct);
@@ -159,12 +149,7 @@ public sealed class PolicyVersionsLifecycleController : ControllerBase
         // catalog. JwtBearer maps `sub` to NameIdentifier; TestAuthHandler sets
         // the Name claim. If neither is present, [Authorize] should already have
         // returned 401 — this is the belt to the framework's braces.
-        var subjectId = User.FindFirstValue(ClaimTypes.NameIdentifier)
-            ?? User.Identity?.Name;
-        if (string.IsNullOrEmpty(subjectId))
-        {
-            return Unauthorized();
-        }
+        var subjectId = ActorSubjectResolver.Require(User);
 
         var dto = await _transitions.TransitionAsync(
             id, versionId, target,

--- a/src/Andy.Policies.Api/Controllers/ScopesController.cs
+++ b/src/Andy.Policies.Api/Controllers/ScopesController.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using Andy.Policies.Api.Authorization;
 using Andy.Policies.Api.Filters;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Domain.Enums;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Andy.Policies.Api.Controllers;
 
@@ -98,15 +100,23 @@ public sealed class ScopesController : ControllerBase
     public async Task<ActionResult<EffectivePolicySetDto>> Effective(
         Guid id,
         [FromQuery] Guid? bundleId,
+        [FromQuery] string? principalSubjectId,
+        [FromQuery(Name = "cohort")] string[]? cohorts,
         [FromServices] IBundleResolver bundleResolver,
         CancellationToken ct)
     {
+        var context = new OverrideResolutionContext(
+            string.IsNullOrWhiteSpace(principalSubjectId)
+                ? ActorSubjectResolver.Require(User)
+                : principalSubjectId.Trim(),
+            cohorts ?? Array.Empty<string>());
         if (bundleId is { } pinned)
         {
-            var snapshotResult = await bundleResolver.ResolveEffectiveForScopeAsync(pinned, id, ct);
+            var snapshotResult = await bundleResolver.ResolveEffectiveForScopeAsync(
+                pinned, id, context, ct);
             return snapshotResult is null ? NotFound() : Ok(snapshotResult);
         }
-        var result = await _resolver.ResolveForScopeAsync(id, ct);
+        var result = await _resolver.ResolveForScopeAsync(id, context, ct);
         return Ok(result);
     }
 
@@ -128,7 +138,8 @@ public sealed class ScopesController : ControllerBase
         [FromBody] CreateScopeNodeRequest request,
         CancellationToken ct)
     {
-        var dto = await _scopes.CreateAsync(request, ct);
+        var dto = await _scopes.CreateAsync(
+            request, ActorSubjectResolver.Require(User), ct);
         return CreatedAtAction(nameof(Get), new { id = dto.Id }, dto);
     }
 
@@ -143,9 +154,13 @@ public sealed class ScopesController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
-    public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
+    public async Task<IActionResult> Delete(
+        Guid id,
+        [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] DeleteScopeNodeRequest? request,
+        CancellationToken ct)
     {
-        await _scopes.DeleteAsync(id, ct);
+        await _scopes.DeleteAsync(
+            id, ActorSubjectResolver.Require(User), request?.Rationale, ct);
         return NoContent();
     }
 }

--- a/src/Andy.Policies.Api/ExceptionHandlers/PolicyExceptionHandler.cs
+++ b/src/Andy.Policies.Api/ExceptionHandlers/PolicyExceptionHandler.cs
@@ -3,6 +3,7 @@
 
 using Andy.Policies.Application.Exceptions;
 using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Api.Authorization;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -27,6 +28,21 @@ public sealed class PolicyExceptionHandler : IExceptionHandler
         Exception exception,
         CancellationToken cancellationToken)
     {
+        if (exception is MissingActorSubjectException)
+        {
+            var problem403 = new ProblemDetails
+            {
+                Status = StatusCodes.Status403Forbidden,
+                Title = "Authenticated subject required",
+                Detail = exception.Message,
+                Type = "/problems/missing-actor-subject",
+                Instance = httpContext.Request.Path,
+            };
+            httpContext.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await httpContext.Response.WriteAsJsonAsync(problem403, cancellationToken);
+            return true;
+        }
+
         // Special-case RationaleRequiredException so the response carries the
         // typed ProblemDetails contract from P2.4 (#14): `type` points at the
         // rationale-required problem class, and `errors.rationale` is populated

--- a/src/Andy.Policies.Api/GrpcServices/Authorization/GrpcMethodPermissionMap.cs
+++ b/src/Andy.Policies.Api/GrpcServices/Authorization/GrpcMethodPermissionMap.cs
@@ -15,11 +15,10 @@ namespace Andy.Policies.Api.GrpcServices.Authorization;
 /// matches the rpc name.
 /// </para>
 /// <para>
-/// <b>Items service is intentionally absent.</b> It ships as template
-/// scaffolding and is not a governance surface — the
-/// <see cref="RbacServerInterceptor"/> bypasses it via the
-/// <see cref="IsEnforcedService"/> allowlist below. Every other
-/// service must have every rpc mapped here, which is asserted by a
+/// Items remains legacy template scaffolding, but it is still an
+/// authenticated mutation/read surface and therefore maps to the
+/// policy read/author permissions. Every service has every rpc mapped,
+/// which is asserted by a
 /// reflection-based coverage test in the integration project.
 /// </para>
 /// </remarks>
@@ -27,6 +26,13 @@ public sealed class GrpcMethodPermissionMap : IGrpcMethodPermissionMap
 {
     private static readonly IReadOnlyDictionary<string, string> Map = new Dictionary<string, string>
     {
+        // Legacy ItemsService — protect until the scaffold is removed.
+        ["/andy_policies.ItemsService/GetAll"]  = "andy-policies:policy:read",
+        ["/andy_policies.ItemsService/GetById"] = "andy-policies:policy:read",
+        ["/andy_policies.ItemsService/Create"]  = "andy-policies:policy:author",
+        ["/andy_policies.ItemsService/Update"]  = "andy-policies:policy:author",
+        ["/andy_policies.ItemsService/Delete"]  = "andy-policies:policy:author",
+
         // PolicyService — reads + drafting
         ["/andy_policies.PolicyService/ListPolicies"]      = "andy-policies:policy:read",
         ["/andy_policies.PolicyService/GetPolicy"]         = "andy-policies:policy:read",
@@ -84,10 +90,10 @@ public sealed class GrpcMethodPermissionMap : IGrpcMethodPermissionMap
         ["/andy_policies.BundleService/DiffBundles"]   = "andy-policies:bundle:read",
     };
 
-    /// <summary>Services not in this set are allowed to bypass RBAC.
-    /// Currently only the template-scaffolding ItemsService.</summary>
+    /// <summary>Services not in this set are allowed to bypass RBAC.</summary>
     private static readonly HashSet<string> EnforcedServices = new(StringComparer.Ordinal)
     {
+        "/andy_policies.ItemsService",
         "/andy_policies.PolicyService",
         "/andy_policies.LifecycleService",
         "/andy_policies.BindingService",

--- a/src/Andy.Policies.Api/GrpcServices/Authorization/RbacServerInterceptor.cs
+++ b/src/Andy.Policies.Api/GrpcServices/Authorization/RbacServerInterceptor.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Security.Claims;
+using Andy.Policies.Api.Authorization;
 using Andy.Policies.Application.Interfaces;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
@@ -26,8 +27,8 @@ namespace Andy.Policies.Api.GrpcServices.Authorization;
 /// <see cref="GrpcMethodPermissionMap"/> would be a security gap.
 /// </para>
 /// <para>
-/// <b>Items service is intentionally bypassed</b> — see
-/// <see cref="GrpcMethodPermissionMap.IsEnforcedService"/>.
+/// Every business service, including Items, is enforced. Only non-business
+/// framework endpoints outside the mapped service set bypass this interceptor.
 /// </para>
 /// </remarks>
 public sealed class RbacServerInterceptor : Interceptor
@@ -80,10 +81,7 @@ public sealed class RbacServerInterceptor : Interceptor
         }
 
         var user = context.GetHttpContext().User;
-        var subjectId = user.FindFirstValue(ClaimTypes.NameIdentifier)
-                     ?? user.FindFirstValue("sub")
-                     ?? user.Identity?.Name
-                     ?? string.Empty;
+        var subjectId = ActorSubjectResolver.Resolve(user) ?? string.Empty;
         if (string.IsNullOrWhiteSpace(subjectId))
         {
             throw new RpcException(new Status(StatusCode.Unauthenticated, "no subject claim"));

--- a/src/Andy.Policies.Api/GrpcServices/BindingsGrpcService.cs
+++ b/src/Andy.Policies.Api/GrpcServices/BindingsGrpcService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Security.Claims;
+using Andy.Policies.Api.Authorization;
 using Andy.Policies.Api.Protos;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Exceptions;
@@ -51,7 +52,11 @@ public class BindingsGrpcService : Andy.Policies.Api.Protos.BindingService.Bindi
         {
             var dto = await _bindings.CreateAsync(
                 new Andy.Policies.Application.Dtos.CreateBindingRequest(
-                    versionId, targetType, request.TargetRef, bindStrength),
+                    versionId,
+                    targetType,
+                    request.TargetRef,
+                    bindStrength,
+                    string.IsNullOrWhiteSpace(request.Rationale) ? null : request.Rationale),
                 ResolveSubjectId(context),
                 context.CancellationToken);
             return new BindingResponse { Binding = ToMessage(dto) };
@@ -151,8 +156,7 @@ public class BindingsGrpcService : Andy.Policies.Api.Protos.BindingService.Bindi
         // to act when no subject id is on the principal rather than write a
         // fallback string into the catalog.
         var http = context.GetHttpContext();
-        var sub = http?.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
-            ?? http?.User.Identity?.Name;
+        var sub = ActorSubjectResolver.Resolve(http?.User);
         if (string.IsNullOrEmpty(sub))
         {
             throw new RpcException(new Status(StatusCode.Unauthenticated,

--- a/src/Andy.Policies.Api/GrpcServices/BundleGrpcService.cs
+++ b/src/Andy.Policies.Api/GrpcServices/BundleGrpcService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Security.Claims;
+using Andy.Policies.Api.Authorization;
 using Andy.Policies.Api.Protos;
 using Andy.Policies.Application.Exceptions;
 using Andy.Policies.Application.Interfaces;
@@ -217,7 +218,7 @@ public class BundleGrpcService : Andy.Policies.Api.Protos.BundleService.BundleSe
     private static string ResolveActor(ServerCallContext context)
     {
         var user = context.GetHttpContext().User;
-        var sub = user.FindFirstValue(ClaimTypes.NameIdentifier) ?? user.Identity?.Name;
+        var sub = ActorSubjectResolver.Resolve(user);
         if (string.IsNullOrEmpty(sub))
         {
             throw new RpcException(new Status(StatusCode.Unauthenticated, "no subject claim"));

--- a/src/Andy.Policies.Api/GrpcServices/ItemsGrpcService.cs
+++ b/src/Andy.Policies.Api/GrpcServices/ItemsGrpcService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using Andy.Policies.Api.Authorization;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Api.Protos;
@@ -38,16 +39,20 @@ public class ItemsGrpcService : Protos.ItemsService.ItemsServiceBase
 
     public override async Task<ItemResponse> Create(CreateItemGrpcRequest request, ServerCallContext context)
     {
-        var userId = context.GetHttpContext().User.Identity?.Name ?? "grpc-client";
-        var createRequest = new CreateItemRequest(request.Name, request.Description);
+        var userId = ActorSubjectResolver.Resolve(context.GetHttpContext().User)
+            ?? throw new RpcException(new Status(StatusCode.Unauthenticated,
+                "Authentication required: no subject id present on the caller's claims principal."));
+        var createRequest = new CreateItemRequest(request.Name, request.Description, request.Rationale);
         var item = await _itemService.CreateAsync(createRequest, userId, context.CancellationToken);
         return new ItemResponse { Item = ToMessage(item) };
     }
 
     public override async Task<ItemResponse> Update(UpdateItemGrpcRequest request, ServerCallContext context)
     {
-        var updateRequest = new CreateItemRequest(request.Name, request.Description);
-        var item = await _itemService.UpdateAsync(Guid.Parse(request.Id), updateRequest, context.CancellationToken);
+        var actor = RequireActor(context);
+        var updateRequest = new CreateItemRequest(request.Name, request.Description, request.Rationale);
+        var item = await _itemService.UpdateAsync(
+            Guid.Parse(request.Id), updateRequest, actor, context.CancellationToken);
         if (item is null)
             throw new RpcException(new Status(StatusCode.NotFound, $"Item {request.Id} not found"));
 
@@ -56,9 +61,15 @@ public class ItemsGrpcService : Protos.ItemsService.ItemsServiceBase
 
     public override async Task<DeleteItemResponse> Delete(DeleteItemRequest request, ServerCallContext context)
     {
-        var deleted = await _itemService.DeleteAsync(Guid.Parse(request.Id), context.CancellationToken);
+        var deleted = await _itemService.DeleteAsync(
+            Guid.Parse(request.Id), RequireActor(context), request.Rationale, context.CancellationToken);
         return new DeleteItemResponse { Success = deleted };
     }
+
+    private static string RequireActor(ServerCallContext context) =>
+        ActorSubjectResolver.Resolve(context.GetHttpContext().User)
+        ?? throw new RpcException(new Status(StatusCode.Unauthenticated,
+            "Authentication required: no subject id present on the caller's claims principal."));
 
     private static ItemMessage ToMessage(ItemDto dto) => new()
     {

--- a/src/Andy.Policies.Api/GrpcServices/LifecycleGrpcService.cs
+++ b/src/Andy.Policies.Api/GrpcServices/LifecycleGrpcService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using Andy.Policies.Api.Authorization;
 using Andy.Policies.Api.Protos;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Exceptions;
@@ -116,8 +117,7 @@ public class LifecycleGrpcService : Protos.LifecycleService.LifecycleServiceBase
         // act when no subject id is on the principal rather than write a fallback
         // string into the catalog. The MCP / gRPC paths share the same posture.
         var http = context.GetHttpContext();
-        var sub = http?.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
-            ?? http?.User.Identity?.Name;
+        var sub = ActorSubjectResolver.Resolve(http?.User);
         if (string.IsNullOrEmpty(sub))
         {
             throw new RpcException(new Status(StatusCode.Unauthenticated,

--- a/src/Andy.Policies.Api/GrpcServices/OverridesGrpcService.cs
+++ b/src/Andy.Policies.Api/GrpcServices/OverridesGrpcService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Security.Claims;
+using Andy.Policies.Api.Authorization;
 using Andy.Policies.Api.Protos;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Exceptions;
@@ -133,7 +134,11 @@ public class OverridesGrpcService : Andy.Policies.Api.Protos.OverridesService.Ov
 
         try
         {
-            var dto = await _service.ApproveAsync(id, subject, context.CancellationToken)
+            var dto = await _service.ApproveAsync(
+                    id,
+                    subject,
+                    string.IsNullOrWhiteSpace(request.Rationale) ? null : request.Rationale,
+                    context.CancellationToken)
                 .ConfigureAwait(false);
             return ToMessage(dto);
         }
@@ -232,7 +237,7 @@ public class OverridesGrpcService : Andy.Policies.Api.Protos.OverridesService.Ov
     private string ResolveSubjectOrThrow()
     {
         var user = _http.HttpContext?.User;
-        var subject = user?.FindFirstValue(ClaimTypes.NameIdentifier) ?? user?.Identity?.Name;
+        var subject = ActorSubjectResolver.Resolve(user);
         if (string.IsNullOrEmpty(subject))
         {
             throw new RpcException(new Status(StatusCode.Unauthenticated,
@@ -339,4 +344,3 @@ public class OverridesGrpcService : Andy.Policies.Api.Protos.OverridesService.Ov
             $"Unmapped exception in OverridesGrpcService: {ex.GetType().Name}", ex),
     };
 }
-

--- a/src/Andy.Policies.Api/GrpcServices/PolicyGrpcService.cs
+++ b/src/Andy.Policies.Api/GrpcServices/PolicyGrpcService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using Andy.Policies.Api.Authorization;
 using Andy.Policies.Api.Protos;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Exceptions;
@@ -124,7 +125,8 @@ public class PolicyGrpcService : Protos.PolicyService.PolicyServiceBase
                     Enforcement: request.Enforcement,
                     Severity: request.Severity,
                     Scopes: request.Scopes.ToList(),
-                    RulesJson: request.RulesJson),
+                    RulesJson: request.RulesJson,
+                    Rationale: NullIfEmpty(request.Rationale)),
                 ResolveSubjectId(context),
                 context.CancellationToken);
 
@@ -146,7 +148,8 @@ public class PolicyGrpcService : Protos.PolicyService.PolicyServiceBase
                     Enforcement: request.Enforcement,
                     Severity: request.Severity,
                     Scopes: request.Scopes.ToList(),
-                    RulesJson: request.RulesJson),
+                    RulesJson: request.RulesJson,
+                    Rationale: NullIfEmpty(request.Rationale)),
                 ResolveSubjectId(context),
                 context.CancellationToken);
 
@@ -162,7 +165,11 @@ public class PolicyGrpcService : Protos.PolicyService.PolicyServiceBase
         try
         {
             var dto = await _policies.BumpDraftFromVersionAsync(
-                policyId, sourceVersionId, ResolveSubjectId(context), context.CancellationToken);
+                policyId,
+                sourceVersionId,
+                ResolveSubjectId(context),
+                NullIfEmpty(request.Rationale),
+                context.CancellationToken);
 
             return new PolicyVersionResponse { Version = ToMessage(dto) };
         }
@@ -186,10 +193,11 @@ public class PolicyGrpcService : Protos.PolicyService.PolicyServiceBase
 
     private static string ResolveSubjectId(ServerCallContext context)
     {
-        // Mirrors PoliciesController + ItemsGrpcService: prefer the
-        // authenticated principal name, fall back to a labeled placeholder.
         var http = context.GetHttpContext();
-        return http?.User.Identity?.Name ?? "grpc-anonymous";
+        return ActorSubjectResolver.Resolve(http?.User)
+            ?? throw new RpcException(new Status(
+                StatusCode.Unauthenticated,
+                "Authentication required: no subject id present on the caller's claims principal."));
     }
 
     private static RpcException MapToRpcException(Exception ex) => ex switch

--- a/src/Andy.Policies.Api/GrpcServices/ScopesGrpcService.cs
+++ b/src/Andy.Policies.Api/GrpcServices/ScopesGrpcService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using Andy.Policies.Api.Authorization;
 using Andy.Policies.Api.Protos;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Exceptions;
@@ -90,7 +91,13 @@ public class ScopesGrpcService : Andy.Policies.Api.Protos.ScopesService.ScopesSe
         try
         {
             var dto = await _scopes.CreateAsync(
-                new CreateScopeNodeRequest(parentId, scopeType, request.TargetRef, request.DisplayName),
+                new CreateScopeNodeRequest(
+                    parentId,
+                    scopeType,
+                    request.TargetRef,
+                    request.DisplayName,
+                    string.IsNullOrWhiteSpace(request.Rationale) ? null : request.Rationale),
+                RequireSubject(context),
                 context.CancellationToken).ConfigureAwait(false);
             return new ScopeNodeResponse { Node = ToMessage(dto) };
         }
@@ -103,7 +110,11 @@ public class ScopesGrpcService : Andy.Policies.Api.Protos.ScopesService.ScopesSe
         var id = ParseGuidOrThrow(request.Id, "id");
         try
         {
-            await _scopes.DeleteAsync(id, context.CancellationToken).ConfigureAwait(false);
+            await _scopes.DeleteAsync(
+                id,
+                RequireSubject(context),
+                string.IsNullOrWhiteSpace(request.Rationale) ? null : request.Rationale,
+                context.CancellationToken).ConfigureAwait(false);
             return new DeleteScopeResponse();
         }
         catch (Exception ex) { throw MapToRpcException(ex); }
@@ -115,7 +126,13 @@ public class ScopesGrpcService : Andy.Policies.Api.Protos.ScopesService.ScopesSe
         var id = ParseGuidOrThrow(request.Id, "id");
         try
         {
-            var result = await _resolver.ResolveForScopeAsync(id, context.CancellationToken)
+            var principal = string.IsNullOrWhiteSpace(request.PrincipalSubjectId)
+                ? RequireSubject(context)
+                : request.PrincipalSubjectId.Trim();
+            var result = await _resolver.ResolveForScopeAsync(
+                id,
+                new OverrideResolutionContext(principal, request.CohortRefs.ToList()),
+                context.CancellationToken)
                 .ConfigureAwait(false);
             var response = new EffectivePolicySetResponse
             {
@@ -128,6 +145,12 @@ public class ScopesGrpcService : Andy.Policies.Api.Protos.ScopesService.ScopesSe
     }
 
     // -- helpers --------------------------------------------------------------
+
+    private static string RequireSubject(ServerCallContext context) =>
+        ActorSubjectResolver.Resolve(context.GetHttpContext().User)
+        ?? throw new RpcException(new Status(
+            StatusCode.Unauthenticated,
+            "Authentication required: no subject id present on the caller's claims principal."));
 
     private static Guid ParseGuidOrThrow(string raw, string field)
     {

--- a/src/Andy.Policies.Api/Mcp/AuditTools.cs
+++ b/src/Andy.Policies.Api/Mcp/AuditTools.cs
@@ -34,12 +34,8 @@ namespace Andy.Policies.Api.Mcp;
 /// <c>andy-policies-cli audit verify --file</c> (P6.5).
 /// </para>
 /// <para>
-/// <b>RBAC posture.</b> Per-tool RBAC (<c>audit:verify</c>,
-/// <c>audit:export</c>) is enforced via <see cref="McpRbacGuard"/>
-/// since P7.6 (#64), mirroring the gRPC interceptor on
-/// <c>AuditService</c>. Reads (<c>list</c>, <c>get</c>) remain
-/// gated only by JWT auth at the MCP edge; the gRPC
-/// surface is the canonical enforcement point for read-side.
+/// <b>RBAC posture.</b> Every tool enforces its operation-specific
+/// permission through <see cref="McpRbacGuard"/>, matching REST and gRPC.
 /// </para>
 /// </remarks>
 [McpServerToolType]
@@ -57,10 +53,13 @@ public static class AuditTools
         "pageSize (1..500, default 50). Returns a JSON object with items, " +
         "nextCursor, and pageSize fields. fieldDiff is a parsed JSON Patch " +
         "array; hashes travel as lowercase hex.")]
+    [RbacGuard("andy-policies:audit:read")]
     public static async Task<string> List(
         IAuditQuery query,
         IAuditRetentionPolicy retention,
         TimeProvider clock,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Filter by actor subject id (exact match)")] string? actor = null,
         [Description("Filter by entity type, e.g. Policy, Override")] string? entityType = null,
         [Description("Filter by entity id (exact match)")] string? entityId = null,
@@ -71,6 +70,10 @@ public static class AuditTools
         [Description("Rows per page; clamped 1..500")] int pageSize = 50,
         CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:audit:read", "policy.audit", null, ct);
+        if (denial is not null) return denial;
+
         if (pageSize < 1 || pageSize > 500)
         {
             return $"policy.audit.invalid_argument: pageSize must be in [1, 500]; got {pageSize}.";
@@ -121,11 +124,18 @@ public static class AuditTools
     [McpServerTool(Name = "policy.audit.get"), Description(
         "Get a single audit event by id. Returns " +
         "policy.audit.not_found when no row matches.")]
+    [RbacGuard("andy-policies:audit:read")]
     public static async Task<string> Get(
         IAuditQuery query,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Audit event id (GUID)")] string id,
         CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:audit:read", "policy.audit", null, ct);
+        if (denial is not null) return denial;
+
         if (!Guid.TryParse(id, out var oid))
         {
             return $"policy.audit.invalid_argument: '{id}' is not a valid GUID.";

--- a/src/Andy.Policies.Api/Mcp/Authorization/McpRbacGuard.cs
+++ b/src/Andy.Policies.Api/Mcp/Authorization/McpRbacGuard.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Security.Claims;
+using Andy.Policies.Api.Authorization;
 using Andy.Policies.Application.Interfaces;
 using Microsoft.AspNetCore.Http;
 
@@ -19,6 +20,28 @@ namespace Andy.Policies.Api.Mcp.Authorization;
 /// </summary>
 public static class McpRbacGuard
 {
+    /// <summary>Convenience wrapper for text-returning tools. Returns
+    /// null on allow or a stable prefixed denial string on deny.</summary>
+    public static async Task<string?> GetDenialAsync(
+        IRbacChecker rbac,
+        IHttpContextAccessor httpContext,
+        string permissionCode,
+        string errorPrefix,
+        string? resourceInstanceId,
+        CancellationToken ct)
+    {
+        try
+        {
+            await EnsureAsync(rbac, httpContext, permissionCode, resourceInstanceId, ct)
+                .ConfigureAwait(false);
+            return null;
+        }
+        catch (McpAuthorizationException ex)
+        {
+            return $"{errorPrefix}.forbidden: {ex.Reason}";
+        }
+    }
+
     /// <summary>
     /// Throws <see cref="McpAuthorizationException"/> when the call
     /// must be denied. Returns silently on allow.
@@ -35,9 +58,7 @@ public static class McpRbacGuard
                 permissionCode, "no-http-context",
                 "MCP tool ran without an HTTP context — cannot extract caller identity.");
 
-        var subjectId = ctx.User.FindFirstValue(ClaimTypes.NameIdentifier)
-                     ?? ctx.User.FindFirstValue("sub")
-                     ?? ctx.User.Identity?.Name;
+        var subjectId = ActorSubjectResolver.Resolve(ctx.User);
         if (string.IsNullOrWhiteSpace(subjectId))
         {
             throw new McpAuthorizationException(
@@ -46,8 +67,23 @@ public static class McpRbacGuard
         }
 
         var groups = ctx.User.FindAll("groups").Select(c => c.Value).ToList();
-        var decision = await rbac.CheckAsync(
-            subjectId, permissionCode, groups, resourceInstanceId, ct).ConfigureAwait(false);
+        RbacDecision decision;
+        try
+        {
+            decision = await rbac.CheckAsync(
+                subjectId, permissionCode, groups, resourceInstanceId, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new McpAuthorizationException(
+                permissionCode,
+                "rbac-unavailable",
+                $"RBAC dependency failed closed: {ex.GetType().Name}.");
+        }
         if (!decision.Allowed)
         {
             throw new McpAuthorizationException(

--- a/src/Andy.Policies.Api/Mcp/BindingTools.cs
+++ b/src/Andy.Policies.Api/Mcp/BindingTools.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Security.Claims;
+using Andy.Policies.Api.Authorization;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -51,12 +52,18 @@ public static class BindingTools
         "List bindings attached to a specific policy version. Each line shows " +
         "id, target type/ref, bind strength, created-by, and (when included) " +
         "the deletion tombstone.")]
+    [RbacGuard("andy-policies:binding:read")]
     public static async Task<string> List(
         IBindingService service,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Policy version id (GUID)")] string policyVersionId,
         [Description("Include soft-deleted (tombstoned) bindings")] bool includeDeleted = false,
         CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:binding:read", "policy.binding", policyVersionId, ct);
+        if (denial is not null) return denial;
         if (!Guid.TryParse(policyVersionId, out var vid))
         {
             return $"Invalid policy version id: '{policyVersionId}' is not a valid GUID.";
@@ -80,6 +87,7 @@ public static class BindingTools
         [Description("One of: Template, Repo, ScopeNode, Tenant, Org")] string targetType,
         [Description("Target reference (e.g. 'template:abc', 'repo:org/name')")] string targetRef,
         [Description("Mandatory or Recommended (default Recommended)")] string bindStrength = "Recommended",
+        [Description("Human-readable reason recorded in the audit chain")] string? rationale = null,
         CancellationToken ct = default)
     {
         if (!Guid.TryParse(policyVersionId, out var vid))
@@ -114,7 +122,7 @@ public static class BindingTools
         try
         {
             var dto = await service.CreateAsync(
-                new CreateBindingRequest(vid, tt, targetRef, bs), actor, ct);
+                new CreateBindingRequest(vid, tt, targetRef, bs, rationale), actor, ct);
             return FormatBindingDetail(dto);
         }
         catch (BindingRetiredVersionException ex)
@@ -184,12 +192,18 @@ public static class BindingTools
         "bind strength). Retired versions are filtered; same-target/same-" +
         "version duplicates dedup with Mandatory > Recommended. Exact-match " +
         "only — no hierarchy walk; that's P4.")]
+    [RbacGuard("andy-policies:binding:read")]
     public static async Task<string> Resolve(
         IBindingResolver resolver,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("One of: Template, Repo, ScopeNode, Tenant, Org")] string targetType,
         [Description("Target reference (e.g. 'template:abc')")] string targetRef,
         CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:binding:read", "policy.binding", targetRef, ct);
+        if (denial is not null) return denial;
         if (!Enum.TryParse<BindingTargetType>(targetType, ignoreCase: true, out var tt))
         {
             return $"policy.binding.invalid_target: targetType '{targetType}' is not valid. Use Template, Repo, ScopeNode, Tenant, or Org.";
@@ -209,8 +223,7 @@ public static class BindingTools
     {
         var user = accessor.HttpContext?.User;
         if (user is null) return null;
-        var sub = user.FindFirstValue(ClaimTypes.NameIdentifier) ?? user.Identity?.Name;
-        return string.IsNullOrEmpty(sub) ? null : sub;
+        return ActorSubjectResolver.Resolve(user);
     }
 
     private static string FormatBindingList(IReadOnlyList<BindingDto> rows, string header)

--- a/src/Andy.Policies.Api/Mcp/BundleTools.cs
+++ b/src/Andy.Policies.Api/Mcp/BundleTools.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Security.Claims;
+using Andy.Policies.Api.Authorization;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -114,13 +115,19 @@ public static class BundleTools
         "List bundles. Active bundles by default; pass " +
         "includeDeleted=true to include soft-deleted rows. take is " +
         "clamped to [1, 200]. Returns a JSON array of BundleDto.")]
+    [RbacGuard("andy-policies:bundle:read")]
     public static async Task<string> List(
         IBundleService service,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Include soft-deleted bundles in the result (default false).")] bool includeDeleted = false,
         [Description("Pagination skip (default 0)")] int skip = 0,
         [Description("Pagination take; clamped to [1, 200] (default 50)")] int take = 50,
         CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:bundle:read", "policy.bundle", null, ct);
+        if (denial is not null) return denial;
         var clampedTake = Math.Clamp(take, 1, 200);
         var clampedSkip = Math.Max(0, skip);
         var rows = await service.ListAsync(
@@ -131,11 +138,17 @@ public static class BundleTools
     [McpServerTool(Name = "policy.bundle.get"), Description(
         "Get a bundle by id. Returns the JSON DTO or " +
         "policy.bundle.not_found when the bundle does not exist.")]
+    [RbacGuard("andy-policies:bundle:read")]
     public static async Task<string> Get(
         IBundleService service,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Bundle id (GUID)")] string bundleId,
         CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:bundle:read", "policy.bundle", bundleId, ct);
+        if (denial is not null) return denial;
         if (!Guid.TryParse(bundleId, out var bid))
         {
             return $"policy.bundle.invalid_argument: '{bundleId}' is not a valid GUID.";
@@ -151,13 +164,19 @@ public static class BundleTools
         "bundle snapshot. targetType is one of Template, Repo, " +
         "ScopeNode, Tenant, Org. Returns BundleResolveResult JSON; " +
         "soft-deleted bundle returns policy.bundle.not_found.")]
+    [RbacGuard("andy-policies:bundle:read")]
     public static async Task<string> Resolve(
         IBundleResolver resolver,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Bundle id (GUID)")] string bundleId,
         [Description("One of Template, Repo, ScopeNode, Tenant, Org")] string targetType,
         [Description("Target reference, e.g. 'repo:rivoli-ai/conductor'")] string targetRef,
         CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:bundle:read", "policy.bundle", bundleId, ct);
+        if (denial is not null) return denial;
         if (!Guid.TryParse(bundleId, out var bid))
         {
             return $"policy.bundle.invalid_argument: '{bundleId}' is not a valid GUID.";
@@ -241,7 +260,6 @@ public static class BundleTools
     {
         var user = accessor.HttpContext?.User;
         if (user is null) return null;
-        var sub = user.FindFirstValue(ClaimTypes.NameIdentifier) ?? user.Identity?.Name;
-        return string.IsNullOrEmpty(sub) ? null : sub;
+        return ActorSubjectResolver.Resolve(user);
     }
 }

--- a/src/Andy.Policies.Api/Mcp/OverrideTools.cs
+++ b/src/Andy.Policies.Api/Mcp/OverrideTools.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Security.Claims;
+using Andy.Policies.Api.Authorization;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -159,6 +160,7 @@ public static class OverrideTools
         IHttpContextAccessor httpContext,
         IRbacChecker rbac,
         [Description("Override id (GUID)")] string id,
+        [Description("Human-readable approval reason recorded in the audit chain")] string? rationale = null,
         CancellationToken ct = default)
     {
         if (!gate.IsEnabled)
@@ -188,7 +190,7 @@ public static class OverrideTools
 
         try
         {
-            var dto = await service.ApproveAsync(oid, actor, ct);
+            var dto = await service.ApproveAsync(oid, actor, rationale, ct);
             return JsonSerializer.Serialize(dto, DtoJsonOptions);
         }
         catch (SelfApprovalException ex)
@@ -276,14 +278,20 @@ public static class OverrideTools
         "Revoked|Expired), scopeKind (Principal|Cohort), scopeRef (exact " +
         "match), policyVersionId (GUID). Returns a JSON array of " +
         "OverrideDto records.")]
+    [RbacGuard("andy-policies:override:read")]
     public static async Task<string> List(
         IOverrideService service,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Proposed | Approved | Revoked | Expired (case-insensitive)")] string? state = null,
         [Description("Principal | Cohort (case-insensitive)")] string? scopeKind = null,
         [Description("Exact-match scope ref")] string? scopeRef = null,
         [Description("Optional policy version id filter (GUID)")] string? policyVersionId = null,
         CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:override:read", "policy.override", scopeRef, ct);
+        if (denial is not null) return denial;
         OverrideState? stateFilter = null;
         if (!string.IsNullOrEmpty(state))
         {
@@ -321,11 +329,17 @@ public static class OverrideTools
         "Get a single override by id. Returns policy.override.not_found " +
         "if the row does not exist; visibility is not state-gated " +
         "(Expired/Revoked rows are still readable for audit).")]
+    [RbacGuard("andy-policies:override:read")]
     public static async Task<string> Get(
         IOverrideService service,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Override id (GUID)")] string id,
         CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:override:read", "policy.override", id, ct);
+        if (denial is not null) return denial;
         if (!Guid.TryParse(id, out var oid))
         {
             return $"policy.override.invalid_argument: '{id}' is not a valid GUID.";
@@ -341,12 +355,18 @@ public static class OverrideTools
         "where State == Approved AND ExpiresAt > now. Used by Conductor " +
         "during admission and by P4.3 chain resolution. Bypasses the " +
         "experimental-overrides settings gate.")]
+    [RbacGuard("andy-policies:override:read")]
     public static async Task<string> Active(
         IOverrideService service,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Principal | Cohort")] string scopeKind,
         [Description("Exact-match scope ref")] string scopeRef,
         CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:override:read", "policy.override", scopeRef, ct);
+        if (denial is not null) return denial;
         if (!Enum.TryParse<OverrideScopeKind>(scopeKind, ignoreCase: true, out var sk))
         {
             return $"policy.override.invalid_argument: scopeKind '{scopeKind}' must be Principal or Cohort.";
@@ -363,7 +383,6 @@ public static class OverrideTools
     {
         var user = accessor.HttpContext?.User;
         if (user is null) return null;
-        var sub = user.FindFirstValue(ClaimTypes.NameIdentifier) ?? user.Identity?.Name;
-        return string.IsNullOrEmpty(sub) ? null : sub;
+        return ActorSubjectResolver.Resolve(user);
     }
 }

--- a/src/Andy.Policies.Api/Mcp/PolicyLifecycleTools.cs
+++ b/src/Andy.Policies.Api/Mcp/PolicyLifecycleTools.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Security.Claims;
+using Andy.Policies.Api.Authorization;
 using System.Text;
 using Andy.Policies.Api.Mcp.Authorization;
 using Andy.Policies.Application.Dtos;
@@ -82,8 +83,16 @@ public static class PolicyLifecycleTools
     [McpServerTool(Name = "policy.lifecycle.matrix"), Description(
         "Returns the canonical lifecycle transition matrix as one rule per line. " +
         "Read-only and side-effect free; safe to call from agent planning loops.")]
-    public static string Matrix(ILifecycleTransitionService transitions)
+    [RbacGuard("andy-policies:policy:read")]
+    public static async Task<string> Matrix(
+        ILifecycleTransitionService transitions,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
+        CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:policy:read", "policy.lifecycle", null, ct);
+        if (denial is not null) return denial;
         var rules = transitions.GetMatrix();
         var sb = new StringBuilder();
         sb.AppendLine($"{rules.Count} allowed transition{(rules.Count == 1 ? "" : "s")}:");
@@ -171,8 +180,7 @@ public static class PolicyLifecycleTools
     {
         var user = accessor.HttpContext?.User;
         if (user is null) return null;
-        var sub = user.FindFirstValue(ClaimTypes.NameIdentifier) ?? user.Identity?.Name;
-        return string.IsNullOrEmpty(sub) ? null : sub;
+        return ActorSubjectResolver.Resolve(user);
     }
 
     private static string FormatVersionDetail(PolicyVersionDto v)

--- a/src/Andy.Policies.Api/Mcp/PolicyTools.cs
+++ b/src/Andy.Policies.Api/Mcp/PolicyTools.cs
@@ -3,9 +3,11 @@
 
 using System.ComponentModel;
 using System.Text;
+using Andy.Policies.Api.Mcp.Authorization;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Application.Queries;
+using Microsoft.AspNetCore.Http;
 using ModelContextProtocol.Server;
 
 namespace Andy.Policies.Api.Mcp;
@@ -24,20 +26,27 @@ public static class PolicyTools
 {
     [McpServerTool(Name = "policy.list"), Description(
         "List policies with optional filters. Filters apply against the active version " +
-        "of each policy (highest non-Draft); policies with no active version are excluded " +
+        "of each policy (LifecycleState.Active only); policies with no active version are excluded " +
         "from filtered results but appear in unfiltered ones. Returns a summary line per " +
         "policy with name, version count, and active version id.")]
+    [RbacGuard("andy-policies:policy:read")]
     public static async Task<string> ListPolicies(
         IPolicyService policies,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Optional case-sensitive prefix on Policy.Name (e.g. 'risk-')")] string? namePrefix = null,
         [Description("Optional exact-match scope membership filter (e.g. 'prod')")] string? scope = null,
         [Description("Optional enforcement filter — MAY / SHOULD / MUST (case-insensitive)")] string? enforcement = null,
         [Description("Optional severity filter — info / moderate / critical (case-insensitive)")] string? severity = null,
         [Description("Pagination offset (default 0)")] int skip = 0,
-        [Description("Page size (default 100, capped at 500)")] int take = 100)
+        [Description("Page size (default 100, capped at 500)")] int take = 100,
+        CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:policy:read", "policy", null, ct);
+        if (denial is not null) return denial;
         var query = new ListPoliciesQuery(namePrefix, scope, enforcement, severity, skip, take);
-        var results = await policies.ListPoliciesAsync(query);
+        var results = await policies.ListPoliciesAsync(query, ct);
 
         if (results.Count == 0)
         {
@@ -57,16 +66,23 @@ public static class PolicyTools
         "Get a single policy by id. Returns the stable identity (name, description) plus " +
         "version-history summary (count + active version id, if any). Use " +
         "policy.version.list to enumerate the versions themselves.")]
+    [RbacGuard("andy-policies:policy:read")]
     public static async Task<string> GetPolicy(
         IPolicyService policies,
-        [Description("Policy id (GUID)")] string policyId)
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
+        [Description("Policy id (GUID)")] string policyId,
+        CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:policy:read", "policy", policyId, ct);
+        if (denial is not null) return denial;
         if (!Guid.TryParse(policyId, out var id))
         {
             return $"Invalid policy id: '{policyId}' is not a valid GUID.";
         }
 
-        var policy = await policies.GetPolicyAsync(id);
+        var policy = await policies.GetPolicyAsync(id, ct);
         if (policy is null)
         {
             return $"Policy {id} not found.";
@@ -78,16 +94,23 @@ public static class PolicyTools
     [McpServerTool(Name = "policy.version.list"), Description(
         "List all versions of a policy in descending version order (newest first). Each " +
         "line shows version number, lifecycle state, enforcement, severity, and proposer.")]
+    [RbacGuard("andy-policies:policy:read")]
     public static async Task<string> ListVersions(
         IPolicyService policies,
-        [Description("Policy id (GUID)")] string policyId)
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
+        [Description("Policy id (GUID)")] string policyId,
+        CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:policy:read", "policy", policyId, ct);
+        if (denial is not null) return denial;
         if (!Guid.TryParse(policyId, out var id))
         {
             return $"Invalid policy id: '{policyId}' is not a valid GUID.";
         }
 
-        var versions = await policies.ListVersionsAsync(id);
+        var versions = await policies.ListVersionsAsync(id, ct);
         if (versions.Count == 0)
         {
             return $"No versions found for policy {id}. Either the policy does not exist or has no versions yet.";
@@ -105,11 +128,18 @@ public static class PolicyTools
     [McpServerTool(Name = "policy.version.get"), Description(
         "Get a specific version of a policy. Returns full content: enforcement, severity, " +
         "scopes, summary, and the rules JSON blob.")]
+    [RbacGuard("andy-policies:policy:read")]
     public static async Task<string> GetVersion(
         IPolicyService policies,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Policy id (GUID)")] string policyId,
-        [Description("Version id (GUID) — use policy.version.list to discover")] string versionId)
+        [Description("Version id (GUID) — use policy.version.list to discover")] string versionId,
+        CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:policy:read", "policy", policyId, ct);
+        if (denial is not null) return denial;
         if (!Guid.TryParse(policyId, out var pid))
         {
             return $"Invalid policy id: '{policyId}' is not a valid GUID.";
@@ -119,7 +149,7 @@ public static class PolicyTools
             return $"Invalid version id: '{versionId}' is not a valid GUID.";
         }
 
-        var version = await policies.GetVersionAsync(pid, vid);
+        var version = await policies.GetVersionAsync(pid, vid, ct);
         if (version is null)
         {
             return $"Version {vid} not found under policy {pid}.";
@@ -129,21 +159,28 @@ public static class PolicyTools
     }
 
     [McpServerTool(Name = "policy.version.get-active"), Description(
-        "Get the active version of a policy. Active = highest version with State != Draft " +
-        "(ADR 0001 §4); returns 'no active version' while every version is still a Draft.")]
+        "Get the active version of a policy. Active means LifecycleState.Active only " +
+        "(ADR 0001/P2); returns 'no active version' when no version is Active.")]
+    [RbacGuard("andy-policies:policy:read")]
     public static async Task<string> GetActiveVersion(
         IPolicyService policies,
-        [Description("Policy id (GUID)")] string policyId)
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
+        [Description("Policy id (GUID)")] string policyId,
+        CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:policy:read", "policy", policyId, ct);
+        if (denial is not null) return denial;
         if (!Guid.TryParse(policyId, out var id))
         {
             return $"Invalid policy id: '{policyId}' is not a valid GUID.";
         }
 
-        var version = await policies.GetActiveVersionAsync(id);
+        var version = await policies.GetActiveVersionAsync(id, ct);
         if (version is null)
         {
-            return $"Policy {id} has no active version (every version is still in Draft, or the policy does not exist).";
+            return $"Policy {id} has no active version, or the policy does not exist.";
         }
 
         return FormatVersionDetail(version);

--- a/src/Andy.Policies.Api/Mcp/ScopeTools.cs
+++ b/src/Andy.Policies.Api/Mcp/ScopeTools.cs
@@ -42,11 +42,17 @@ public static class ScopeTools
         "type is one of Org / Tenant / Team / Repo / Template / Run " +
         "(case-insensitive); omit to return the entire catalogue. " +
         "Returns one line per node with id, type, ref, and depth.")]
+    [RbacGuard("andy-policies:scope:read")]
     public static async Task<string> List(
         IScopeService service,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Optional type filter (Org/Tenant/Team/Repo/Template/Run). Omit for all.")] string? type = null,
         CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:scope:read", "policy.scope", null, ct);
+        if (denial is not null) return denial;
         ScopeType? filter = null;
         if (!string.IsNullOrEmpty(type))
         {
@@ -74,11 +80,17 @@ public static class ScopeTools
     [McpServerTool(Name = "policy.scope.get"), Description(
         "Get a single scope node by id. Returns formatted detail or " +
         "policy.scope.not_found.")]
+    [RbacGuard("andy-policies:scope:read")]
     public static async Task<string> Get(
         IScopeService service,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Scope node id (GUID).")] string id,
         CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:scope:read", "policy.scope", id, ct);
+        if (denial is not null) return denial;
         if (!Guid.TryParse(id, out var nodeId))
         {
             return $"policy.scope.invalid_input: '{id}' is not a valid GUID.";
@@ -92,10 +104,16 @@ public static class ScopeTools
     [McpServerTool(Name = "policy.scope.tree"), Description(
         "Return the full scope forest as JSON. Each entry has " +
         "{ node, children[] } and is ordered by Ref ASC at every level.")]
+    [RbacGuard("andy-policies:scope:read")]
     public static async Task<string> Tree(
         IScopeService service,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:scope:read", "policy.scope", null, ct);
+        if (denial is not null) return denial;
         var forest = await service.GetTreeAsync(ct);
         return JsonSerializer.Serialize(forest, JsonOptions);
     }
@@ -115,6 +133,7 @@ public static class ScopeTools
         [Description("Scope type (Org/Tenant/Team/Repo/Template/Run).")] string type,
         [Description("Opaque scope reference (e.g. 'repo:rivoli-ai/conductor').")] string @ref,
         [Description("Human-readable display name.")] string displayName,
+        [Description("Human-readable reason recorded in the audit chain.")] string? rationale = null,
         CancellationToken ct = default)
     {
         if (!Enum.TryParse<ScopeType>(type, ignoreCase: true, out var scopeType))
@@ -146,7 +165,9 @@ public static class ScopeTools
         try
         {
             var dto = await service.CreateAsync(
-                new CreateScopeNodeRequest(parentGuid, scopeType, @ref, displayName), ct);
+                new CreateScopeNodeRequest(parentGuid, scopeType, @ref, displayName, rationale),
+                Andy.Policies.Api.Authorization.ActorSubjectResolver.Require(httpContext.HttpContext?.User),
+                ct);
             return FormatNodeDetail(dto);
         }
         catch (InvalidScopeTypeException ex)
@@ -176,6 +197,7 @@ public static class ScopeTools
         IHttpContextAccessor httpContext,
         IRbacChecker rbac,
         [Description("Scope node id (GUID).")] string id,
+        [Description("Human-readable reason recorded in the audit chain.")] string? rationale = null,
         CancellationToken ct = default)
     {
         if (!Guid.TryParse(id, out var nodeId))
@@ -193,7 +215,11 @@ public static class ScopeTools
         }
         try
         {
-            await service.DeleteAsync(nodeId, ct);
+            await service.DeleteAsync(
+                nodeId,
+                Andy.Policies.Api.Authorization.ActorSubjectResolver.Require(httpContext.HttpContext?.User),
+                rationale,
+                ct);
             return $"ScopeNode {nodeId} deleted.";
         }
         catch (NotFoundException ex)
@@ -211,18 +237,34 @@ public static class ScopeTools
         "stricter-tightens-only fold from P4.3. Returns JSON envelope " +
         "{ scopeNodeId, policies[] } ordered Mandatory-first then by " +
         "PolicyKey ASC. Returns policy.scope.not_found for unknown ids.")]
+    [RbacGuard("andy-policies:scope:read")]
     public static async Task<string> Effective(
         IBindingResolutionService resolver,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Scope node id (GUID).")] string id,
+        [Description("Principal subject id. Defaults to the authenticated caller.")] string? principalSubjectId = null,
+        [Description("Comma-separated cohort refs.")] string? cohorts = null,
         CancellationToken ct = default)
     {
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:scope:read", "policy.scope", id, ct);
+        if (denial is not null) return denial;
         if (!Guid.TryParse(id, out var nodeId))
         {
             return $"policy.scope.invalid_input: '{id}' is not a valid GUID.";
         }
         try
         {
-            var result = await resolver.ResolveForScopeAsync(nodeId, ct);
+            var principal = string.IsNullOrWhiteSpace(principalSubjectId)
+                ? Andy.Policies.Api.Authorization.ActorSubjectResolver.Resolve(httpContext.HttpContext?.User)
+                : principalSubjectId.Trim();
+            var cohortRefs = (cohorts ?? string.Empty)
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var result = await resolver.ResolveForScopeAsync(
+                nodeId,
+                new OverrideResolutionContext(principal, cohortRefs),
+                ct);
             return JsonSerializer.Serialize(result, JsonOptions);
         }
         catch (NotFoundException ex)

--- a/src/Andy.Policies.Api/Mcp/ServiceTools.cs
+++ b/src/Andy.Policies.Api/Mcp/ServiceTools.cs
@@ -1,8 +1,11 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using Andy.Policies.Api.Authorization;
+using Andy.Policies.Api.Mcp.Authorization;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
+using Microsoft.AspNetCore.Http;
 using ModelContextProtocol.Server;
 using System.ComponentModel;
 
@@ -12,9 +15,17 @@ namespace Andy.Policies.Api.Mcp;
 public static class ServiceTools
 {
     [McpServerTool, Description("List all items")]
-    public static async Task<string> ListItems(IItemService itemService)
+    [RbacGuard("andy-policies:policy:read")]
+    public static async Task<string> ListItems(
+        IItemService itemService,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
+        CancellationToken ct = default)
     {
-        var items = await itemService.GetAllAsync();
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:policy:read", "item", null, ct);
+        if (denial is not null) return denial;
+        var items = await itemService.GetAllAsync(ct);
         if (!items.Any())
             return "No items found.";
 
@@ -23,11 +34,18 @@ public static class ServiceTools
     }
 
     [McpServerTool, Description("Get details of a specific item by ID")]
+    [RbacGuard("andy-policies:policy:read")]
     public static async Task<string> GetItem(
         IItemService itemService,
-        [Description("The item ID (GUID)")] string itemId)
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
+        [Description("The item ID (GUID)")] string itemId,
+        CancellationToken ct = default)
     {
-        var item = await itemService.GetByIdAsync(Guid.Parse(itemId));
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:policy:read", "item", itemId, ct);
+        if (denial is not null) return denial;
+        var item = await itemService.GetByIdAsync(Guid.Parse(itemId), ct);
         if (item is null)
             return $"Item {itemId} not found.";
 
@@ -35,22 +53,40 @@ public static class ServiceTools
     }
 
     [McpServerTool, Description("Create a new item")]
+    [RbacGuard("andy-policies:policy:author")]
     public static async Task<string> CreateItem(
         IItemService itemService,
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
         [Description("Name of the item")] string name,
-        [Description("Optional description")] string? description = null)
+        [Description("Optional description")] string? description = null,
+        [Description("Reason recorded in the audit chain")] string? rationale = null,
+        CancellationToken ct = default)
     {
-        var request = new CreateItemRequest(name, description);
-        var item = await itemService.CreateAsync(request, "mcp-client");
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:policy:author", "item", null, ct);
+        if (denial is not null) return denial;
+        var request = new CreateItemRequest(name, description, rationale);
+        var actor = ActorSubjectResolver.Require(httpContext.HttpContext?.User);
+        var item = await itemService.CreateAsync(request, actor, ct);
         return $"Created item: {item.Name} ({item.Id})";
     }
 
     [McpServerTool, Description("Delete an item by ID")]
+    [RbacGuard("andy-policies:policy:author")]
     public static async Task<string> DeleteItem(
         IItemService itemService,
-        [Description("The item ID (GUID)")] string itemId)
+        IHttpContextAccessor httpContext,
+        IRbacChecker rbac,
+        [Description("The item ID (GUID)")] string itemId,
+        [Description("Reason recorded in the audit chain")] string? rationale = null,
+        CancellationToken ct = default)
     {
-        var deleted = await itemService.DeleteAsync(Guid.Parse(itemId));
+        var denial = await McpRbacGuard.GetDenialAsync(
+            rbac, httpContext, "andy-policies:policy:author", "item", itemId, ct);
+        if (denial is not null) return denial;
+        var actor = ActorSubjectResolver.Require(httpContext.HttpContext?.User);
+        var deleted = await itemService.DeleteAsync(Guid.Parse(itemId), actor, rationale, ct);
         return deleted ? $"Item {itemId} deleted." : $"Item {itemId} not found.";
     }
 }

--- a/src/Andy.Policies.Api/Program.cs
+++ b/src/Andy.Policies.Api/Program.cs
@@ -156,16 +156,14 @@ builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IBindingResoluti
 // Injected into BindingService so CreateAsync refuses Recommended
 // proposals that would shadow a Mandatory ancestor binding.
 builder.Services.AddScoped<Andy.Policies.Application.Interfaces.ITightenOnlyValidator, Andy.Policies.Infrastructure.Services.TightenOnlyValidator>();
-// P3.2 (#20): Binding mutations call IAuditWriter — Epic P6
-// (rivoli-ai/andy-policies#6) replaces the no-op with the real
-// hash-chained writer. Singleton because the P6 implementation will own a
-// content-addressed sequence pointer.
-builder.Services.AddSingleton<Andy.Policies.Application.Interfaces.IAuditWriter, Andy.Policies.Infrastructure.Services.NoopAuditWriter>();
 // P6.2 (#42): tamper-evident catalog audit chain. Scoped because
 // AuditChain depends on the scoped AppDbContext; downstream callers
 // invoke AppendAsync inside their own DbContext transaction so
 // state-change + audit-row commit atomically.
 builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IAuditChain, Andy.Policies.Infrastructure.Audit.AuditChain>();
+// #249: every mutation hook writes to the real chain using the same
+// scoped AppDbContext/transaction as the catalog state change.
+builder.Services.AddScoped<Andy.Policies.Application.Interfaces.IAuditWriter, Andy.Policies.Infrastructure.Services.AuditWriter>();
 // P6.6 (#46): cursor-paginated query over audit_events. Scoped
 // because AuditQuery depends on the scoped AppDbContext; the
 // service is read-only (no transactions, no advisory locks).

--- a/src/Andy.Policies.Api/Protos/bindings.proto
+++ b/src/Andy.Policies.Api/Protos/bindings.proto
@@ -108,6 +108,7 @@ message CreateBindingRequest {
   TargetType target_type = 2;
   string target_ref = 3;
   BindStrength bind_strength = 4;
+  string rationale = 5;
 }
 
 message DeleteBindingRequest {

--- a/src/Andy.Policies.Api/Protos/items.proto
+++ b/src/Andy.Policies.Api/Protos/items.proto
@@ -28,16 +28,19 @@ message GetItemByIdRequest {
 message CreateItemGrpcRequest {
   string name = 1;
   string description = 2;
+  string rationale = 3;
 }
 
 message UpdateItemGrpcRequest {
   string id = 1;
   string name = 2;
   string description = 3;
+  string rationale = 4;
 }
 
 message DeleteItemRequest {
   string id = 1;
+  string rationale = 2;
 }
 
 message DeleteItemResponse {

--- a/src/Andy.Policies.Api/Protos/overrides.proto
+++ b/src/Andy.Policies.Api/Protos/overrides.proto
@@ -114,6 +114,7 @@ message ProposeOverrideRequest {
 
 message ApproveOverrideRequest {
   string id = 1;
+  string rationale = 2;
 }
 
 message RevokeOverrideRequest {

--- a/src/Andy.Policies.Api/Protos/policies.proto
+++ b/src/Andy.Policies.Api/Protos/policies.proto
@@ -119,6 +119,7 @@ message CreateDraftRequest {
   string severity = 5;
   repeated string scopes = 6;
   string rules_json = 7;
+  string rationale = 8;
 }
 
 message UpdateDraftRequest {
@@ -129,9 +130,11 @@ message UpdateDraftRequest {
   string severity = 5;
   repeated string scopes = 6;
   string rules_json = 7;
+  string rationale = 8;
 }
 
 message BumpDraftRequest {
   string policy_id = 1;
   string source_version_id = 2;
+  string rationale = 3;
 }

--- a/src/Andy.Policies.Api/Protos/scopes.proto
+++ b/src/Andy.Policies.Api/Protos/scopes.proto
@@ -127,16 +127,20 @@ message CreateScopeRequest {
   ScopeType type = 2;
   string target_ref = 3;
   string display_name = 4;
+  string rationale = 5;
 }
 
 message DeleteScopeRequest {
   string id = 1;
+  string rationale = 2;
 }
 
 message DeleteScopeResponse {}
 
 message GetEffectivePoliciesRequest {
   string id = 1;
+  string principal_subject_id = 2;
+  repeated string cohort_refs = 3;
 }
 
 message EffectivePolicySetResponse {

--- a/src/Andy.Policies.Application/Dtos/ApproveOverrideRequest.cs
+++ b/src/Andy.Policies.Application/Dtos/ApproveOverrideRequest.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.Dtos;
+
+/// <summary>Audit rationale supplied by the override approver.</summary>
+public sealed record ApproveOverrideRequest(string? Rationale);

--- a/src/Andy.Policies.Application/Dtos/BumpPolicyVersionRequest.cs
+++ b/src/Andy.Policies.Application/Dtos/BumpPolicyVersionRequest.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.Dtos;
+
+/// <summary>Audit rationale for creating a new Draft from a source version.</summary>
+public sealed record BumpPolicyVersionRequest(string? Rationale);

--- a/src/Andy.Policies.Application/Dtos/CreateItemRequest.cs
+++ b/src/Andy.Policies.Application/Dtos/CreateItemRequest.cs
@@ -7,4 +7,5 @@ namespace Andy.Policies.Application.Dtos;
 
 public record CreateItemRequest(
     [Required] string Name,
-    string? Description);
+    string? Description,
+    string? Rationale = null);

--- a/src/Andy.Policies.Application/Dtos/CreateScopeNodeRequest.cs
+++ b/src/Andy.Policies.Application/Dtos/CreateScopeNodeRequest.cs
@@ -16,4 +16,5 @@ public sealed record CreateScopeNodeRequest(
     Guid? ParentId,
     ScopeType Type,
     string Ref,
-    string DisplayName);
+    string DisplayName,
+    string? Rationale = null);

--- a/src/Andy.Policies.Application/Dtos/DeleteScopeNodeRequest.cs
+++ b/src/Andy.Policies.Application/Dtos/DeleteScopeNodeRequest.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.Dtos;
+
+/// <summary>Audit rationale for deleting a leaf scope node.</summary>
+public sealed record DeleteScopeNodeRequest(string? Rationale);

--- a/src/Andy.Policies.Application/Dtos/EffectivePolicySetDto.cs
+++ b/src/Andy.Policies.Application/Dtos/EffectivePolicySetDto.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Rivoli AI 2026. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using Andy.Policies.Domain.Enums;
+
 namespace Andy.Policies.Application.Dtos;
 
 /// <summary>
@@ -12,4 +14,19 @@ namespace Andy.Policies.Application.Dtos;
 /// </summary>
 public sealed record EffectivePolicySetDto(
     Guid? ScopeNodeId,
-    IReadOnlyList<EffectivePolicyDto> Policies);
+    IReadOnlyList<EffectivePolicyDto> Policies)
+{
+    /// <summary>Deterministic explanation of every override that changed
+    /// the baseline set, including Exempt entries whose policy is absent
+    /// from <see cref="Policies"/>.</summary>
+    public IReadOnlyList<AppliedOverrideDto> AppliedOverrides { get; init; } =
+        Array.Empty<AppliedOverrideDto>();
+}
+
+public sealed record AppliedOverrideDto(
+    Guid OverrideId,
+    OverrideEffect Effect,
+    OverrideScopeKind ScopeKind,
+    string ScopeRef,
+    Guid OriginalPolicyVersionId,
+    Guid? ReplacementPolicyVersionId);

--- a/src/Andy.Policies.Application/Dtos/OverrideResolutionContext.cs
+++ b/src/Andy.Policies.Application/Dtos/OverrideResolutionContext.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+namespace Andy.Policies.Application.Dtos;
+
+/// <summary>
+/// Caller identity context used when applying principal/cohort overrides
+/// to an effective-policy result. A missing context deliberately means
+/// "resolve the baseline binding set without overrides".
+/// </summary>
+public sealed record OverrideResolutionContext(
+    string? PrincipalSubjectId,
+    IReadOnlyList<string> CohortRefs)
+{
+    public static OverrideResolutionContext ForPrincipal(string subjectId) =>
+        new(subjectId, Array.Empty<string>());
+}

--- a/src/Andy.Policies.Application/Dtos/UpdateScopeNodeRequest.cs
+++ b/src/Andy.Policies.Application/Dtos/UpdateScopeNodeRequest.cs
@@ -9,4 +9,6 @@ namespace Andy.Policies.Application.Dtos;
 /// hierarchy fields (<c>ParentId</c>, <c>Type</c>, <c>Ref</c>) are
 /// immutable per ADR 0004 (re-parenting is out of scope for Epic P4).
 /// </summary>
-public sealed record UpdateScopeNodeRequest(string DisplayName);
+public sealed record UpdateScopeNodeRequest(
+    string DisplayName,
+    string? Rationale = null);

--- a/src/Andy.Policies.Application/Interfaces/IAuditWriter.cs
+++ b/src/Andy.Policies.Application/Interfaces/IAuditWriter.cs
@@ -4,11 +4,9 @@
 namespace Andy.Policies.Application.Interfaces;
 
 /// <summary>
-/// Append-only audit writer hook (P3.2, story rivoli-ai/andy-policies#20).
-/// Per-mutation services call this to record an audit row; the real
-/// hash-chained implementation lands in Epic P6
-/// (rivoli-ai/andy-policies#6). A no-op implementation in Infrastructure
-/// keeps DI satisfied until then.
+/// Append-only mutation audit adapter. Production DI maps this interface
+/// to the tamper-evident <see cref="IAuditChain"/> implementation; callers
+/// append inside the same database transaction as the catalog mutation.
 /// </summary>
 public interface IAuditWriter
 {

--- a/src/Andy.Policies.Application/Interfaces/IBindingResolutionService.cs
+++ b/src/Andy.Policies.Application/Interfaces/IBindingResolutionService.cs
@@ -54,6 +54,17 @@ public interface IBindingResolutionService
         CancellationToken ct = default);
 
     /// <summary>
+    /// Resolve the effective set and apply active overrides matching the
+    /// supplied principal/cohort context. Principal overrides take
+    /// precedence over cohort overrides.
+    /// </summary>
+    Task<EffectivePolicySetDto> ResolveForScopeAsync(
+        Guid scopeNodeId,
+        OverrideResolutionContext overrideContext,
+        CancellationToken ct = default)
+        => ResolveForScopeAsync(scopeNodeId, ct);
+
+    /// <summary>
     /// Resolve the effective policy set for a foreign target. If
     /// <paramref name="targetType"/>/<paramref name="targetRef"/>
     /// maps to a known <see cref="Domain.Entities.ScopeNode"/>, the

--- a/src/Andy.Policies.Application/Interfaces/IBundleResolver.cs
+++ b/src/Andy.Policies.Application/Interfaces/IBundleResolver.cs
@@ -15,15 +15,9 @@ namespace Andy.Policies.Application.Interfaces;
 /// pre-materialised <c>SnapshotJson</c> instead of live tables, so
 /// answers are reproducible across catalog mutations.
 /// </summary>
-/// <remarks>
-/// <para>
-/// <b>Override application is intentionally out of scope</b> for
-/// P8.3. The live <see cref="IBindingResolver"/> doesn't apply
-/// override effects either — that lives in P5's flow. Bundle-time
-/// override semantics will be pinned by ADR 0008 (P8.8) and wired
-/// in a follow-up.
-/// </para>
-/// </remarks>
+/// <remarks>Effective-scope resolution supports the same scope-node and
+/// Org/Tenant/Repo/Template bridge targets as the live resolver. Its context
+/// overload applies the Approved, unexpired overrides frozen into the snapshot.</remarks>
 public interface IBundleResolver
 {
     /// <summary>
@@ -62,7 +56,7 @@ public interface IBundleResolver
 
     /// <summary>
     /// Snapshot-backed equivalent of
-    /// <see cref="IBindingResolutionService.ResolveForScopeAsync"/>
+    /// <see cref="IBindingResolutionService.ResolveForScopeAsync(Guid, CancellationToken)"/>
     /// (P8.4, #84). Walks the bundle's scope tree from the target
     /// node up to its root and folds matching bindings with
     /// stricter-tightens-only semantics. Returns <c>null</c> when
@@ -71,18 +65,21 @@ public interface IBundleResolver
     /// <c>Policies</c> when the bundle exists but the scope node
     /// is absent from it.
     /// </summary>
-    /// <remarks>
-    /// <b>Scope of dispatch.</b> This method matches only
-    /// <c>TargetType=ScopeNode</c> bindings keyed by
-    /// <c>scope:{nodeId}</c>. The bridge logic from
-    /// <c>BindingResolutionService</c> (which also matches
-    /// <c>Repo</c> / <c>Tenant</c> / <c>Org</c> / <c>Template</c>
-    /// targets against the chain's external refs) is deferred to
-    /// a follow-up; consumers using bridge-typed bindings should
-    /// keep <c>bundleVersionPinning=false</c> until then.
-    /// </remarks>
+    /// <remarks>Matches explicit <c>ScopeNode</c> bindings plus
+    /// <c>Org</c>, <c>Tenant</c>, <c>Repo</c>, and <c>Template</c>
+    /// bridge bindings against external refs on the frozen chain.</remarks>
     Task<EffectivePolicySetDto?> ResolveEffectiveForScopeAsync(
         Guid bundleId, Guid scopeNodeId, CancellationToken ct = default);
+
+    /// <summary>Resolve a pinned effective set and apply only the active
+    /// overrides captured in that bundle snapshot which match the supplied
+    /// principal/cohort context.</summary>
+    Task<EffectivePolicySetDto?> ResolveEffectiveForScopeAsync(
+        Guid bundleId,
+        Guid scopeNodeId,
+        OverrideResolutionContext overrideContext,
+        CancellationToken ct = default)
+        => ResolveEffectiveForScopeAsync(bundleId, scopeNodeId, ct);
 
     /// <summary>
     /// P9 follow-up #204 (2026-05-07): denormalised contents tree for the

--- a/src/Andy.Policies.Application/Interfaces/IItemService.cs
+++ b/src/Andy.Policies.Application/Interfaces/IItemService.cs
@@ -10,6 +10,6 @@ public interface IItemService
     Task<IEnumerable<ItemDto>> GetAllAsync(CancellationToken ct = default);
     Task<ItemDto?> GetByIdAsync(Guid id, CancellationToken ct = default);
     Task<ItemDto> CreateAsync(CreateItemRequest request, string userId, CancellationToken ct = default);
-    Task<ItemDto?> UpdateAsync(Guid id, CreateItemRequest request, CancellationToken ct = default);
-    Task<bool> DeleteAsync(Guid id, CancellationToken ct = default);
+    Task<ItemDto?> UpdateAsync(Guid id, CreateItemRequest request, string actorSubjectId, CancellationToken ct = default);
+    Task<bool> DeleteAsync(Guid id, string actorSubjectId, string? rationale, CancellationToken ct = default);
 }

--- a/src/Andy.Policies.Application/Interfaces/IOverrideService.cs
+++ b/src/Andy.Policies.Application/Interfaces/IOverrideService.cs
@@ -42,6 +42,7 @@ public interface IOverrideService
     Task<OverrideDto> ApproveAsync(
         Guid id,
         string approverSubjectId,
+        string? rationale = null,
         CancellationToken ct = default);
 
     Task<OverrideDto> RevokeAsync(

--- a/src/Andy.Policies.Application/Interfaces/IPolicyService.cs
+++ b/src/Andy.Policies.Application/Interfaces/IPolicyService.cs
@@ -12,11 +12,9 @@ namespace Andy.Policies.Application.Interfaces;
 /// across surfaces per CLAUDE.md.
 /// </summary>
 /// <remarks>
-/// This service performs no enforcement, no token issuance, no role storage, and
-/// does not call andy-rbac. Edit-RBAC sits in the controller layer (Epic P7 —
-/// rivoli-ai/andy-policies#7). Audit chain emission is Epic P6 — this service
-/// may emit in-process domain events (out of scope for P1.4); audit rows are
-/// persisted by the P6 chain writer.
+/// This service performs no authorization, token issuance, or role storage;
+/// surface adapters enforce edit RBAC. It does enforce mutation rationale and
+/// appends through the P6 chain writer inside the mutation transaction.
 /// </remarks>
 public interface IPolicyService
 {
@@ -36,7 +34,12 @@ public interface IPolicyService
 
     Task<PolicyVersionDto> UpdateDraftAsync(Guid policyId, Guid versionId, UpdatePolicyVersionRequest request, string subjectId, CancellationToken ct = default);
 
-    Task<PolicyVersionDto> BumpDraftFromVersionAsync(Guid policyId, Guid sourceVersionId, string subjectId, CancellationToken ct = default);
+    Task<PolicyVersionDto> BumpDraftFromVersionAsync(
+        Guid policyId,
+        Guid sourceVersionId,
+        string subjectId,
+        string? rationale = null,
+        CancellationToken ct = default);
 
     /// <summary>
     /// Mark a Draft version as ready for an approver to review (#216).

--- a/src/Andy.Policies.Application/Interfaces/IScopeService.cs
+++ b/src/Andy.Policies.Application/Interfaces/IScopeService.cs
@@ -17,7 +17,10 @@ namespace Andy.Policies.Application.Interfaces;
 /// </summary>
 public interface IScopeService
 {
-    Task<ScopeNodeDto> CreateAsync(CreateScopeNodeRequest request, CancellationToken ct = default);
+    Task<ScopeNodeDto> CreateAsync(
+        CreateScopeNodeRequest request,
+        string actorSubjectId,
+        CancellationToken ct = default);
 
     Task<ScopeNodeDto?> GetAsync(Guid id, CancellationToken ct = default);
 
@@ -25,12 +28,20 @@ public interface IScopeService
 
     Task<IReadOnlyList<ScopeNodeDto>> ListAsync(ScopeType? type, CancellationToken ct = default);
 
-    Task<ScopeNodeDto> UpdateAsync(Guid id, UpdateScopeNodeRequest request, CancellationToken ct = default);
+    Task<ScopeNodeDto> UpdateAsync(
+        Guid id,
+        UpdateScopeNodeRequest request,
+        string actorSubjectId,
+        CancellationToken ct = default);
 
     /// <summary>Hard-delete a leaf node. Throws
     /// <c>ScopeHasDescendantsException</c> when the node still has
     /// children.</summary>
-    Task DeleteAsync(Guid id, CancellationToken ct = default);
+    Task DeleteAsync(
+        Guid id,
+        string actorSubjectId,
+        string? rationale,
+        CancellationToken ct = default);
 
     /// <summary>
     /// Walk-up: returns every ancestor of <paramref name="id"/> ordered

--- a/src/Andy.Policies.Application/PlanEvaluation/PlanEvaluationGoalView.cs
+++ b/src/Andy.Policies.Application/PlanEvaluation/PlanEvaluationGoalView.cs
@@ -47,5 +47,5 @@ public sealed record PlanEvaluationGoalView(
 public sealed record PlanEvaluationTaskView(
     Guid TaskId,
     string? EffectiveAgentId,
-    IReadOnlyList<string> ToolsAllowed,
+    IReadOnlyList<string>? ToolsAllowed,
     string? TargetEnv);

--- a/src/Andy.Policies.Application/Queries/ListPoliciesQuery.cs
+++ b/src/Andy.Policies.Application/Queries/ListPoliciesQuery.cs
@@ -5,8 +5,8 @@ namespace Andy.Policies.Application.Queries;
 
 /// <summary>
 /// Filters + pagination for <c>IPolicyService.ListPoliciesAsync</c>. Filters match
-/// against the <i>active version</i> of each policy (per P1's "highest non-Draft"
-/// rule); policies with no active version are excluded from filtered results.
+/// against the version whose state is exactly <c>Active</c>; policies with no
+/// Active version are excluded from filtered results.
 /// </summary>
 /// <param name="NamePrefix">Optional case-sensitive prefix match on <c>Policy.Name</c>.</param>
 /// <param name="Scope">Optional membership test against the active version's scopes.</param>

--- a/src/Andy.Policies.Domain/ValueObjects/BundleSnapshot.cs
+++ b/src/Andy.Policies.Domain/ValueObjects/BundleSnapshot.cs
@@ -64,7 +64,9 @@ public sealed record BundleOverrideEntry(
     string ScopeRef,
     string Effect,
     Guid? ReplacementPolicyVersionId,
-    DateTimeOffset ExpiresAt);
+    DateTimeOffset ExpiresAt,
+    BundlePolicyEntry? ReplacementPolicy = null,
+    DateTimeOffset? ApprovedAt = null);
 
 /// <summary>One row per scope node at snapshot time.</summary>
 public sealed record BundleScopeEntry(

--- a/src/Andy.Policies.Infrastructure/Services/AuditWriter.cs
+++ b/src/Andy.Policies.Infrastructure/Services/AuditWriter.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Interfaces;
+using System.Text.Json;
+
+namespace Andy.Policies.Infrastructure.Services;
+
+/// <summary>
+/// Compatibility adapter from the early mutation hook to the production
+/// tamper-evident audit chain. The caller owns the transaction; because
+/// both services share the scoped AppDbContext, the audit append joins it.
+/// </summary>
+public sealed class AuditWriter : IAuditWriter
+{
+    private readonly IAuditChain _chain;
+
+    public AuditWriter(IAuditChain chain)
+    {
+        _chain = chain;
+    }
+
+    public Task AppendAsync(
+        string action,
+        Guid entityId,
+        string actorSubjectId,
+        string? rationale,
+        CancellationToken ct = default)
+    {
+        var prefix = action.Split('.', 2)[0];
+        var entityType = prefix switch
+        {
+            "policy" => "PolicyVersion",
+            "binding" => "Binding",
+            "scope" => "ScopeNode",
+            "override" => "Override",
+            "item" => "Item",
+            _ => "CatalogEntity",
+        };
+        return AppendCoreAsync(action, entityType, entityId, actorSubjectId, rationale, ct);
+    }
+
+    private async Task AppendCoreAsync(
+        string action,
+        string entityType,
+        Guid entityId,
+        string actorSubjectId,
+        string? rationale,
+        CancellationToken ct)
+    {
+        await _chain.AppendAsync(new AuditAppendRequest(
+            Action: action,
+            EntityType: entityType,
+            EntityId: entityId.ToString(),
+            // The compatibility hook does not receive before/after entity
+            // snapshots, but mutation audit rows must still carry a
+            // populated JSON Patch document. Record the stable mutation
+            // action instead of emitting an ambiguous empty patch.
+            FieldDiffJson: JsonSerializer.Serialize(new[]
+            {
+                new { op = "replace", path = "/lastMutation", value = action },
+            }),
+            Rationale: string.IsNullOrWhiteSpace(rationale) ? null : rationale.Trim(),
+            ActorSubjectId: actorSubjectId,
+            ActorRoles: Array.Empty<string>()), ct).ConfigureAwait(false);
+    }
+}

--- a/src/Andy.Policies.Infrastructure/Services/BindingResolutionService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BindingResolutionService.cs
@@ -24,16 +24,36 @@ public sealed class BindingResolutionService : IBindingResolutionService
 {
     private readonly AppDbContext _db;
     private readonly IScopeService _scopes;
+    private readonly IOverrideService? _overrides;
 
-    public BindingResolutionService(AppDbContext db, IScopeService scopes)
+    public BindingResolutionService(
+        AppDbContext db,
+        IScopeService scopes,
+        IOverrideService? overrides = null)
     {
         _db = db;
         _scopes = scopes;
+        _overrides = overrides;
     }
 
     public async Task<EffectivePolicySetDto> ResolveForScopeAsync(
         Guid scopeNodeId,
         CancellationToken ct = default)
+        => await ResolveForScopeCoreAsync(scopeNodeId, null, ct).ConfigureAwait(false);
+
+    public async Task<EffectivePolicySetDto> ResolveForScopeAsync(
+        Guid scopeNodeId,
+        OverrideResolutionContext overrideContext,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(overrideContext);
+        return await ResolveForScopeCoreAsync(scopeNodeId, overrideContext, ct).ConfigureAwait(false);
+    }
+
+    private async Task<EffectivePolicySetDto> ResolveForScopeCoreAsync(
+        Guid scopeNodeId,
+        OverrideResolutionContext? overrideContext,
+        CancellationToken ct)
     {
         var leaf = await _db.ScopeNodes.AsNoTracking()
             .FirstOrDefaultAsync(s => s.Id == scopeNodeId, ct)
@@ -45,8 +65,124 @@ public sealed class BindingResolutionService : IBindingResolutionService
         chain.Add(new ChainNode(leaf.Id, leaf.Type, leaf.Ref, leaf.Depth));
 
         var policies = await ResolveAlongChainAsync(chain, ct).ConfigureAwait(false);
-        return new EffectivePolicySetDto(scopeNodeId, policies);
+        IReadOnlyList<AppliedOverrideDto> appliedOverrides = Array.Empty<AppliedOverrideDto>();
+        if (overrideContext is not null && _overrides is not null)
+        {
+            var applied = await ApplyOverridesAsync(policies, overrideContext, ct).ConfigureAwait(false);
+            policies = applied.Policies;
+            appliedOverrides = applied.AppliedOverrides;
+        }
+        return new EffectivePolicySetDto(scopeNodeId, policies)
+        {
+            AppliedOverrides = appliedOverrides,
+        };
     }
+
+    private async Task<(IReadOnlyList<EffectivePolicyDto> Policies,
+        IReadOnlyList<AppliedOverrideDto> AppliedOverrides)> ApplyOverridesAsync(
+        IReadOnlyList<EffectivePolicyDto> policies,
+        OverrideResolutionContext context,
+        CancellationToken ct)
+    {
+        var principal = string.IsNullOrWhiteSpace(context.PrincipalSubjectId)
+            ? Array.Empty<OverrideDto>()
+            : (await _overrides!.GetActiveAsync(
+                OverrideScopeKind.Principal,
+                context.PrincipalSubjectId.Trim(),
+                ct).ConfigureAwait(false)).ToArray();
+
+        var cohorts = new List<OverrideDto>();
+        foreach (var cohort in context.CohortRefs
+                     .Where(c => !string.IsNullOrWhiteSpace(c))
+                     .Select(c => c.Trim())
+                     .Distinct(StringComparer.Ordinal)
+                     .OrderBy(c => c, StringComparer.Ordinal))
+        {
+            cohorts.AddRange(await _overrides!.GetActiveAsync(
+                OverrideScopeKind.Cohort, cohort, ct).ConfigureAwait(false));
+        }
+
+        var result = new List<EffectivePolicyDto>(policies.Count);
+        var appliedOverrides = new List<AppliedOverrideDto>();
+        foreach (var policy in policies)
+        {
+            // Principal-specific grants are more specific than cohort
+            // grants. Within one specificity, latest approval wins.
+            var match = principal
+                .Where(o => o.PolicyVersionId == policy.PolicyVersionId)
+                .OrderBy(o => o.ApprovedAt)
+                .ThenBy(o => o.Id)
+                .LastOrDefault()
+                ?? cohorts
+                    .Where(o => o.PolicyVersionId == policy.PolicyVersionId)
+                    .OrderBy(o => o.ApprovedAt)
+                    .ThenBy(o => o.ScopeRef, StringComparer.Ordinal)
+                    .ThenBy(o => o.Id)
+                    .LastOrDefault();
+
+            if (match is null)
+            {
+                result.Add(policy);
+                continue;
+            }
+            if (match.Effect == OverrideEffect.Exempt)
+            {
+                appliedOverrides.Add(ToAppliedOverride(match));
+                continue;
+            }
+            if (match.ReplacementPolicyVersionId is not { } replacementId)
+            {
+                result.Add(policy);
+                continue;
+            }
+
+            var replacement = await _db.PolicyVersions.AsNoTracking()
+                .Where(v => v.Id == replacementId && v.State != LifecycleState.Retired)
+                .Select(v => new
+                {
+                    Version = v,
+                    PolicyId = v.PolicyId,
+                    PolicyName = v.Policy!.Name,
+                })
+                .FirstOrDefaultAsync(ct)
+                .ConfigureAwait(false);
+            if (replacement is null)
+            {
+                // A stale replacement cannot relax the baseline by
+                // making it disappear; retain the original policy.
+                result.Add(policy);
+                continue;
+            }
+
+            result.Add(policy with
+            {
+                PolicyId = replacement.PolicyId,
+                PolicyVersionId = replacement.Version.Id,
+                PolicyKey = replacement.PolicyName,
+                Version = replacement.Version.Version,
+            });
+            appliedOverrides.Add(ToAppliedOverride(match));
+        }
+
+        var effective = result
+            .GroupBy(p => p.PolicyId)
+            .Select(g => g.OrderBy(p => p.BindStrength).ThenByDescending(p => p.SourceDepth).First())
+            .OrderBy(p => p.BindStrength)
+            .ThenBy(p => p.PolicyKey, StringComparer.Ordinal)
+            .ToList();
+        return (effective, appliedOverrides
+            .OrderBy(o => o.OriginalPolicyVersionId)
+            .ThenBy(o => o.OverrideId)
+            .ToList());
+    }
+
+    private static AppliedOverrideDto ToAppliedOverride(OverrideDto value) => new(
+        value.Id,
+        value.Effect,
+        value.ScopeKind,
+        value.ScopeRef,
+        value.PolicyVersionId,
+        value.ReplacementPolicyVersionId);
 
     public async Task<EffectivePolicySetDto> ResolveForTargetAsync(
         BindingTargetType targetType,

--- a/src/Andy.Policies.Infrastructure/Services/BindingService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BindingService.cs
@@ -26,9 +26,10 @@ public sealed class BindingService : IBindingService
     private readonly IAuditWriter _audit;
     private readonly TimeProvider _clock;
     private readonly ITightenOnlyValidator? _tightenValidator;
+    private readonly IRationalePolicy _rationale;
 
     public BindingService(AppDbContext db, IAuditWriter audit, TimeProvider clock)
-        : this(db, audit, clock, tightenValidator: null) { }
+        : this(db, audit, clock, tightenValidator: null, rationale: null) { }
 
     /// <summary>
     /// Optional <see cref="ITightenOnlyValidator"/> overload (P4.4,
@@ -44,12 +45,14 @@ public sealed class BindingService : IBindingService
         AppDbContext db,
         IAuditWriter audit,
         TimeProvider clock,
-        ITightenOnlyValidator? tightenValidator)
+        ITightenOnlyValidator? tightenValidator,
+        IRationalePolicy? rationale = null)
     {
         _db = db;
         _audit = audit;
         _clock = clock;
         _tightenValidator = tightenValidator;
+        _rationale = rationale ?? new RequireNonEmptyRationalePolicy();
     }
 
     public async Task<BindingDto> CreateAsync(
@@ -59,6 +62,11 @@ public sealed class BindingService : IBindingService
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentException.ThrowIfNullOrEmpty(actorSubjectId);
+        ValidateRationale(request.Rationale);
+
+        await using var transaction = _db.Database.IsRelational()
+            ? await _db.Database.BeginTransactionAsync(ct).ConfigureAwait(false)
+            : null;
 
         var targetRef = (request.TargetRef ?? string.Empty).Trim();
         if (string.IsNullOrEmpty(targetRef))
@@ -117,6 +125,11 @@ public sealed class BindingService : IBindingService
             "binding.created", binding.Id, actorSubjectId, request.Rationale, ct)
             .ConfigureAwait(false);
 
+        if (transaction is not null)
+        {
+            await transaction.CommitAsync(ct).ConfigureAwait(false);
+        }
+
         return ToDto(binding);
     }
 
@@ -127,6 +140,11 @@ public sealed class BindingService : IBindingService
         CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(actorSubjectId);
+        ValidateRationale(rationale);
+
+        await using var transaction = _db.Database.IsRelational()
+            ? await _db.Database.BeginTransactionAsync(ct).ConfigureAwait(false)
+            : null;
 
         var binding = await _db.Bindings
             .FirstOrDefaultAsync(b => b.Id == bindingId, ct)
@@ -146,6 +164,10 @@ public sealed class BindingService : IBindingService
         await _audit.AppendAsync(
             "binding.deleted", binding.Id, actorSubjectId, rationale, ct)
             .ConfigureAwait(false);
+        if (transaction is not null)
+        {
+            await transaction.CommitAsync(ct).ConfigureAwait(false);
+        }
     }
 
     public async Task<BindingDto?> GetAsync(Guid bindingId, CancellationToken ct = default)
@@ -155,6 +177,15 @@ public sealed class BindingService : IBindingService
             .FirstOrDefaultAsync(b => b.Id == bindingId, ct)
             .ConfigureAwait(false);
         return binding is null ? null : ToDto(binding);
+    }
+
+    private void ValidateRationale(string? rationale)
+    {
+        var error = _rationale.ValidateRationale(rationale);
+        if (error is not null)
+        {
+            throw new RationaleRequiredException(error);
+        }
     }
 
     public async Task<IReadOnlyList<BindingDto>> ListByPolicyVersionAsync(

--- a/src/Andy.Policies.Infrastructure/Services/BundleResolver.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BundleResolver.cs
@@ -131,6 +131,25 @@ public sealed class BundleResolver : IBundleResolver
 
     public async Task<EffectivePolicySetDto?> ResolveEffectiveForScopeAsync(
         Guid bundleId, Guid scopeNodeId, CancellationToken ct = default)
+        => await ResolveEffectiveForScopeCoreAsync(bundleId, scopeNodeId, null, ct)
+            .ConfigureAwait(false);
+
+    public async Task<EffectivePolicySetDto?> ResolveEffectiveForScopeAsync(
+        Guid bundleId,
+        Guid scopeNodeId,
+        OverrideResolutionContext overrideContext,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(overrideContext);
+        return await ResolveEffectiveForScopeCoreAsync(
+            bundleId, scopeNodeId, overrideContext, ct).ConfigureAwait(false);
+    }
+
+    private async Task<EffectivePolicySetDto?> ResolveEffectiveForScopeCoreAsync(
+        Guid bundleId,
+        Guid scopeNodeId,
+        OverrideResolutionContext? overrideContext,
+        CancellationToken ct)
     {
         var carrier = await LoadAsync(bundleId, ct).ConfigureAwait(false);
         if (carrier is null) return null;
@@ -153,30 +172,46 @@ public sealed class BundleResolver : IBundleResolver
         var chain = WalkAncestorChain(scopeById, scopeNodeId);
         var policiesByVersionId = carrier.Snapshot.Policies.ToDictionary(p => p.PolicyVersionId);
 
-        // Match bindings that target ScopeNode and reference a chain
-        // node via "scope:{nodeId}". Each candidate is tagged with its
-        // node's depth (its position in the root→leaf chain) so the
-        // tighten-only fold can prefer deeper Mandatory rows.
+        // Match explicit ScopeNode bindings and the Org/Tenant/Repo/
+        // Template bridge bindings supported by the live resolver.
+        // Each candidate is tagged with its node depth so the same
+        // tighten-only fold applies in pinned and live modes.
         var depthByNodeId = chain
             .Select((n, idx) => (n.ScopeNodeId, Depth: idx))
             .ToDictionary(p => p.ScopeNodeId, p => p.Depth);
         var candidates = new List<EffectiveCandidate>();
         foreach (var b in carrier.Snapshot.Bindings)
         {
-            if (!string.Equals(b.TargetType, BindingTargetType.ScopeNode.ToString(), StringComparison.Ordinal))
+            BundleScopeEntry? node;
+            int depth;
+            if (string.Equals(b.TargetType, BindingTargetType.ScopeNode.ToString(), StringComparison.Ordinal))
             {
-                continue;
+                if (!b.TargetRef.StartsWith("scope:", StringComparison.Ordinal)
+                    || !Guid.TryParse(b.TargetRef.AsSpan("scope:".Length), out var nodeId)
+                    || !depthByNodeId.TryGetValue(nodeId, out depth))
+                {
+                    continue;
+                }
+                node = scopeById[nodeId];
             }
-            if (!b.TargetRef.StartsWith("scope:", StringComparison.Ordinal)
-                || !Guid.TryParse(b.TargetRef.AsSpan("scope:".Length), out var nodeId))
+            else
             {
-                continue;
+                var bridgeMatch = chain
+                    .Select((entry, idx) => new { Entry = entry, Depth = idx })
+                    .Where(x => string.Equals(
+                                    TryMapToBindingTargetType(ParseScopeType(x.Entry.Type))?.ToString(),
+                                    b.TargetType,
+                                    StringComparison.Ordinal)
+                                && string.Equals(x.Entry.Ref, b.TargetRef, StringComparison.Ordinal))
+                    .OrderByDescending(x => x.Depth)
+                    .FirstOrDefault();
+                if (bridgeMatch is null) continue;
+                node = bridgeMatch.Entry;
+                depth = bridgeMatch.Depth;
             }
-            if (!depthByNodeId.TryGetValue(nodeId, out var depth)) continue;
             if (!policiesByVersionId.TryGetValue(b.PolicyVersionId, out var policy)) continue;
-            var node = scopeById[nodeId];
             candidates.Add(new EffectiveCandidate(
-                b, policy, depth, nodeId, ParseScopeType(node.Type)));
+                b, policy, depth, node.ScopeNodeId, ParseScopeType(node.Type)));
         }
 
         var folded = candidates
@@ -204,8 +239,99 @@ public sealed class BundleResolver : IBundleResolver
             .ThenBy(p => p.PolicyKey, StringComparer.Ordinal)
             .ToList();
 
-        return new EffectivePolicySetDto(scopeNodeId, folded);
+        var applied = overrideContext is null
+            ? (Policies: (IReadOnlyList<EffectivePolicyDto>)folded,
+               AppliedOverrides: (IReadOnlyList<AppliedOverrideDto>)Array.Empty<AppliedOverrideDto>())
+            : ApplySnapshotOverrides(folded, carrier.Snapshot.Overrides, overrideContext);
+        return new EffectivePolicySetDto(scopeNodeId, applied.Policies)
+        {
+            AppliedOverrides = applied.AppliedOverrides,
+        };
     }
+
+    private static (IReadOnlyList<EffectivePolicyDto> Policies,
+        IReadOnlyList<AppliedOverrideDto> AppliedOverrides) ApplySnapshotOverrides(
+        IReadOnlyList<EffectivePolicyDto> policies,
+        IReadOnlyList<BundleOverrideEntry> overrides,
+        OverrideResolutionContext context)
+    {
+        var principalRef = context.PrincipalSubjectId?.Trim();
+        var cohortRefs = context.CohortRefs
+            .Where(c => !string.IsNullOrWhiteSpace(c))
+            .Select(c => c.Trim())
+            .ToHashSet(StringComparer.Ordinal);
+
+        var result = new List<EffectivePolicyDto>(policies.Count);
+        var appliedOverrides = new List<AppliedOverrideDto>();
+        foreach (var policy in policies)
+        {
+            var principalMatch = string.IsNullOrWhiteSpace(principalRef)
+                ? null
+                : overrides
+                    .Where(o => o.PolicyVersionId == policy.PolicyVersionId
+                                && string.Equals(o.ScopeKind, OverrideScopeKind.Principal.ToString(), StringComparison.Ordinal)
+                                && string.Equals(o.ScopeRef, principalRef, StringComparison.Ordinal))
+                    .OrderBy(o => o.ApprovedAt)
+                    .ThenBy(o => o.OverrideId)
+                    .LastOrDefault();
+            var match = principalMatch ?? overrides
+                .Where(o => o.PolicyVersionId == policy.PolicyVersionId
+                            && string.Equals(o.ScopeKind, OverrideScopeKind.Cohort.ToString(), StringComparison.Ordinal)
+                            && cohortRefs.Contains(o.ScopeRef))
+                .OrderBy(o => o.ApprovedAt)
+                .ThenBy(o => o.ScopeRef, StringComparer.Ordinal)
+                .ThenBy(o => o.OverrideId)
+                .LastOrDefault();
+
+            if (match is null)
+            {
+                result.Add(policy);
+                continue;
+            }
+            if (string.Equals(match.Effect, OverrideEffect.Exempt.ToString(), StringComparison.Ordinal))
+            {
+                appliedOverrides.Add(ToAppliedOverride(match, OverrideEffect.Exempt));
+                continue;
+            }
+            if (!string.Equals(match.Effect, OverrideEffect.Replace.ToString(), StringComparison.Ordinal)
+                || match.ReplacementPolicy is not { } replacement)
+            {
+                // Old snapshots do not carry replacement content. Keep
+                // the baseline policy rather than failing open.
+                result.Add(policy);
+                continue;
+            }
+
+            result.Add(policy with
+            {
+                PolicyId = replacement.PolicyId,
+                PolicyVersionId = replacement.PolicyVersionId,
+                PolicyKey = replacement.Name,
+                Version = replacement.Version,
+            });
+            appliedOverrides.Add(ToAppliedOverride(match, OverrideEffect.Replace));
+        }
+
+        var effective = result
+            .GroupBy(p => p.PolicyId)
+            .Select(g => g.OrderBy(p => p.BindStrength).ThenByDescending(p => p.SourceDepth).First())
+            .OrderBy(p => p.BindStrength)
+            .ThenBy(p => p.PolicyKey, StringComparer.Ordinal)
+            .ToList();
+        return (effective, appliedOverrides
+            .OrderBy(o => o.OriginalPolicyVersionId)
+            .ThenBy(o => o.OverrideId)
+            .ToList());
+    }
+
+    private static AppliedOverrideDto ToAppliedOverride(
+        BundleOverrideEntry value, OverrideEffect effect) => new(
+        value.OverrideId,
+        effect,
+        Enum.Parse<OverrideScopeKind>(value.ScopeKind),
+        value.ScopeRef,
+        value.PolicyVersionId,
+        value.ReplacementPolicyVersionId);
 
     /// <summary>Root-to-leaf chain of scope nodes. The leaf is at the
     /// end of the list; depth increases with index. Stops at the
@@ -233,6 +359,15 @@ public sealed class BundleResolver : IBundleResolver
 
     private static ScopeType ParseScopeType(string wire)
         => Enum.TryParse<ScopeType>(wire, ignoreCase: true, out var st) ? st : default;
+
+    private static BindingTargetType? TryMapToBindingTargetType(ScopeType type) => type switch
+    {
+        ScopeType.Org => BindingTargetType.Org,
+        ScopeType.Tenant => BindingTargetType.Tenant,
+        ScopeType.Repo => BindingTargetType.Repo,
+        ScopeType.Template => BindingTargetType.Template,
+        _ => null,
+    };
 
     private sealed record EffectiveCandidate(
         BundleBindingEntry Binding,

--- a/src/Andy.Policies.Infrastructure/Services/BundleService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BundleService.cs
@@ -207,6 +207,10 @@ public sealed class BundleService : IBundleService
             throw new ValidationException("Rationale is required and may not be empty or whitespace.");
         }
 
+        await using var transaction = _db.Database.IsRelational()
+            ? await _db.Database.BeginTransactionAsync(ct).ConfigureAwait(false)
+            : null;
+
         var bundle = await _db.Bundles
             .FirstOrDefaultAsync(b => b.Id == bundleId, ct)
             .ConfigureAwait(false);
@@ -230,6 +234,10 @@ public sealed class BundleService : IBundleService
             Rationale: rationale.Trim(),
             ActorSubjectId: actorSubjectId,
             ActorRoles: Array.Empty<string>()), ct).ConfigureAwait(false);
+        if (transaction is not null)
+        {
+            await transaction.CommitAsync(ct).ConfigureAwait(false);
+        }
         return true;
     }
 

--- a/src/Andy.Policies.Infrastructure/Services/BundleSnapshotBuilder.cs
+++ b/src/Andy.Policies.Infrastructure/Services/BundleSnapshotBuilder.cs
@@ -122,20 +122,72 @@ public sealed class BundleSnapshotBuilder : IBundleSnapshotBuilder
                     o.Effect,
                     o.ReplacementPolicyVersionId,
                     o.ExpiresAt,
+                    o.ApprovedAt,
                 })
                 .ToListAsync(ct)
                 .ConfigureAwait(false);
+
+            // Replacement versions are not necessarily Active (the
+            // override contract also permits WindingDown versions), so
+            // embed their policy content directly on the override entry.
+            // This keeps pinned Replace semantics reproducible without
+            // polluting the snapshot's Active policy list.
+            var replacementIds = approvedRows
+                .Where(o => o.ExpiresAt > capturedAt)
+                .Select(o => o.ReplacementPolicyVersionId)
+                .OfType<Guid>()
+                .Distinct()
+                .ToList();
+            var replacementRows = await _db.PolicyVersions
+                .AsNoTracking()
+                .Where(v => replacementIds.Contains(v.Id))
+                .Select(v => new
+                {
+                    v.PolicyId,
+                    PolicyName = v.Policy!.Name,
+                    v.Id,
+                    v.Version,
+                    v.Enforcement,
+                    v.Severity,
+                    v.Scopes,
+                    v.RulesJson,
+                    v.Summary,
+                })
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+            var replacementById = replacementRows.ToDictionary(
+                r => r.Id,
+                r => new BundlePolicyEntry(
+                    r.PolicyId,
+                    r.PolicyName,
+                    r.Id,
+                    r.Version,
+                    r.Enforcement.ToString(),
+                    r.Severity.ToString(),
+                    r.Scopes.ToList(),
+                    r.RulesJson,
+                    r.Summary));
             overrides = approvedRows
                 .Where(o => o.ExpiresAt > capturedAt)
                 .OrderBy(o => o.Id)
-                .Select(o => new BundleOverrideEntry(
-                    o.Id,
-                    o.PolicyVersionId,
-                    o.ScopeKind.ToString(),
-                    o.ScopeRef,
-                    o.Effect.ToString(),
-                    o.ReplacementPolicyVersionId,
-                    o.ExpiresAt))
+                .Select(o =>
+                {
+                    BundlePolicyEntry? replacement = null;
+                    if (o.ReplacementPolicyVersionId is { } replacementId)
+                    {
+                        replacementById.TryGetValue(replacementId, out replacement);
+                    }
+                    return new BundleOverrideEntry(
+                        o.Id,
+                        o.PolicyVersionId,
+                        o.ScopeKind.ToString(),
+                        o.ScopeRef,
+                        o.Effect.ToString(),
+                        o.ReplacementPolicyVersionId,
+                        o.ExpiresAt,
+                        replacement,
+                        o.ApprovedAt);
+                })
                 .ToList();
         }
         else

--- a/src/Andy.Policies.Infrastructure/Services/ItemService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/ItemService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Exceptions;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Domain.Entities;
 using Andy.Policies.Infrastructure.Data;
@@ -12,10 +13,14 @@ namespace Andy.Policies.Infrastructure.Services;
 public class ItemService : IItemService
 {
     private readonly AppDbContext _db;
+    private readonly IAuditWriter _audit;
+    private readonly IRationalePolicy _rationale;
 
-    public ItemService(AppDbContext db)
+    public ItemService(AppDbContext db, IAuditWriter audit, IRationalePolicy rationale)
     {
         _db = db;
+        _audit = audit;
+        _rationale = rationale;
     }
 
     public async Task<IEnumerable<ItemDto>> GetAllAsync(CancellationToken ct = default)
@@ -35,6 +40,12 @@ public class ItemService : IItemService
 
     public async Task<ItemDto> CreateAsync(CreateItemRequest request, string userId, CancellationToken ct = default)
     {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrEmpty(userId);
+        ValidateRationale(request.Rationale);
+        await using var transaction = _db.Database.IsRelational()
+            ? await _db.Database.BeginTransactionAsync(ct).ConfigureAwait(false)
+            : null;
         var item = new Item
         {
             Id = Guid.NewGuid(),
@@ -47,11 +58,21 @@ public class ItemService : IItemService
 
         _db.Items.Add(item);
         await _db.SaveChangesAsync(ct);
+        await _audit.AppendAsync("item.created", item.Id, userId, request.Rationale, ct)
+            .ConfigureAwait(false);
+        if (transaction is not null) await transaction.CommitAsync(ct).ConfigureAwait(false);
         return ToDto(item);
     }
 
-    public async Task<ItemDto?> UpdateAsync(Guid id, CreateItemRequest request, CancellationToken ct = default)
+    public async Task<ItemDto?> UpdateAsync(
+        Guid id, CreateItemRequest request, string actorSubjectId, CancellationToken ct = default)
     {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrEmpty(actorSubjectId);
+        ValidateRationale(request.Rationale);
+        await using var transaction = _db.Database.IsRelational()
+            ? await _db.Database.BeginTransactionAsync(ct).ConfigureAwait(false)
+            : null;
         var item = await _db.Items.FindAsync(new object[] { id }, ct);
         if (item is null) return null;
 
@@ -60,17 +81,35 @@ public class ItemService : IItemService
         item.UpdatedAt = DateTimeOffset.UtcNow;
 
         await _db.SaveChangesAsync(ct);
+        await _audit.AppendAsync("item.updated", item.Id, actorSubjectId, request.Rationale, ct)
+            .ConfigureAwait(false);
+        if (transaction is not null) await transaction.CommitAsync(ct).ConfigureAwait(false);
         return ToDto(item);
     }
 
-    public async Task<bool> DeleteAsync(Guid id, CancellationToken ct = default)
+    public async Task<bool> DeleteAsync(
+        Guid id, string actorSubjectId, string? rationale, CancellationToken ct = default)
     {
+        ArgumentException.ThrowIfNullOrEmpty(actorSubjectId);
+        ValidateRationale(rationale);
+        await using var transaction = _db.Database.IsRelational()
+            ? await _db.Database.BeginTransactionAsync(ct).ConfigureAwait(false)
+            : null;
         var item = await _db.Items.FindAsync(new object[] { id }, ct);
         if (item is null) return false;
 
         _db.Items.Remove(item);
         await _db.SaveChangesAsync(ct);
+        await _audit.AppendAsync("item.deleted", item.Id, actorSubjectId, rationale, ct)
+            .ConfigureAwait(false);
+        if (transaction is not null) await transaction.CommitAsync(ct).ConfigureAwait(false);
         return true;
+    }
+
+    private void ValidateRationale(string? rationale)
+    {
+        var error = _rationale.ValidateRationale(rationale);
+        if (error is not null) throw new RationaleRequiredException(error);
     }
 
     private static ItemDto ToDto(Item item) => new(

--- a/src/Andy.Policies.Infrastructure/Services/LifecycleTransitionService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/LifecycleTransitionService.cs
@@ -42,17 +42,20 @@ public sealed class LifecycleTransitionService : ILifecycleTransitionService
     private readonly IRationalePolicy _rationale;
     private readonly IDomainEventDispatcher _events;
     private readonly TimeProvider _clock;
+    private readonly IAuditWriter? _audit;
 
     public LifecycleTransitionService(
         AppDbContext db,
         IRationalePolicy rationale,
         IDomainEventDispatcher events,
-        TimeProvider clock)
+        TimeProvider clock,
+        IAuditWriter? audit = null)
     {
         _db = db;
         _rationale = rationale;
         _events = events;
         _clock = clock;
+        _audit = audit;
     }
 
     public bool IsTransitionAllowed(LifecycleState from, LifecycleState to)
@@ -197,6 +200,28 @@ public sealed class LifecycleTransitionService : ILifecycleTransitionService
         try
         {
             await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+            if (_audit is not null)
+            {
+                if (pendingSuperseded is not null)
+                {
+                    await _audit.AppendAsync(
+                        "policy.version.superseded",
+                        pendingSuperseded.PreviousVersionId,
+                        actorSubjectId,
+                        rationale,
+                        ct).ConfigureAwait(false);
+                }
+                var action = target switch
+                {
+                    LifecycleState.Active => "policy.version.published",
+                    LifecycleState.WindingDown => "policy.version.winding_down",
+                    LifecycleState.Retired => "policy.version.retired",
+                    _ => "policy.version.transitioned",
+                };
+                await _audit.AppendAsync(
+                    action, version.Id, actorSubjectId, rationale, ct)
+                    .ConfigureAwait(false);
+            }
             await transaction.CommitAsync(ct).ConfigureAwait(false);
         }
         catch (DbUpdateException ex) when (IsConcurrentPublishSignal(ex))

--- a/src/Andy.Policies.Infrastructure/Services/OverrideService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/OverrideService.cs
@@ -50,17 +50,23 @@ public sealed class OverrideService : IOverrideService
     private readonly IRbacChecker _rbac;
     private readonly IDomainEventDispatcher _events;
     private readonly TimeProvider _clock;
+    private readonly IAuditWriter? _audit;
+    private readonly IRationalePolicy _rationale;
 
     public OverrideService(
         AppDbContext db,
         IRbacChecker rbac,
         IDomainEventDispatcher events,
-        TimeProvider clock)
+        TimeProvider clock,
+        IAuditWriter? audit = null,
+        IRationalePolicy? rationale = null)
     {
         _db = db;
         _rbac = rbac;
         _events = events;
         _clock = clock;
+        _audit = audit;
+        _rationale = rationale ?? new RequireNonEmptyRationalePolicy();
     }
 
     public async Task<OverrideDto> ProposeAsync(
@@ -70,6 +76,10 @@ public sealed class OverrideService : IOverrideService
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentException.ThrowIfNullOrEmpty(proposerSubjectId);
+
+        await using var transaction = _db.Database.IsRelational()
+            ? await _db.Database.BeginTransactionAsync(ct).ConfigureAwait(false)
+            : null;
 
         var scopeRef = (request.ScopeRef ?? string.Empty).Trim();
         if (string.IsNullOrEmpty(scopeRef))
@@ -157,6 +167,16 @@ public sealed class OverrideService : IOverrideService
         };
         _db.Overrides.Add(ovr);
         await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        if (_audit is not null)
+        {
+            await _audit.AppendAsync(
+                "override.proposed", ovr.Id, proposerSubjectId, rationale, ct)
+                .ConfigureAwait(false);
+        }
+        if (transaction is not null)
+        {
+            await transaction.CommitAsync(ct).ConfigureAwait(false);
+        }
 
         await _events.DispatchAsync(new OverrideProposed(
             OverrideId: ovr.Id,
@@ -173,9 +193,11 @@ public sealed class OverrideService : IOverrideService
     public async Task<OverrideDto> ApproveAsync(
         Guid id,
         string approverSubjectId,
+        string? rationale = null,
         CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(approverSubjectId);
+        ValidateRationale(rationale);
 
         await using var transaction = await _db.Database
             .BeginTransactionAsync(IsolationLevel.Serializable, ct)
@@ -222,6 +244,12 @@ public sealed class OverrideService : IOverrideService
         ovr.ApproverSubjectId = approverSubjectId;
         ovr.ApprovedAt = now;
         await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        if (_audit is not null)
+        {
+            await _audit.AppendAsync(
+                "override.approved", ovr.Id, approverSubjectId, rationale, ct)
+                .ConfigureAwait(false);
+        }
         await transaction.CommitAsync(ct).ConfigureAwait(false);
 
         await _events.DispatchAsync(new OverrideApproved(
@@ -290,6 +318,12 @@ public sealed class OverrideService : IOverrideService
         ovr.State = OverrideState.Revoked;
         ovr.RevocationReason = reason;
         await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        if (_audit is not null)
+        {
+            await _audit.AppendAsync(
+                "override.revoked", ovr.Id, actorSubjectId, reason, ct)
+                .ConfigureAwait(false);
+        }
         await transaction.CommitAsync(ct).ConfigureAwait(false);
 
         await _events.DispatchAsync(new OverrideRevoked(
@@ -359,6 +393,12 @@ public sealed class OverrideService : IOverrideService
         ovr.State = OverrideState.Rejected;
         ovr.RevocationReason = reason;
         await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        if (_audit is not null)
+        {
+            await _audit.AppendAsync(
+                "override.rejected", ovr.Id, actorSubjectId, reason, ct)
+                .ConfigureAwait(false);
+        }
         await transaction.CommitAsync(ct).ConfigureAwait(false);
 
         await _events.DispatchAsync(new OverrideRejected(
@@ -403,6 +443,12 @@ public sealed class OverrideService : IOverrideService
 
         ovr.State = OverrideState.Expired;
         await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        if (_audit is not null)
+        {
+            await _audit.AppendAsync(
+                "override.expired", ovr.Id, "system:reaper", "automatic expiry", ct)
+                .ConfigureAwait(false);
+        }
         await transaction.CommitAsync(ct).ConfigureAwait(false);
 
         await _events.DispatchAsync(new OverrideExpired(
@@ -465,6 +511,15 @@ public sealed class OverrideService : IOverrideService
             .OrderBy(o => o.ApprovedAt)
             .Select(ToDto)
             .ToList();
+    }
+
+    private void ValidateRationale(string? rationale)
+    {
+        var error = _rationale.ValidateRationale(rationale);
+        if (error is not null)
+        {
+            throw new RationaleRequiredException(error);
+        }
     }
 
     private static OverrideDto ToDto(Override o) => new(

--- a/src/Andy.Policies.Infrastructure/Services/PlanEvaluation/HttpTasksPlanClient.cs
+++ b/src/Andy.Policies.Infrastructure/Services/PlanEvaluation/HttpTasksPlanClient.cs
@@ -96,9 +96,11 @@ public sealed class HttpTasksPlanClient : ITasksPlanClient
         EffectiveAgentId: !string.IsNullOrWhiteSpace(t.ExecutorId)
             ? t.ExecutorId
             : t.SuggestedAgentIds?.FirstOrDefault(),
-        ToolsAllowed: t.DelegationContract?.ToolsAllowed
-            ?? (IReadOnlyList<string>)Array.Empty<string>(),
-        TargetEnv: null /* not on TaskDto today */);
+        // Preserve null as "data unavailable". An explicit empty
+        // collection means the contract is present and permits no
+        // tools; collapsing the states would approve incomplete data.
+        ToolsAllowed: t.DelegationContract?.ToolsAllowed,
+        TargetEnv: t.TargetEnv);
 
     private async Task<T?> GetOrNullAsync<T>(string path, CancellationToken ct)
         where T : class
@@ -143,7 +145,8 @@ public sealed class HttpTasksPlanClient : ITasksPlanClient
         string? ExternalId,
         DelegationContractEnvelope? DelegationContract,
         IReadOnlyList<string>? SuggestedAgentIds,
-        string? ExecutorId);
+        string? ExecutorId,
+        string? TargetEnv);
 
     private sealed record DelegationContractEnvelope(
         string? Objective,

--- a/src/Andy.Policies.Infrastructure/Services/PlanEvaluation/PlanPredicates.cs
+++ b/src/Andy.Policies.Infrastructure/Services/PlanEvaluation/PlanPredicates.cs
@@ -65,8 +65,13 @@ public sealed class AllTasksReadOnlyPredicate : IPlanPredicate
             return PredicateEvaluation.Pass("no tasks in plan");
         }
 
+        if (view.Tasks.Any(t => t.ToolsAllowed is null))
+        {
+            return PredicateEvaluation.Unevaluable();
+        }
+
         var offenders = view.Tasks
-            .Where(t => t.ToolsAllowed.Any(WriteOrExecToolHeuristics.LooksWriteOrExec))
+            .Where(t => t.ToolsAllowed!.Any(WriteOrExecToolHeuristics.LooksWriteOrExec))
             .Select(t => t.TaskId.ToString())
             .ToList();
 
@@ -107,9 +112,13 @@ public sealed class NoProductionDeployPredicate : IPlanPredicate
             return PredicateEvaluation.Pass("no tasks in plan");
         }
 
+        if (view.Tasks.Any(t => string.IsNullOrWhiteSpace(t.TargetEnv)))
+        {
+            return PredicateEvaluation.Unevaluable();
+        }
+
         var prodTasks = view.Tasks
-            .Where(t => t.TargetEnv is not null &&
-                        ProdMarkers.Any(m => string.Equals(t.TargetEnv, m,
+            .Where(t => ProdMarkers.Any(m => string.Equals(t.TargetEnv, m,
                                               StringComparison.OrdinalIgnoreCase)))
             .Select(t => t.TaskId.ToString())
             .ToList();

--- a/src/Andy.Policies.Infrastructure/Services/PolicyService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/PolicyService.cs
@@ -36,16 +36,19 @@ public sealed partial class PolicyService : IPolicyService
 
     private readonly AppDbContext _db;
     private readonly IAuditWriter? _audit;
+    private readonly IRationalePolicy _rationale;
 
-    /// <param name="audit">Optional audit writer. Production DI wires
-    /// <c>NoopAuditWriter</c> (P3.2) and the real hash-chained writer
-    /// (P6.2). Tests that construct directly may pass <c>null</c> to
-    /// skip audit emission — the 57 pre-existing direct-instantiation
-    /// tests rely on that. New audit-aware tests inject a spy.</param>
-    public PolicyService(AppDbContext db, IAuditWriter? audit = null)
+    /// <param name="audit">Mutation audit adapter. Production DI wires the
+    /// real hash-chained writer; direct-construction tests may pass null when
+    /// audit emission is outside their scope.</param>
+    public PolicyService(
+        AppDbContext db,
+        IAuditWriter? audit = null,
+        IRationalePolicy? rationale = null)
     {
         _db = db;
         _audit = audit;
+        _rationale = rationale ?? new RequireNonEmptyRationalePolicy();
     }
 
     public async Task<IReadOnlyList<PolicyDto>> ListPoliciesAsync(ListPoliciesQuery query, CancellationToken ct = default)
@@ -129,7 +132,7 @@ public sealed partial class PolicyService : IPolicyService
     {
         var active = await _db.PolicyVersions
             .AsNoTracking()
-            .Where(v => v.PolicyId == policyId && v.State != LifecycleState.Draft)
+            .Where(v => v.PolicyId == policyId && v.State == LifecycleState.Active)
             .OrderByDescending(v => v.Version)
             .FirstOrDefaultAsync(ct);
         return active is null ? null : ToVersionDto(active);
@@ -139,6 +142,7 @@ public sealed partial class PolicyService : IPolicyService
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentException.ThrowIfNullOrEmpty(subjectId);
+        ValidateRationale(request.Rationale);
 
         var name = request.Name ?? string.Empty;
         if (!NameRegex().IsMatch(name))
@@ -191,17 +195,13 @@ public sealed partial class PolicyService : IPolicyService
         _db.Policies.Add(policy);
         _db.PolicyVersions.Add(version);
         await _db.SaveChangesAsync(ct);
-        await tx.CommitAsync(ct);
-
-        // Audit append after commit — matches BindingService.CreateAsync's
-        // pattern. NoopAuditWriter today; the P6.2 real writer will need
-        // to fold this into the same transaction when it lands.
         if (_audit is not null)
         {
             await _audit.AppendAsync(
-                "policy.draft.created", policy.Id, subjectId, request.Rationale, ct)
+                "policy.draft.created", version.Id, subjectId, request.Rationale, ct)
                 .ConfigureAwait(false);
         }
+        await tx.CommitAsync(ct);
 
         return ToVersionDto(version);
     }
@@ -210,6 +210,9 @@ public sealed partial class PolicyService : IPolicyService
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentException.ThrowIfNullOrEmpty(subjectId);
+        ValidateRationale(request.Rationale);
+
+        await using var tx = await _db.Database.BeginTransactionAsync(ct);
 
         var version = await _db.PolicyVersions.FirstOrDefaultAsync(
             v => v.PolicyId == policyId && v.Id == versionId, ct)
@@ -263,13 +266,20 @@ public sealed partial class PolicyService : IPolicyService
                 "policy.draft.updated", version.Id, subjectId, request.Rationale, ct)
                 .ConfigureAwait(false);
         }
+        await tx.CommitAsync(ct);
 
         return ToVersionDto(version);
     }
 
-    public async Task<PolicyVersionDto> BumpDraftFromVersionAsync(Guid policyId, Guid sourceVersionId, string subjectId, CancellationToken ct = default)
+    public async Task<PolicyVersionDto> BumpDraftFromVersionAsync(
+        Guid policyId,
+        Guid sourceVersionId,
+        string subjectId,
+        string? rationale = null,
+        CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(subjectId);
+        ValidateRationale(rationale);
 
         await using var tx = await _db.Database.BeginTransactionAsync(ct);
 
@@ -312,6 +322,12 @@ public sealed partial class PolicyService : IPolicyService
 
         _db.PolicyVersions.Add(next);
         await _db.SaveChangesAsync(ct);
+        if (_audit is not null)
+        {
+            await _audit.AppendAsync(
+                "policy.draft.bumped", next.Id, subjectId, rationale, ct)
+                .ConfigureAwait(false);
+        }
         await tx.CommitAsync(ct);
 
         return ToVersionDto(next);
@@ -321,10 +337,9 @@ public sealed partial class PolicyService : IPolicyService
 
     private static PolicyVersion? ResolveActive(IEnumerable<PolicyVersion> versions)
     {
-        // P1 rule: "highest Version with State != Draft". P2 tightens to State == Active
-        // via its own transition service; the resolver here stays compatible with both.
+        // P2 lifecycle semantics: only LifecycleState.Active is active.
         return versions
-            .Where(v => v.State != LifecycleState.Draft)
+            .Where(v => v.State == LifecycleState.Active)
             .OrderByDescending(v => v.Version)
             .FirstOrDefault();
     }
@@ -346,6 +361,9 @@ public sealed partial class PolicyService : IPolicyService
         Guid policyId, Guid versionId, string? rationale, string subjectId, CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(subjectId);
+        ValidateRationale(rationale);
+
+        await using var tx = await _db.Database.BeginTransactionAsync(ct);
 
         var version = await _db.PolicyVersions.FirstOrDefaultAsync(
             v => v.PolicyId == policyId && v.Id == versionId, ct)
@@ -365,6 +383,7 @@ public sealed partial class PolicyService : IPolicyService
         // chain with duplicate `policy.draft.proposed` events.
         if (version.ReadyForReview)
         {
+            await tx.CommitAsync(ct);
             return ToVersionDto(version);
         }
 
@@ -380,6 +399,7 @@ public sealed partial class PolicyService : IPolicyService
                 "policy.draft.proposed", version.Id, subjectId, rationale, ct)
                 .ConfigureAwait(false);
         }
+        await tx.CommitAsync(ct);
 
         return ToVersionDto(version);
     }
@@ -397,6 +417,8 @@ public sealed partial class PolicyService : IPolicyService
             throw new ValidationException("Rationale is required and may not be empty or whitespace.");
         }
 
+        await using var tx = await _db.Database.BeginTransactionAsync(ct);
+
         var version = await _db.PolicyVersions.FirstOrDefaultAsync(
             v => v.PolicyId == policyId && v.Id == versionId, ct)
             ?? throw new NotFoundException($"PolicyVersion {versionId} not found under policy {policyId}.");
@@ -412,6 +434,7 @@ public sealed partial class PolicyService : IPolicyService
         // we don't write an audit event for the empty transition.
         if (!version.ReadyForReview)
         {
+            await tx.CommitAsync(ct);
             return ToVersionDto(version);
         }
 
@@ -427,6 +450,7 @@ public sealed partial class PolicyService : IPolicyService
                 "policy.draft.rejected", version.Id, subjectId, rationale, ct)
                 .ConfigureAwait(false);
         }
+        await tx.CommitAsync(ct);
 
         return ToVersionDto(version);
     }
@@ -453,6 +477,15 @@ public sealed partial class PolicyService : IPolicyService
             .Take(clampedTake)
             .Select(ToVersionDto)
             .ToList();
+    }
+
+    private void ValidateRationale(string? rationale)
+    {
+        var error = _rationale.ValidateRationale(rationale);
+        if (error is not null)
+        {
+            throw new RationaleRequiredException(error);
+        }
     }
 
     private static PolicyVersionDto ToVersionDto(PolicyVersion v) => new(

--- a/src/Andy.Policies.Infrastructure/Services/ScopeService.cs
+++ b/src/Andy.Policies.Infrastructure/Services/ScopeService.cs
@@ -26,16 +26,33 @@ public sealed class ScopeService : IScopeService
 
     private readonly AppDbContext _db;
     private readonly TimeProvider _clock;
+    private readonly IAuditWriter _audit;
+    private readonly IRationalePolicy _rationale;
 
-    public ScopeService(AppDbContext db, TimeProvider clock)
+    public ScopeService(
+        AppDbContext db,
+        TimeProvider clock,
+        IAuditWriter audit,
+        IRationalePolicy? rationale = null)
     {
         _db = db;
         _clock = clock;
+        _audit = audit;
+        _rationale = rationale ?? new RequireNonEmptyRationalePolicy();
     }
 
-    public async Task<ScopeNodeDto> CreateAsync(CreateScopeNodeRequest request, CancellationToken ct = default)
+    public async Task<ScopeNodeDto> CreateAsync(
+        CreateScopeNodeRequest request,
+        string actorSubjectId,
+        CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrEmpty(actorSubjectId);
+        ValidateRationale(request.Rationale);
+
+        await using var transaction = _db.Database.IsRelational()
+            ? await _db.Database.BeginTransactionAsync(ct).ConfigureAwait(false)
+            : null;
 
         var refValue = (request.Ref ?? string.Empty).Trim();
         if (string.IsNullOrEmpty(refValue))
@@ -114,6 +131,14 @@ public sealed class ScopeService : IScopeService
             throw new ScopeRefConflictException(request.Type, refValue, ex);
         }
 
+        await _audit.AppendAsync(
+            "scope.created", node.Id, actorSubjectId, request.Rationale, ct)
+            .ConfigureAwait(false);
+        if (transaction is not null)
+        {
+            await transaction.CommitAsync(ct).ConfigureAwait(false);
+        }
+
         return ToDto(node);
     }
 
@@ -153,9 +178,18 @@ public sealed class ScopeService : IScopeService
             .ToList();
     }
 
-    public async Task<ScopeNodeDto> UpdateAsync(Guid id, UpdateScopeNodeRequest request, CancellationToken ct = default)
+    public async Task<ScopeNodeDto> UpdateAsync(
+        Guid id,
+        UpdateScopeNodeRequest request,
+        string actorSubjectId,
+        CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrEmpty(actorSubjectId);
+        ValidateRationale(request.Rationale);
+        await using var transaction = _db.Database.IsRelational()
+            ? await _db.Database.BeginTransactionAsync(ct).ConfigureAwait(false)
+            : null;
         var displayName = (request.DisplayName ?? string.Empty).Trim();
         if (string.IsNullOrEmpty(displayName))
         {
@@ -175,11 +209,27 @@ public sealed class ScopeService : IScopeService
         node.DisplayName = displayName;
         node.UpdatedAt = _clock.GetUtcNow();
         await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        await _audit.AppendAsync(
+            "scope.updated", node.Id, actorSubjectId, request.Rationale, ct)
+            .ConfigureAwait(false);
+        if (transaction is not null)
+        {
+            await transaction.CommitAsync(ct).ConfigureAwait(false);
+        }
         return ToDto(node);
     }
 
-    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    public async Task DeleteAsync(
+        Guid id,
+        string actorSubjectId,
+        string? rationale,
+        CancellationToken ct = default)
     {
+        ArgumentException.ThrowIfNullOrEmpty(actorSubjectId);
+        ValidateRationale(rationale);
+        await using var transaction = _db.Database.IsRelational()
+            ? await _db.Database.BeginTransactionAsync(ct).ConfigureAwait(false)
+            : null;
         var node = await _db.ScopeNodes
             .FirstOrDefaultAsync(s => s.Id == id, ct)
             .ConfigureAwait(false)
@@ -195,6 +245,22 @@ public sealed class ScopeService : IScopeService
 
         _db.ScopeNodes.Remove(node);
         await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        await _audit.AppendAsync(
+            "scope.deleted", id, actorSubjectId, rationale, ct)
+            .ConfigureAwait(false);
+        if (transaction is not null)
+        {
+            await transaction.CommitAsync(ct).ConfigureAwait(false);
+        }
+    }
+
+    private void ValidateRationale(string? rationale)
+    {
+        var error = _rationale.ValidateRationale(rationale);
+        if (error is not null)
+        {
+            throw new RationaleRequiredException(error);
+        }
     }
 
     public async Task<IReadOnlyList<ScopeNodeDto>> GetAncestorsAsync(Guid id, CancellationToken ct = default)

--- a/tests/Andy.Policies.Tests.Integration/Authorization/ActorSubjectResolverTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Authorization/ActorSubjectResolverTests.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Security.Claims;
+using Andy.Policies.Api.Authorization;
+using FluentAssertions;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Authorization;
+
+public sealed class ActorSubjectResolverTests
+{
+    [Fact]
+    public void Resolve_UsesCanonicalPrecedenceAndTrimsSubject()
+    {
+        var principal = Principal(
+            (ClaimTypes.NameIdentifier, "  user:name-id  "),
+            ("sub", "user:raw-sub"),
+            (ClaimTypes.Name, "display name"));
+
+        ActorSubjectResolver.Resolve(principal).Should().Be("user:name-id");
+    }
+
+    [Fact]
+    public void Resolve_SkipsBlankMappedClaimAndUsesRawSub()
+    {
+        var principal = Principal(
+            (ClaimTypes.NameIdentifier, "  "),
+            ("sub", "user:raw-sub"),
+            (ClaimTypes.Name, "display name"));
+
+        ActorSubjectResolver.Resolve(principal).Should().Be("user:raw-sub");
+    }
+
+    [Fact]
+    public void Require_RejectsPrincipalWithoutAnyUsableSubject()
+    {
+        var act = () => ActorSubjectResolver.Require(Principal(("groups", "operators")));
+
+        act.Should().Throw<MissingActorSubjectException>();
+    }
+
+    private static ClaimsPrincipal Principal(params (string Type, string Value)[] claims) =>
+        new(new ClaimsIdentity(claims.Select(c => new Claim(c.Type, c.Value)), "test"));
+}

--- a/tests/Andy.Policies.Tests.Integration/Authorization/GrpcPermissionMapCoverageTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Authorization/GrpcPermissionMapCoverageTests.cs
@@ -23,6 +23,7 @@ public class GrpcPermissionMapCoverageTests
     /// <summary>The proto-generated bases for every enforced gRPC service.</summary>
     public static IEnumerable<object[]> EnforcedServiceBases() => new[]
     {
+        new object[] { typeof(ItemsService.ItemsServiceBase) },
         new object[] { typeof(PolicyService.PolicyServiceBase) },
         new object[] { typeof(LifecycleService.LifecycleServiceBase) },
         new object[] { typeof(BindingService.BindingServiceBase) },
@@ -80,14 +81,11 @@ public class GrpcPermissionMapCoverageTests
     }
 
     [Fact]
-    public void ItemsServiceIsBypassedNotMapped()
+    public void ItemsServiceIsMappedAndEnforced()
     {
         var map = new GrpcMethodPermissionMap();
-        // ItemsService ships as template scaffolding; it is intentionally
-        // not enforced. Defend the bypass: no map entries, IsEnforcedService
-        // returns false.
-        map.Entries.Keys.Should().NotContain(k => k.StartsWith("/andy_policies.ItemsService/"));
-        GrpcMethodPermissionMap.IsEnforcedService("/andy_policies.ItemsService/CreateItem").Should().BeFalse();
+        map.Entries.Keys.Should().Contain(k => k.StartsWith("/andy_policies.ItemsService/"));
+        GrpcMethodPermissionMap.IsEnforcedService("/andy_policies.ItemsService/Create").Should().BeTrue();
     }
 
     /// <summary>

--- a/tests/Andy.Policies.Tests.Integration/Controllers/PolicyVersionsLifecycleControllerActorClaimTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Controllers/PolicyVersionsLifecycleControllerActorClaimTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Security.Claims;
+using Andy.Policies.Api.Authorization;
 using Andy.Policies.Api.Controllers;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
@@ -19,9 +20,9 @@ namespace Andy.Policies.Tests.Integration.Controllers;
 /// controller must never write a fallback subject id like <c>"anonymous"</c>
 /// into <c>ILifecycleTransitionService.TransitionAsync</c>; if neither
 /// <c>NameIdentifier</c> (production JWT <c>sub</c>) nor <c>Name</c> (test
-/// principal) is present it must short-circuit to 401 before the service
-/// runs. This test exercises the controller in-process with a fake principal —
-/// the HTTP integration tests cover the happy path through TestAuthHandler.
+/// principal) is present it must throw the canonical missing-actor exception
+/// before the service runs. The global exception handler maps that exception
+/// to HTTP 403; these tests exercise the controller directly.
 /// </summary>
 public class PolicyVersionsLifecycleControllerActorClaimTests
 {
@@ -44,15 +45,15 @@ public class PolicyVersionsLifecycleControllerActorClaimTests
     }
 
     [Fact]
-    public async Task Publish_WithNoSubjectClaims_Returns401_AndDoesNotCallService()
+    public async Task Publish_WithNoSubjectClaims_ThrowsAndDoesNotCallService()
     {
         var anonymous = new ClaimsPrincipal(new ClaimsIdentity());
         var (controller, stub) = Build(anonymous);
 
-        var result = await controller.Publish(
+        var act = () => controller.Publish(
             Guid.NewGuid(), Guid.NewGuid(), new LifecycleTransitionRequest("ship"), CancellationToken.None);
 
-        result.Result.Should().BeOfType<UnauthorizedResult>();
+        await act.Should().ThrowAsync<MissingActorSubjectException>();
         stub.Calls.Should().BeEmpty();
     }
 
@@ -91,28 +92,28 @@ public class PolicyVersionsLifecycleControllerActorClaimTests
     }
 
     [Fact]
-    public async Task Retire_WithNoSubjectClaims_Returns401()
+    public async Task Retire_WithNoSubjectClaims_Throws()
     {
         var anonymous = new ClaimsPrincipal(new ClaimsIdentity());
         var (controller, stub) = Build(anonymous);
 
-        var result = await controller.Retire(
+        var act = () => controller.Retire(
             Guid.NewGuid(), Guid.NewGuid(), new LifecycleTransitionRequest("tomb"), CancellationToken.None);
 
-        result.Result.Should().BeOfType<UnauthorizedResult>();
+        await act.Should().ThrowAsync<MissingActorSubjectException>();
         stub.Calls.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task WindDown_WithNoSubjectClaims_Returns401()
+    public async Task WindDown_WithNoSubjectClaims_Throws()
     {
         var anonymous = new ClaimsPrincipal(new ClaimsIdentity());
         var (controller, stub) = Build(anonymous);
 
-        var result = await controller.WindDown(
+        var act = () => controller.WindDown(
             Guid.NewGuid(), Guid.NewGuid(), new LifecycleTransitionRequest("sunset"), CancellationToken.None);
 
-        result.Result.Should().BeOfType<UnauthorizedResult>();
+        await act.Should().ThrowAsync<MissingActorSubjectException>();
         stub.Calls.Should().BeEmpty();
     }
 

--- a/tests/Andy.Policies.Tests.Integration/Fixtures/MutationTestDoubles.cs
+++ b/tests/Andy.Policies.Tests.Integration/Fixtures/MutationTestDoubles.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+
+namespace Andy.Policies.Infrastructure.Services
+{
+    internal sealed class IntegrationTestAuditWriter : Application.Interfaces.IAuditWriter
+    {
+        public static IntegrationTestAuditWriter Instance { get; } = new();
+
+        public Task AppendAsync(
+            string action,
+            Guid entityId,
+            string actorSubjectId,
+            string? rationale,
+            CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    internal sealed class IntegrationAllowAnyRationalePolicy : Application.Interfaces.IRationalePolicy
+    {
+        public static IntegrationAllowAnyRationalePolicy Instance { get; } = new();
+
+        public bool IsRequired => false;
+
+        public string? ValidateRationale(string? rationale) => null;
+    }
+}
+
+namespace Andy.Policies.Application.Interfaces
+{
+    internal static class ScopeServiceIntegrationTestExtensions
+    {
+        private const string Actor = "test:actor";
+
+        public static Task<ScopeNodeDto> CreateAsync(
+            this IScopeService service,
+            CreateScopeNodeRequest request,
+            CancellationToken ct = default) => service.CreateAsync(request, Actor, ct);
+
+        public static Task<ScopeNodeDto> UpdateAsync(
+            this IScopeService service,
+            Guid id,
+            UpdateScopeNodeRequest request,
+            CancellationToken ct = default) => service.UpdateAsync(id, request, Actor, ct);
+
+        public static Task DeleteAsync(
+            this IScopeService service,
+            Guid id,
+            CancellationToken ct = default) =>
+            service.DeleteAsync(id, Actor, "test rationale", ct);
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/GrpcServices/LifecycleGrpcServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/GrpcServices/LifecycleGrpcServiceTests.cs
@@ -141,7 +141,9 @@ public class LifecycleGrpcServiceTests : IClassFixture<PoliciesApiFactory>, IDis
         var policies = new Andy.Policies.Api.Protos.PolicyService.PolicyServiceClient(localChannel);
 
         var metadata = new Metadata { { TestAuthHandler.SubjectHeader, "test-creator" } };
-        var draft = (await policies.CreateDraftAsync(MinimalCreate(Slug("nora")), metadata)).Version;
+        var create = MinimalCreate(Slug("nora"));
+        create.Rationale = "create test draft";
+        var draft = (await policies.CreateDraftAsync(create, metadata)).Version;
 
         var ex = await Assert.ThrowsAsync<RpcException>(() =>
             lifecycle.PublishVersionAsync(new PublishVersionRequest

--- a/tests/Andy.Policies.Tests.Integration/GrpcServices/RbacInterceptorTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/GrpcServices/RbacInterceptorTests.cs
@@ -218,11 +218,9 @@ public class RbacInterceptorTests
             "guarantee depends on running before");
     }
 
-    // The Items bypass is pinned at the unit level by
-    // GrpcPermissionMapCoverageTests.ItemsServiceIsBypassedNotMapped;
-    // a runtime version would require generating a client stub for items.proto
-    // (it ships GrpcServices="Server" — no client class), and the
-    // interceptor's bypass branch is a single IsEnforcedService check.
+    // Items is included in the reflected permission-map coverage. Its proto
+    // ships server stubs only, so the policy service calls below remain the
+    // representative runtime interceptor checks.
 
     [Fact]
     public async Task EnforcedRpc_AfterAllow_ResponsePassesThroughUnmodified()
@@ -244,6 +242,7 @@ public class RbacInterceptorTests
             Enforcement = "Must",
             Severity = "Critical",
             RulesJson = "{}",
+            Rationale = "verify allowed response",
         });
 
         created.Version.Version.Should().Be(1);

--- a/tests/Andy.Policies.Tests.Integration/Mcp/AuditToolsTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/AuditToolsTests.cs
@@ -84,7 +84,9 @@ public class AuditToolsTests : IDisposable
     {
         await SeedAsync(3);
 
-        var output = await AuditTools.List(_query, NoRetention.Instance, TimeProvider.System);
+        var output = await AuditTools.List(
+            _query, NoRetention.Instance, TimeProvider.System,
+            AccessorFor("test:user"), AllowAllRbac);
 
         var page = JsonSerializer.Deserialize<AuditPageDto>(output, JsonOpts);
         page!.Items.Should().HaveCount(3);
@@ -95,7 +97,9 @@ public class AuditToolsTests : IDisposable
     [Fact]
     public async Task List_PageSizeOutOfRange_ReturnsInvalidArgument()
     {
-        var output = await AuditTools.List(_query, NoRetention.Instance, TimeProvider.System, pageSize: 501);
+        var output = await AuditTools.List(
+            _query, NoRetention.Instance, TimeProvider.System,
+            AccessorFor("test:user"), AllowAllRbac, pageSize: 501);
 
         output.Should().StartWith("policy.audit.invalid_argument:");
         output.Should().Contain("pageSize");
@@ -104,7 +108,9 @@ public class AuditToolsTests : IDisposable
     [Fact]
     public async Task List_BadFromTimestamp_ReturnsInvalidArgument()
     {
-        var output = await AuditTools.List(_query, NoRetention.Instance, TimeProvider.System, from: "not-a-date");
+        var output = await AuditTools.List(
+            _query, NoRetention.Instance, TimeProvider.System,
+            AccessorFor("test:user"), AllowAllRbac, from: "not-a-date");
 
         output.Should().StartWith("policy.audit.invalid_argument:");
     }
@@ -112,7 +118,9 @@ public class AuditToolsTests : IDisposable
     [Fact]
     public async Task List_FromGreaterThanTo_ReturnsInvalidArgument()
     {
-        var output = await AuditTools.List(_query, NoRetention.Instance, TimeProvider.System,
+        var output = await AuditTools.List(
+            _query, NoRetention.Instance, TimeProvider.System,
+            AccessorFor("test:user"), AllowAllRbac,
             from: "2026-12-31T00:00:00Z",
             to: "2026-01-01T00:00:00Z");
 
@@ -122,7 +130,9 @@ public class AuditToolsTests : IDisposable
     [Fact]
     public async Task List_MalformedCursor_ReturnsInvalidArgument()
     {
-        var output = await AuditTools.List(_query, NoRetention.Instance, TimeProvider.System, cursor: "not-base64-content!");
+        var output = await AuditTools.List(
+            _query, NoRetention.Instance, TimeProvider.System,
+            AccessorFor("test:user"), AllowAllRbac, cursor: "not-base64-content!");
 
         output.Should().StartWith("policy.audit.invalid_argument:");
     }
@@ -133,7 +143,9 @@ public class AuditToolsTests : IDisposable
         await SeedAsync(2, actor: "user:alice");
         await SeedAsync(3, actor: "user:bob");
 
-        var output = await AuditTools.List(_query, NoRetention.Instance, TimeProvider.System, actor: "user:alice");
+        var output = await AuditTools.List(
+            _query, NoRetention.Instance, TimeProvider.System,
+            AccessorFor("test:user"), AllowAllRbac, actor: "user:alice");
         var page = JsonSerializer.Deserialize<AuditPageDto>(output, JsonOpts);
 
         page!.Items.Should().HaveCount(2);
@@ -145,14 +157,16 @@ public class AuditToolsTests : IDisposable
     [Fact]
     public async Task Get_BadGuid_ReturnsInvalidArgument()
     {
-        var output = await AuditTools.Get(_query, "not-a-guid");
+        var output = await AuditTools.Get(
+            _query, AccessorFor("test:user"), AllowAllRbac, "not-a-guid");
         output.Should().StartWith("policy.audit.invalid_argument:");
     }
 
     [Fact]
     public async Task Get_UnknownId_ReturnsNotFound()
     {
-        var output = await AuditTools.Get(_query, Guid.NewGuid().ToString());
+        var output = await AuditTools.Get(
+            _query, AccessorFor("test:user"), AllowAllRbac, Guid.NewGuid().ToString());
         output.Should().StartWith("policy.audit.not_found:");
     }
 
@@ -161,10 +175,13 @@ public class AuditToolsTests : IDisposable
     {
         await SeedAsync(1);
         var page = JsonSerializer.Deserialize<AuditPageDto>(
-            await AuditTools.List(_query, NoRetention.Instance, TimeProvider.System), JsonOpts);
+            await AuditTools.List(
+                _query, NoRetention.Instance, TimeProvider.System,
+                AccessorFor("test:user"), AllowAllRbac), JsonOpts);
         var id = page!.Items[0].Id;
 
-        var output = await AuditTools.Get(_query, id.ToString());
+        var output = await AuditTools.Get(
+            _query, AccessorFor("test:user"), AllowAllRbac, id.ToString());
 
         var dto = JsonSerializer.Deserialize<AuditEventDto>(output, JsonOpts);
         dto!.Id.Should().Be(id);

--- a/tests/Andy.Policies.Tests.Integration/Mcp/BindingToolsTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/BindingToolsTests.cs
@@ -46,9 +46,12 @@ public class BindingToolsTests
     {
         var db = NewDb();
         return (
-            new BindingService(db, new NoopAuditWriter(NullLogger<NoopAuditWriter>.Instance), TimeProvider.System),
+            new BindingService(
+                db, new NoopAuditWriter(NullLogger<NoopAuditWriter>.Instance),
+                TimeProvider.System, tightenValidator: null,
+                IntegrationAllowAnyRationalePolicy.Instance),
             new BindingResolver(db),
-            new PolicyService(db),
+            new PolicyService(db, rationale: IntegrationAllowAnyRationalePolicy.Instance),
             db);
     }
 
@@ -176,7 +179,8 @@ public class BindingToolsTests
         await BindingTools.Create(svc, AccessorFor("agent-1"), AllowRbac,
             draft.Id.ToString(), "Repo", "repo:a/x", "Mandatory");
 
-        var output = await BindingTools.List(svc, draft.Id.ToString());
+        var output = await BindingTools.List(
+            svc, AccessorFor("test:user"), AllowRbac, draft.Id.ToString());
 
         output.Should().Contain("1 binding on version");
         output.Should().Contain("Repo=repo:a/x");
@@ -188,7 +192,8 @@ public class BindingToolsTests
     {
         var (svc, _, _, _) = NewServices();
 
-        var output = await BindingTools.List(svc, "not-a-guid");
+        var output = await BindingTools.List(
+            svc, AccessorFor("test:user"), AllowRbac, "not-a-guid");
 
         output.Should().StartWith("Invalid policy version id:");
     }
@@ -230,7 +235,8 @@ public class BindingToolsTests
         await BindingTools.Create(svc, AccessorFor("agent-1"), AllowRbac,
             draft.Id.ToString(), "Template", "template:abc", "Mandatory");
 
-        var output = await BindingTools.Resolve(resolver, "Template", "template:abc");
+        var output = await BindingTools.Resolve(
+            resolver, AccessorFor("test:user"), AllowRbac, "Template", "template:abc");
 
         // Output is JSON; parse it back to confirm the envelope shape.
         using var doc = JsonDocument.Parse(output);
@@ -249,7 +255,8 @@ public class BindingToolsTests
     {
         var (_, resolver, _, _) = NewServices();
 
-        var output = await BindingTools.Resolve(resolver, "Unicorn", "anything");
+        var output = await BindingTools.Resolve(
+            resolver, AccessorFor("test:user"), AllowRbac, "Unicorn", "anything");
 
         output.Should().StartWith("policy.binding.invalid_target:");
     }
@@ -259,7 +266,8 @@ public class BindingToolsTests
     {
         var (_, resolver, _, _) = NewServices();
 
-        var output = await BindingTools.Resolve(resolver, "Template", "  ");
+        var output = await BindingTools.Resolve(
+            resolver, AccessorFor("test:user"), AllowRbac, "Template", "  ");
 
         output.Should().StartWith("policy.binding.invalid_target:");
     }

--- a/tests/Andy.Policies.Tests.Integration/Mcp/BundleToolsTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/BundleToolsTests.cs
@@ -204,7 +204,7 @@ public class BundleToolsTests : IDisposable
         await BundleTools.Delete(svc, AccessorFor("user:op"), AllowAllRbac,
             bundleId: doomedId.ToString(), rationale: "tombstone");
 
-        var output = await BundleTools.List(svc);
+        var output = await BundleTools.List(svc, AccessorFor("test:user"), AllowAllRbac);
 
         var doc = JsonDocument.Parse(output);
         var names = doc.RootElement.EnumerateArray()
@@ -229,7 +229,8 @@ public class BundleToolsTests : IDisposable
         await BundleTools.Delete(svc, AccessorFor("user:op"), AllowAllRbac,
             bundleId: doomedId.ToString(), rationale: "tombstone");
 
-        var output = await BundleTools.List(svc, includeDeleted: true);
+        var output = await BundleTools.List(
+            svc, AccessorFor("test:user"), AllowAllRbac, includeDeleted: true);
 
         var doc = JsonDocument.Parse(output);
         var names = doc.RootElement.EnumerateArray()
@@ -254,7 +255,8 @@ public class BundleToolsTests : IDisposable
         // is the explicit upper bound; without it, an evolving
         // service that raised its MaxPageSize would silently let
         // memory grow.
-        var output = await BundleTools.List(svc, take: 999);
+        var output = await BundleTools.List(
+            svc, AccessorFor("test:user"), AllowAllRbac, take: 999);
 
         output.Should().StartWith("[");
     }
@@ -272,7 +274,8 @@ public class BundleToolsTests : IDisposable
             name: "snap-get", rationale: "x"));
         var bundleId = created.RootElement.GetProperty("id").GetGuid();
 
-        var output = await BundleTools.Get(svc, bundleId.ToString());
+        var output = await BundleTools.Get(
+            svc, AccessorFor("test:user"), AllowAllRbac, bundleId.ToString());
 
         var doc = JsonDocument.Parse(output);
         doc.RootElement.GetProperty("id").GetGuid().Should().Be(bundleId);
@@ -284,7 +287,8 @@ public class BundleToolsTests : IDisposable
         await using var db = await InitDbAsync();
         var svc = NewBundleService(db);
 
-        var output = await BundleTools.Get(svc, Guid.NewGuid().ToString());
+        var output = await BundleTools.Get(
+            svc, AccessorFor("test:user"), AllowAllRbac, Guid.NewGuid().ToString());
 
         output.Should().StartWith("policy.bundle.not_found:");
     }
@@ -295,7 +299,8 @@ public class BundleToolsTests : IDisposable
         await using var db = await InitDbAsync();
         var svc = NewBundleService(db);
 
-        var output = await BundleTools.Get(svc, "not-a-guid");
+        var output = await BundleTools.Get(
+            svc, AccessorFor("test:user"), AllowAllRbac, "not-a-guid");
 
         output.Should().StartWith("policy.bundle.invalid_argument:");
     }
@@ -315,7 +320,8 @@ public class BundleToolsTests : IDisposable
         var bundleId = created.RootElement.GetProperty("id").GetGuid();
 
         var output = await BundleTools.Resolve(
-            resolver, bundleId.ToString(), "Repo", "repo:rivoli-ai/x");
+            resolver, AccessorFor("test:user"), AllowAllRbac,
+            bundleId.ToString(), "Repo", "repo:rivoli-ai/x");
 
         var doc = JsonDocument.Parse(output);
         doc.RootElement.GetProperty("bundleId").GetGuid().Should().Be(bundleId);
@@ -330,7 +336,8 @@ public class BundleToolsTests : IDisposable
         var resolver = NewResolver(db);
 
         var output = await BundleTools.Resolve(
-            resolver, Guid.NewGuid().ToString(), "Repo", "repo:any");
+            resolver, AccessorFor("test:user"), AllowAllRbac,
+            Guid.NewGuid().ToString(), "Repo", "repo:any");
 
         output.Should().StartWith("policy.bundle.not_found:");
     }
@@ -342,7 +349,8 @@ public class BundleToolsTests : IDisposable
         var resolver = NewResolver(db);
 
         var output = await BundleTools.Resolve(
-            resolver, Guid.NewGuid().ToString(), "Unicorn", "ref");
+            resolver, AccessorFor("test:user"), AllowAllRbac,
+            Guid.NewGuid().ToString(), "Unicorn", "ref");
 
         output.Should().StartWith("policy.bundle.invalid_argument:");
     }
@@ -354,7 +362,8 @@ public class BundleToolsTests : IDisposable
         var resolver = NewResolver(db);
 
         var output = await BundleTools.Resolve(
-            resolver, Guid.NewGuid().ToString(), "Repo", "  ");
+            resolver, AccessorFor("test:user"), AllowAllRbac,
+            Guid.NewGuid().ToString(), "Repo", "  ");
 
         output.Should().StartWith("policy.bundle.invalid_argument:");
     }

--- a/tests/Andy.Policies.Tests.Integration/Mcp/McpRbacCoverageTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/McpRbacCoverageTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Reflection;
+using System.Security.Claims;
+using Andy.Policies.Api.Mcp;
+using Andy.Policies.Api.Mcp.Authorization;
+using Andy.Policies.Application.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using ModelContextProtocol.Server;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Mcp;
+
+public sealed class McpRbacCoverageTests
+{
+    [Fact]
+    public void EveryBusinessTool_HasAWellFormedRbacGuard()
+    {
+        var assembly = typeof(PolicyTools).Assembly;
+        var toolTypes = assembly.GetTypes()
+            .Where(t => t.GetCustomAttribute<McpServerToolTypeAttribute>() is not null)
+            .Where(t => t != typeof(HelpTools));
+
+        var unguarded = toolTypes
+            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Where(m => m.GetCustomAttribute<McpServerToolAttribute>() is not null)
+                .Select(m => new { Type = t, Method = m,
+                    Guard = m.GetCustomAttribute<RbacGuardAttribute>() }))
+            .Where(x => x.Guard is null
+                || string.IsNullOrWhiteSpace(x.Guard.PermissionCode)
+                || !x.Guard.PermissionCode.StartsWith("andy-policies:", StringComparison.Ordinal))
+            .Select(x => $"{x.Type.Name}.{x.Method.Name}")
+            .OrderBy(x => x)
+            .ToList();
+
+        unguarded.Should().BeEmpty(
+            "every catalog/audit MCP tool must declare its permission; HelpTools is the sole public-content allowlist");
+    }
+
+    [Fact]
+    public async Task RbacDependencyException_FailsClosedWithStableDenial()
+    {
+        var context = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim("sub", "user:alice") }, "test")),
+        };
+        var accessor = new HttpContextAccessor { HttpContext = context };
+
+        var denial = await McpRbacGuard.GetDenialAsync(
+            new ThrowingRbac(), accessor, "andy-policies:audit:read",
+            "policy.audit", null, CancellationToken.None);
+
+        denial.Should().Be("policy.audit.forbidden: rbac-unavailable");
+    }
+
+    private sealed class ThrowingRbac : IRbacChecker
+    {
+        public Task<RbacDecision> CheckAsync(
+            string subjectId,
+            string permissionCode,
+            IReadOnlyList<string> groups,
+            string? resourceInstanceId,
+            CancellationToken ct) => throw new HttpRequestException("dependency unavailable");
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Mcp/OverrideToolsRbacTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/OverrideToolsRbacTests.cs
@@ -98,7 +98,9 @@ public class OverrideToolsRbacTests
         // this test class targets). Hand it an unconditional allow stub
         // so we isolate the *MCP* guard signal we're measuring.
         var serviceLayerAllow = new RecordingRbac();
-        var service = new OverrideService(db, serviceLayerAllow, new NoopDispatcher(), TimeProvider.System);
+        var service = new OverrideService(
+            db, serviceLayerAllow, new NoopDispatcher(), TimeProvider.System,
+            rationale: IntegrationAllowAnyRationalePolicy.Instance);
         return (service, db, new StubGate { IsEnabled = true });
     }
 

--- a/tests/Andy.Policies.Tests.Integration/Mcp/OverrideToolsTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/OverrideToolsTests.cs
@@ -78,7 +78,9 @@ public class OverrideToolsTests
     private static (OverrideService service, AppDbContext db, StubGate gate) NewServices()
     {
         var db = NewDb();
-        var service = new OverrideService(db, new AllowRbac(), new NoopDispatcher(), TimeProvider.System);
+        var service = new OverrideService(
+            db, new AllowRbac(), new NoopDispatcher(), TimeProvider.System,
+            rationale: IntegrationAllowAnyRationalePolicy.Instance);
         return (service, db, new StubGate { IsEnabled = true });
     }
 
@@ -322,7 +324,8 @@ public class OverrideToolsTests
         await SeedProposedAsync(svc, db);
         gate.IsEnabled = false;
 
-        var output = await OverrideTools.List(svc);
+        var output = await OverrideTools.List(
+            svc, AccessorFor("test:user"), AllowRbacInstance);
 
         // Read tools don't take the gate; output is JSON array.
         output.TrimStart().Should().StartWith("[");
@@ -338,7 +341,8 @@ public class OverrideToolsTests
         await SeedProposedAsync(svc, db, scopeRef: "user:2");
         await svc.ApproveAsync(a.Id, "user:approver");
 
-        var output = await OverrideTools.List(svc, state: "Approved");
+        var output = await OverrideTools.List(
+            svc, AccessorFor("test:user"), AllowRbacInstance, state: "Approved");
         var rows = JsonSerializer.Deserialize<List<OverrideDto>>(output, JsonOptions);
 
         rows.Should().ContainSingle().Which.Id.Should().Be(a.Id);
@@ -349,7 +353,8 @@ public class OverrideToolsTests
     {
         var (svc, _, _) = NewServices();
 
-        var output = await OverrideTools.Get(svc, Guid.NewGuid().ToString());
+        var output = await OverrideTools.Get(
+            svc, AccessorFor("test:user"), AllowRbacInstance, Guid.NewGuid().ToString());
 
         output.Should().StartWith("policy.override.not_found:");
     }
@@ -363,7 +368,8 @@ public class OverrideToolsTests
         await SeedProposedAsync(svc, db, scopeRef: "user:42"); // proposed only — should NOT appear
 
         gate.IsEnabled = false;
-        var output = await OverrideTools.Active(svc, "Principal", "user:42");
+        var output = await OverrideTools.Active(
+            svc, AccessorFor("test:user"), AllowRbacInstance, "Principal", "user:42");
         gate.IsEnabled = true;
 
         var rows = JsonSerializer.Deserialize<List<OverrideDto>>(output, JsonOptions);
@@ -375,7 +381,8 @@ public class OverrideToolsTests
     {
         var (svc, _, _) = NewServices();
 
-        var output = await OverrideTools.Active(svc, "NotAScope", "user:42");
+        var output = await OverrideTools.Active(
+            svc, AccessorFor("test:user"), AllowRbacInstance, "NotAScope", "user:42");
 
         output.Should().StartWith("policy.override.invalid_argument:");
     }

--- a/tests/Andy.Policies.Tests.Integration/Mcp/PolicyLifecycleToolsTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/PolicyLifecycleToolsTests.cs
@@ -62,7 +62,8 @@ public class PolicyLifecycleToolsTests
             new RequireNonEmptyRationalePolicy(),
             new NoopDispatcher(),
             TimeProvider.System);
-        return (new PolicyService(db), lifecycle, db);
+        return (new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance), lifecycle, db);
     }
 
     private static IHttpContextAccessor AccessorFor(string? subjectId)
@@ -226,11 +227,12 @@ public class PolicyLifecycleToolsTests
     }
 
     [Fact]
-    public void Matrix_ReturnsTheFourCanonicalRules()
+    public async Task Matrix_ReturnsTheFourCanonicalRules()
     {
         var (_, lifecycle, _) = NewServices();
 
-        var output = PolicyLifecycleTools.Matrix(lifecycle);
+        var output = await PolicyLifecycleTools.Matrix(
+            lifecycle, AccessorFor("test:user"), AllowRbac);
 
         output.Should().Contain("4 allowed transitions:");
         output.Should().Contain("Draft -> Active (Publish)");

--- a/tests/Andy.Policies.Tests.Integration/Mcp/PolicyToolsTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/PolicyToolsTests.cs
@@ -6,9 +6,12 @@ using Andy.Policies.Application.Dtos;
 using Andy.Policies.Domain.Enums;
 using Andy.Policies.Infrastructure.Data;
 using Andy.Policies.Infrastructure.Services;
+using Andy.Policies.Tests.Integration.Fixtures;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Xunit;
+
+using static Andy.Policies.Tests.Integration.Fixtures.McpToolStubs;
 
 namespace Andy.Policies.Tests.Integration.Mcp;
 
@@ -45,9 +48,11 @@ public class PolicyToolsTests
     public async Task ListPolicies_NoMatches_ReturnsHelpfulEmptyMessage()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance);
 
-        var output = await PolicyTools.ListPolicies(service, namePrefix: "no-such-");
+        var output = await PolicyTools.ListPolicies(
+            service, AccessorFor("test:user"), AllowAllRbac, namePrefix: "no-such-");
 
         Assert.Contains("No policies found", output);
     }
@@ -56,11 +61,12 @@ public class PolicyToolsTests
     public async Task ListPolicies_FormatsSummaryLine_PerPolicy()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance);
         await service.CreateDraftAsync(MinimalCreate("first"), "sam");
         await service.CreateDraftAsync(MinimalCreate("second"), "sam");
 
-        var output = await PolicyTools.ListPolicies(service);
+        var output = await PolicyTools.ListPolicies(service, AccessorFor("test:user"), AllowAllRbac);
 
         Assert.Contains("2 policies:", output);
         Assert.Contains("first", output);
@@ -73,14 +79,16 @@ public class PolicyToolsTests
     public async Task ListPolicies_PassesFiltersThrough_ToService()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance);
         var a = await service.CreateDraftAsync(MinimalCreate("filtered", scope: "prod"), "sam");
         await service.CreateDraftAsync(MinimalCreate("ignored", scope: "staging"), "sam");
         var entity = await db.PolicyVersions.FirstAsync(v => v.Id == a.Id);
         entity.State = LifecycleState.Active;
         await db.SaveChangesAsync();
 
-        var output = await PolicyTools.ListPolicies(service, scope: "prod");
+        var output = await PolicyTools.ListPolicies(
+            service, AccessorFor("test:user"), AllowAllRbac, scope: "prod");
 
         Assert.Contains("filtered", output);
         Assert.DoesNotContain("ignored", output);
@@ -90,9 +98,11 @@ public class PolicyToolsTests
     public async Task GetPolicy_InvalidGuid_ReturnsValidationMessage_WithoutCallingService()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance);
 
-        var output = await PolicyTools.GetPolicy(service, policyId: "not-a-guid");
+        var output = await PolicyTools.GetPolicy(
+            service, AccessorFor("test:user"), AllowAllRbac, policyId: "not-a-guid");
 
         Assert.Contains("not a valid GUID", output);
     }
@@ -101,10 +111,12 @@ public class PolicyToolsTests
     public async Task GetPolicy_NotFound_ReturnsHelpfulMessage()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance);
         var missing = Guid.NewGuid();
 
-        var output = await PolicyTools.GetPolicy(service, missing.ToString());
+        var output = await PolicyTools.GetPolicy(
+            service, AccessorFor("test:user"), AllowAllRbac, missing.ToString());
 
         Assert.Contains($"Policy {missing} not found", output);
     }
@@ -113,10 +125,12 @@ public class PolicyToolsTests
     public async Task GetPolicy_Found_FormatsDetail()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance);
         var v = await service.CreateDraftAsync(MinimalCreate("detail-policy"), "sam");
 
-        var output = await PolicyTools.GetPolicy(service, v.PolicyId.ToString());
+        var output = await PolicyTools.GetPolicy(
+            service, AccessorFor("test:user"), AllowAllRbac, v.PolicyId.ToString());
 
         Assert.Contains("Policy: detail-policy", output);
         Assert.Contains("Versions: 1", output);
@@ -127,14 +141,16 @@ public class PolicyToolsTests
     public async Task ListVersions_ReturnsDescendingOrder_WithStateAndDimensions()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance);
         var v1 = await service.CreateDraftAsync(MinimalCreate("multi-version"), "sam");
         var entity = await db.PolicyVersions.FirstAsync(x => x.Id == v1.Id);
         entity.State = LifecycleState.Active;
         await db.SaveChangesAsync();
         var v2 = await service.BumpDraftFromVersionAsync(v1.PolicyId, v1.Id, "alice");
 
-        var output = await PolicyTools.ListVersions(service, v1.PolicyId.ToString());
+        var output = await PolicyTools.ListVersions(
+            service, AccessorFor("test:user"), AllowAllRbac, v1.PolicyId.ToString());
 
         Assert.Contains("2 versions", output);
         // v2 (Draft) appears before v1 (Active) — descending order.
@@ -150,9 +166,11 @@ public class PolicyToolsTests
     public async Task ListVersions_NoSuchPolicy_ReturnsHelpfulEmptyMessage()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance);
 
-        var output = await PolicyTools.ListVersions(service, Guid.NewGuid().ToString());
+        var output = await PolicyTools.ListVersions(
+            service, AccessorFor("test:user"), AllowAllRbac, Guid.NewGuid().ToString());
 
         Assert.Contains("No versions found", output);
     }
@@ -161,12 +179,15 @@ public class PolicyToolsTests
     public async Task GetVersion_Found_FormatsRulesJsonAndScopes()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance);
         var v = await service.CreateDraftAsync(
             MinimalCreate("rich-version", scope: "prod") with { RulesJson = "{\"allow\":true}" },
             "sam");
 
-        var output = await PolicyTools.GetVersion(service, v.PolicyId.ToString(), v.Id.ToString());
+        var output = await PolicyTools.GetVersion(
+            service, AccessorFor("test:user"), AllowAllRbac,
+            v.PolicyId.ToString(), v.Id.ToString());
 
         Assert.Contains($"v{v.Version} of policy {v.PolicyId}", output);
         Assert.Contains("State: Draft", output);
@@ -180,12 +201,14 @@ public class PolicyToolsTests
     public async Task GetVersion_NotFound_ReturnsHelpfulMessage()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance);
         var missingPolicy = Guid.NewGuid();
         var missingVersion = Guid.NewGuid();
 
         var output = await PolicyTools.GetVersion(
-            service, missingPolicy.ToString(), missingVersion.ToString());
+            service, AccessorFor("test:user"), AllowAllRbac,
+            missingPolicy.ToString(), missingVersion.ToString());
 
         Assert.Contains("not found", output);
     }
@@ -194,10 +217,12 @@ public class PolicyToolsTests
     public async Task GetActiveVersion_AllDraft_ReturnsHelpfulMessage()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance);
         var v = await service.CreateDraftAsync(MinimalCreate("only-draft"), "sam");
 
-        var output = await PolicyTools.GetActiveVersion(service, v.PolicyId.ToString());
+        var output = await PolicyTools.GetActiveVersion(
+            service, AccessorFor("test:user"), AllowAllRbac, v.PolicyId.ToString());
 
         Assert.Contains("no active version", output);
     }
@@ -206,13 +231,15 @@ public class PolicyToolsTests
     public async Task GetActiveVersion_AfterTransition_ResolvesAndFormatsDetail()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance);
         var v = await service.CreateDraftAsync(MinimalCreate("active-flow"), "sam");
         var entity = await db.PolicyVersions.FirstAsync(x => x.Id == v.Id);
         entity.State = LifecycleState.Active;
         await db.SaveChangesAsync();
 
-        var output = await PolicyTools.GetActiveVersion(service, v.PolicyId.ToString());
+        var output = await PolicyTools.GetActiveVersion(
+            service, AccessorFor("test:user"), AllowAllRbac, v.PolicyId.ToString());
 
         Assert.Contains($"v{v.Version} of policy {v.PolicyId}", output);
         Assert.Contains("State: Active", output);
@@ -222,17 +249,20 @@ public class PolicyToolsTests
     public async Task AllToolsTakingGuidArguments_RejectMalformedInput_BeforeServiceCall()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance);
 
         Assert.Contains("not a valid GUID",
-            await PolicyTools.GetPolicy(service, "abc"));
+            await PolicyTools.GetPolicy(service, AccessorFor("test:user"), AllowAllRbac, "abc"));
         Assert.Contains("not a valid GUID",
-            await PolicyTools.ListVersions(service, "abc"));
+            await PolicyTools.ListVersions(service, AccessorFor("test:user"), AllowAllRbac, "abc"));
         Assert.Contains("not a valid GUID",
-            await PolicyTools.GetActiveVersion(service, "abc"));
+            await PolicyTools.GetActiveVersion(service, AccessorFor("test:user"), AllowAllRbac, "abc"));
         Assert.Contains("not a valid GUID",
-            await PolicyTools.GetVersion(service, "abc", Guid.NewGuid().ToString()));
+            await PolicyTools.GetVersion(
+                service, AccessorFor("test:user"), AllowAllRbac, "abc", Guid.NewGuid().ToString()));
         Assert.Contains("not a valid GUID",
-            await PolicyTools.GetVersion(service, Guid.NewGuid().ToString(), "abc"));
+            await PolicyTools.GetVersion(
+                service, AccessorFor("test:user"), AllowAllRbac, Guid.NewGuid().ToString(), "abc"));
     }
 }

--- a/tests/Andy.Policies.Tests.Integration/Mcp/ScopeToolsTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Mcp/ScopeToolsTests.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using Andy.Policies.Api.Mcp;
 using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Domain.Enums;
 using Andy.Policies.Infrastructure.Data;
 using Andy.Policies.Infrastructure.Services;
@@ -41,7 +42,9 @@ public class ScopeToolsTests
     private static (ScopeService scopes, BindingResolutionService resolver, AppDbContext db) NewServices()
     {
         var db = NewDb();
-        var scopes = new ScopeService(db, TimeProvider.System);
+        var scopes = new ScopeService(
+            db, TimeProvider.System, IntegrationTestAuditWriter.Instance,
+            IntegrationAllowAnyRationalePolicy.Instance);
         var resolver = new BindingResolutionService(db, scopes);
         return (scopes, resolver, db);
     }
@@ -51,7 +54,7 @@ public class ScopeToolsTests
     {
         var (scopes, _, _) = NewServices();
 
-        var output = await ScopeTools.List(scopes);
+        var output = await ScopeTools.List(scopes, AccessorFor("test:user"), AllowAllRbac);
 
         output.Should().Contain("No scope nodes");
     }
@@ -62,7 +65,8 @@ public class ScopeToolsTests
         var (scopes, _, _) = NewServices();
         await scopes.CreateAsync(new CreateScopeNodeRequest(null, ScopeType.Org, "org:t-list", "T"));
 
-        var output = await ScopeTools.List(scopes, type: "Org");
+        var output = await ScopeTools.List(
+            scopes, AccessorFor("test:user"), AllowAllRbac, type: "Org");
 
         output.Should().Contain("1 scope node:");
         output.Should().Contain("[Org@0]");
@@ -74,7 +78,8 @@ public class ScopeToolsTests
     {
         var (scopes, _, _) = NewServices();
 
-        var output = await ScopeTools.List(scopes, type: "Unicorn");
+        var output = await ScopeTools.List(
+            scopes, AccessorFor("test:user"), AllowAllRbac, type: "Unicorn");
 
         output.Should().StartWith("policy.scope.invalid_input:");
     }
@@ -85,8 +90,10 @@ public class ScopeToolsTests
         var (scopes, _, _) = NewServices();
         var dto = await scopes.CreateAsync(new CreateScopeNodeRequest(null, ScopeType.Org, "org:t-get", "T"));
 
-        var hit = await ScopeTools.Get(scopes, dto.Id.ToString());
-        var miss = await ScopeTools.Get(scopes, Guid.NewGuid().ToString());
+        var hit = await ScopeTools.Get(
+            scopes, AccessorFor("test:user"), AllowAllRbac, dto.Id.ToString());
+        var miss = await ScopeTools.Get(
+            scopes, AccessorFor("test:user"), AllowAllRbac, Guid.NewGuid().ToString());
 
         hit.Should().Contain($"ScopeNode {dto.Id}");
         miss.Should().StartWith("policy.scope.not_found:");
@@ -97,7 +104,8 @@ public class ScopeToolsTests
     {
         var (scopes, _, _) = NewServices();
 
-        var output = await ScopeTools.Get(scopes, "not-a-guid");
+        var output = await ScopeTools.Get(
+            scopes, AccessorFor("test:user"), AllowAllRbac, "not-a-guid");
 
         output.Should().StartWith("policy.scope.invalid_input:");
     }
@@ -109,7 +117,7 @@ public class ScopeToolsTests
         var org = await scopes.CreateAsync(new CreateScopeNodeRequest(null, ScopeType.Org, "org:t-tree", "T"));
         await scopes.CreateAsync(new CreateScopeNodeRequest(org.Id, ScopeType.Tenant, "tenant:t-tree", "Tn"));
 
-        var output = await ScopeTools.Tree(scopes);
+        var output = await ScopeTools.Tree(scopes, AccessorFor("test:user"), AllowAllRbac);
 
         using var doc = JsonDocument.Parse(output);
         doc.RootElement.GetArrayLength().Should().Be(1);
@@ -207,7 +215,8 @@ public class ScopeToolsTests
         var (scopes, resolver, _) = NewServices();
         var dto = await scopes.CreateAsync(new CreateScopeNodeRequest(null, ScopeType.Org, "org:t-eff", "Eff"));
 
-        var output = await ScopeTools.Effective(resolver, dto.Id.ToString());
+        var output = await ScopeTools.Effective(
+            resolver, AccessorFor("test:user"), AllowAllRbac, dto.Id.ToString());
 
         using var doc = JsonDocument.Parse(output);
         doc.RootElement.GetProperty("scopeNodeId").GetString().Should().Be(dto.Id.ToString());
@@ -219,7 +228,8 @@ public class ScopeToolsTests
     {
         var (_, resolver, _) = NewServices();
 
-        var output = await ScopeTools.Effective(resolver, Guid.NewGuid().ToString());
+        var output = await ScopeTools.Effective(
+            resolver, AccessorFor("test:user"), AllowAllRbac, Guid.NewGuid().ToString());
 
         output.Should().StartWith("policy.scope.not_found:");
     }

--- a/tests/Andy.Policies.Tests.Integration/OpenApi/OpenApiSnapshotExportTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/OpenApi/OpenApiSnapshotExportTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Tests.Integration.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Writers;
+using Swashbuckle.AspNetCore.Swagger;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.OpenApi;
+
+/// <summary>
+/// Deterministic export entry point used by scripts/export-openapi.sh. Resolving
+/// ISwaggerProvider from the already-supported test host avoids the CLI tool
+/// waiting on production hosted services during design-time startup.
+/// </summary>
+public sealed class OpenApiSnapshotExportTests : IClassFixture<PoliciesApiFactory>
+{
+    private readonly PoliciesApiFactory _factory;
+
+    public OpenApiSnapshotExportTests(PoliciesApiFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task ExportYaml_WhenExplicitlyRequested()
+    {
+        if (!string.Equals(Environment.GetEnvironmentVariable("UPDATE_OPENAPI"), "1",
+                StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        using var scope = _factory.Services.CreateScope();
+        var provider = scope.ServiceProvider.GetRequiredService<ISwaggerProvider>();
+        var document = provider.GetSwagger("v1");
+        var repoRoot = FindRepoRoot();
+        var output = Path.Combine(repoRoot, "docs", "openapi", "andy-policies-v1.yaml");
+        await using var stream = File.CreateText(output);
+        var writer = new OpenApiYamlWriter(stream);
+        document.SerializeAsV3(writer);
+        await stream.FlushAsync();
+    }
+
+    private static string FindRepoRoot()
+    {
+        var cursor = new DirectoryInfo(AppContext.BaseDirectory);
+        while (cursor is not null && !File.Exists(Path.Combine(cursor.FullName, "Andy.Policies.sln")))
+        {
+            cursor = cursor.Parent;
+        }
+        return cursor?.FullName
+            ?? throw new InvalidOperationException("Could not locate repository root.");
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Parity/BindingCrossSurfaceParityTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Parity/BindingCrossSurfaceParityTests.cs
@@ -18,6 +18,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+
+using static Andy.Policies.Tests.Integration.Fixtures.McpToolStubs;
 using ProtoBindStrength = Andy.Policies.Api.Protos.BindStrength;
 using DomainBindStrength = Andy.Policies.Domain.Enums.BindStrength;
 using RestResolveBindingsResponse = Andy.Policies.Application.Dtos.ResolveBindingsResponse;
@@ -165,7 +167,8 @@ public class BindingCrossSurfaceParityTests : IClassFixture<PoliciesApiFactory>,
         // we deserialize and compare structurally to the REST shape.
         using var scope = _factory.Services.CreateScope();
         var resolver = scope.ServiceProvider.GetRequiredService<IBindingResolver>();
-        var mcpJson = await BindingTools.Resolve(resolver, "Repo", target);
+        var mcpJson = await BindingTools.Resolve(
+            resolver, AccessorFor("test:user"), AllowAllRbac, "Repo", target);
         using var mcpDoc = JsonDocument.Parse(mcpJson);
 
         // Counts match.

--- a/tests/Andy.Policies.Tests.Integration/Parity/CrossSurfaceParityTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Parity/CrossSurfaceParityTests.cs
@@ -7,11 +7,14 @@ using Andy.Policies.Api.Protos;
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Tests.Integration.Controllers;
+using Andy.Policies.Tests.Integration.Fixtures;
 using FluentAssertions;
 using Grpc.Net.Client;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+
+using static Andy.Policies.Tests.Integration.Fixtures.McpToolStubs;
 
 namespace Andy.Policies.Tests.Integration.Parity;
 
@@ -85,7 +88,8 @@ public class CrossSurfaceParityTests : IClassFixture<PoliciesApiFactory>
 
         using var scope = _factory.Services.CreateScope();
         var service = scope.ServiceProvider.GetRequiredService<IPolicyService>();
-        var mcp = await PolicyTools.GetPolicy(service, seeded.Id.ToString());
+        var mcp = await PolicyTools.GetPolicy(
+            service, AccessorFor("test:user"), AllowAllRbac, seeded.Id.ToString());
 
         rest.Should().NotBeNull();
         mcp.Should().Contain(rest!.Name);
@@ -136,7 +140,8 @@ public class CrossSurfaceParityTests : IClassFixture<PoliciesApiFactory>
 
         using var scope = _factory.Services.CreateScope();
         var service = scope.ServiceProvider.GetRequiredService<IPolicyService>();
-        var mcp = await PolicyTools.GetActiveVersion(service, seeded.Id.ToString());
+        var mcp = await PolicyTools.GetActiveVersion(
+            service, AccessorFor("test:user"), AllowAllRbac, seeded.Id.ToString());
         mcp.Should().Contain("no active version");
     }
 }

--- a/tests/Andy.Policies.Tests.Integration/Perf/ScopeWalkPerfTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Perf/ScopeWalkPerfTests.cs
@@ -109,7 +109,9 @@ public class ScopeWalkPerfTests : IAsyncLifetime
 
     private static (ScopeService scopes, BindingResolutionService resolver, AppDbContext db) NewServices(AppDbContext db)
     {
-        var scopes = new ScopeService(db, TimeProvider.System);
+        var scopes = new ScopeService(
+            db, TimeProvider.System, IntegrationTestAuditWriter.Instance,
+            IntegrationAllowAnyRationalePolicy.Instance);
         var resolver = new BindingResolutionService(db, scopes);
         return (scopes, resolver, db);
     }

--- a/tests/Andy.Policies.Tests.Integration/PlanEvaluation/HttpTasksPlanClientContractTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/PlanEvaluation/HttpTasksPlanClientContractTests.cs
@@ -87,6 +87,7 @@ public sealed class HttpTasksPlanClientContractTests : IDisposable
                     },
                     "suggestedAgentIds": ["coder", "reviewer"],
                     "executorId": null
+                    ,"targetEnv": "dev"
                   }
                 ]
                 """));
@@ -130,6 +131,39 @@ public sealed class HttpTasksPlanClientContractTests : IDisposable
         view.Tasks[0].EffectiveAgentId.Should().Be("coder",
             "with no executor pinned, the top suggested agent wins");
         view.Tasks[0].ToolsAllowed.Should().BeEquivalentTo("read-file", "search-code");
+        view.Tasks[0].TargetEnv.Should().Be("dev");
+    }
+
+    [Fact]
+    public async Task Preserves_missing_null_empty_and_populated_task_contract_fields()
+    {
+        var goalId = Guid.NewGuid();
+        var ids = Enumerable.Range(0, 4).Select(_ => Guid.NewGuid()).ToArray();
+        StubGoal(goalId, planVersion: "1");
+        _server
+            .Given(Request.Create().WithPath($"/api/goals/{goalId:D}/tasks").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody($$"""
+                [
+                  { "id": "{{ids[0]}}" },
+                  { "id": "{{ids[1]}}", "delegationContract": { "toolsAllowed": null }, "targetEnv": null },
+                  { "id": "{{ids[2]}}", "delegationContract": { "toolsAllowed": [] }, "targetEnv": "" },
+                  { "id": "{{ids[3]}}", "delegationContract": { "toolsAllowed": ["read-file"] }, "targetEnv": "prod" }
+                ]
+                """));
+        StubEstimates(goalId, null);
+
+        var tasks = (await NewClient().FetchGoalViewAsync(goalId))!.Tasks;
+
+        tasks[0].ToolsAllowed.Should().BeNull();
+        tasks[0].TargetEnv.Should().BeNull();
+        tasks[1].ToolsAllowed.Should().BeNull();
+        tasks[1].TargetEnv.Should().BeNull();
+        tasks[2].ToolsAllowed.Should().BeEmpty();
+        tasks[2].TargetEnv.Should().BeEmpty();
+        tasks[3].ToolsAllowed.Should().Equal("read-file");
+        tasks[3].TargetEnv.Should().Be("prod");
     }
 
     [Fact]

--- a/tests/Andy.Policies.Tests.Integration/Services/BindingConcurrencyStressTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Services/BindingConcurrencyStressTests.cs
@@ -70,7 +70,9 @@ public class BindingConcurrencyStressTests : IAsyncLifetime
             .Options);
 
     private static BindingService NewService(AppDbContext db) =>
-        new(db, new NoopAuditWriter(NullLogger<NoopAuditWriter>.Instance), TimeProvider.System);
+        new(db, new NoopAuditWriter(NullLogger<NoopAuditWriter>.Instance),
+            TimeProvider.System, tightenValidator: null,
+            IntegrationAllowAnyRationalePolicy.Instance);
 
     [SkippableFact]
     public async Task FiftyParallelCreates_AgainstSameTarget_AllSucceed_NoDeadlocks()

--- a/tests/Andy.Policies.Tests.Integration/Services/MutationAuditAtomicityTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Services/MutationAuditAtomicityTests.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Application.Interfaces;
+using Andy.Policies.Domain.Entities;
+using Andy.Policies.Domain.Enums;
+using Andy.Policies.Infrastructure.Data;
+using Andy.Policies.Infrastructure.Services;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Andy.Policies.Tests.Integration.Services;
+
+public sealed class MutationAuditAtomicityTests
+{
+    [Fact]
+    public async Task PolicyCreate_AuditFailureRollsBackState()
+    {
+        await using var fixture = await SqliteFixture.CreateAsync();
+        var service = new PolicyService(
+            fixture.Db, new ThrowingAuditWriter(), IntegrationAllowAnyRationalePolicy.Instance);
+
+        var act = () => service.CreateDraftAsync(new CreatePolicyRequest(
+            "atomic-policy", null, "summary", "Must", "Critical",
+            Array.Empty<string>(), "{}", "test rationale"), "user:alice");
+
+        await act.Should().ThrowAsync<AuditFailureException>();
+        fixture.Db.ChangeTracker.Clear();
+        (await fixture.Db.Policies.CountAsync()).Should().Be(0);
+        (await fixture.Db.PolicyVersions.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task BindingCreate_AuditFailureRollsBackState()
+    {
+        await using var fixture = await SqliteFixture.CreateAsync();
+        var version = await SeedVersionAsync(fixture.Db);
+        var service = new BindingService(
+            fixture.Db, new ThrowingAuditWriter(), TimeProvider.System,
+            null, IntegrationAllowAnyRationalePolicy.Instance);
+
+        var act = () => service.CreateAsync(new CreateBindingRequest(
+            version.Id, BindingTargetType.Repo, "repo:acme/svc",
+            BindStrength.Mandatory, "test rationale"), "user:alice");
+
+        await act.Should().ThrowAsync<AuditFailureException>();
+        fixture.Db.ChangeTracker.Clear();
+        (await fixture.Db.Bindings.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ScopeCreate_AuditFailureRollsBackState()
+    {
+        await using var fixture = await SqliteFixture.CreateAsync();
+        var service = new ScopeService(
+            fixture.Db, TimeProvider.System, new ThrowingAuditWriter(),
+            IntegrationAllowAnyRationalePolicy.Instance);
+
+        var act = () => service.CreateAsync(new CreateScopeNodeRequest(
+            null, ScopeType.Org, "org:acme", "Acme", "test rationale"), "user:alice");
+
+        await act.Should().ThrowAsync<AuditFailureException>();
+        fixture.Db.ChangeTracker.Clear();
+        (await fixture.Db.ScopeNodes.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItemCreate_AuditFailureRollsBackState()
+    {
+        await using var fixture = await SqliteFixture.CreateAsync();
+        var service = new ItemService(
+            fixture.Db, new ThrowingAuditWriter(), IntegrationAllowAnyRationalePolicy.Instance);
+
+        var act = () => service.CreateAsync(
+            new CreateItemRequest("item", "description", "test rationale"), "user:alice");
+
+        await act.Should().ThrowAsync<AuditFailureException>();
+        fixture.Db.ChangeTracker.Clear();
+        (await fixture.Db.Items.CountAsync()).Should().Be(0);
+    }
+
+    private static async Task<PolicyVersion> SeedVersionAsync(AppDbContext db)
+    {
+        var policy = new Policy { Id = Guid.NewGuid(), Name = "seed", CreatedBySubjectId = "test" };
+        var version = new PolicyVersion
+        {
+            Id = Guid.NewGuid(), PolicyId = policy.Id, Version = 1,
+            State = LifecycleState.Active, Enforcement = EnforcementLevel.Must,
+            Severity = Severity.Critical, Scopes = new List<string>(),
+            Summary = "seed", RulesJson = "{}", CreatedBySubjectId = "test",
+            ProposerSubjectId = "test",
+        };
+        db.AddRange(policy, version);
+        await db.SaveChangesAsync();
+        return version;
+    }
+
+    private sealed class ThrowingAuditWriter : IAuditWriter
+    {
+        public Task AppendAsync(string action, Guid entityId, string actorSubjectId,
+            string? rationale, CancellationToken ct = default) =>
+            throw new AuditFailureException();
+    }
+
+    private sealed class AuditFailureException : Exception;
+
+    private sealed class SqliteFixture : IAsyncDisposable
+    {
+        private readonly SqliteConnection _connection;
+        public AppDbContext Db { get; }
+
+        private SqliteFixture(SqliteConnection connection, AppDbContext db)
+        {
+            _connection = connection;
+            Db = db;
+        }
+
+        public static async Task<SqliteFixture> CreateAsync()
+        {
+            var connection = new SqliteConnection("Data Source=:memory:");
+            await connection.OpenAsync();
+            var db = new AppDbContext(new DbContextOptionsBuilder<AppDbContext>()
+                .UseSqlite(connection).Options);
+            await db.Database.EnsureCreatedAsync();
+            return new SqliteFixture(connection, db);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Db.DisposeAsync();
+            await _connection.DisposeAsync();
+        }
+    }
+}

--- a/tests/Andy.Policies.Tests.Integration/Services/PolicyServicePersistenceTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Services/PolicyServicePersistenceTests.cs
@@ -55,7 +55,8 @@ public class PolicyServicePersistenceTests : IDisposable
     public async Task CreateDraftAsync_PersistsBothPolicyAndFirstVersion()
     {
         using var db = NewContext();
-        var service = new PolicyService(db);
+        var service = new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance);
 
         var dto = await service.CreateDraftAsync(MinimalCreate("persistence"), "sam");
 
@@ -70,7 +71,8 @@ public class PolicyServicePersistenceTests : IDisposable
     public async Task CreateDraftAsync_OnSlugConflict_DoesNotLeakRows()
     {
         using var db = NewContext();
-        var service = new PolicyService(db);
+        var service = new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance);
         await service.CreateDraftAsync(MinimalCreate("same-slug"), "sam");
 
         await Assert.ThrowsAsync<ConflictException>(
@@ -85,7 +87,8 @@ public class PolicyServicePersistenceTests : IDisposable
     public async Task BumpDraftFromVersionAsync_UnderPartialUniqueIndex_RejectsSecondOpenDraft()
     {
         using var db = NewContext();
-        var service = new PolicyService(db);
+        var service = new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance);
         var v1 = await service.CreateDraftAsync(MinimalCreate("only-one-draft"), "sam");
 
         // v1 is still in Draft — service guard triggers BEFORE the DB partial index would.
@@ -107,7 +110,8 @@ public class PolicyServicePersistenceTests : IDisposable
         // Use service to create the initial draft.
         using (var setupDb = NewContext())
         {
-            var service = new PolicyService(setupDb);
+            var service = new PolicyService(
+                setupDb, rationale: IntegrationAllowAnyRationalePolicy.Instance);
             var v1 = await service.CreateDraftAsync(MinimalCreate("race"), "sam");
             versionId = v1.Id;
             policyId = v1.PolicyId;
@@ -116,8 +120,10 @@ public class PolicyServicePersistenceTests : IDisposable
         // Two parallel services each load the entity at Revision=0.
         using var contextA = NewContext();
         using var contextB = NewContext();
-        var serviceA = new PolicyService(contextA);
-        var serviceB = new PolicyService(contextB);
+        var serviceA = new PolicyService(
+            contextA, rationale: IntegrationAllowAnyRationalePolicy.Instance);
+        var serviceB = new PolicyService(
+            contextB, rationale: IntegrationAllowAnyRationalePolicy.Instance);
 
         // Service A writes first — Revision advances from 0 to 1.
         await serviceA.UpdateDraftAsync(policyId, versionId,
@@ -145,7 +151,8 @@ public class PolicyServicePersistenceTests : IDisposable
     public async Task CreateDraftAsync_StoresCanonicalisedScopes_InPersistedRow()
     {
         using var db = NewContext();
-        var service = new PolicyService(db);
+        var service = new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance);
         var req = MinimalCreate("scope-order") with { Scopes = new[] { "tool:z", "tool:a", "prod" } };
 
         var dto = await service.CreateDraftAsync(req, "sam");
@@ -159,7 +166,8 @@ public class PolicyServicePersistenceTests : IDisposable
     public async Task GetActiveVersionAsync_AfterForcedActiveTransition_ResolvesVersion()
     {
         using var db = NewContext();
-        var service = new PolicyService(db);
+        var service = new PolicyService(
+            db, rationale: IntegrationAllowAnyRationalePolicy.Instance);
         var v1 = await service.CreateDraftAsync(MinimalCreate("active-flow"), "sam");
 
         using (var transitionDb = NewContext())

--- a/tests/Andy.Policies.Tests.Integration/Services/ScopeServiceConcurrencyTests.cs
+++ b/tests/Andy.Policies.Tests.Integration/Services/ScopeServiceConcurrencyTests.cs
@@ -3,6 +3,7 @@
 
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Exceptions;
+using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Domain.Enums;
 using Andy.Policies.Infrastructure.Data;
 using Andy.Policies.Infrastructure.Services;
@@ -63,7 +64,9 @@ public class ScopeServiceConcurrencyTests : IAsyncLifetime
             .UseNpgsql(_connectionString)
             .Options);
 
-    private static ScopeService NewService(AppDbContext db) => new(db, TimeProvider.System);
+    private static ScopeService NewService(AppDbContext db) => new(
+        db, TimeProvider.System, IntegrationTestAuditWriter.Instance,
+        IntegrationAllowAnyRationalePolicy.Instance);
 
     [SkippableFact]
     public async Task DuplicateTypeRefPair_ThrowsScopeRefConflict()

--- a/tests/Andy.Policies.Tests.Unit/Fixtures/MutationTestDoubles.cs
+++ b/tests/Andy.Policies.Tests.Unit/Fixtures/MutationTestDoubles.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Interfaces;
+
+namespace Andy.Policies.Tests.Unit.Fixtures;
+
+internal sealed class TestAuditWriter : IAuditWriter
+{
+    public static TestAuditWriter Instance { get; } = new();
+
+    public Task AppendAsync(
+        string action,
+        Guid entityId,
+        string actorSubjectId,
+        string? rationale,
+        CancellationToken ct = default) => Task.CompletedTask;
+}
+
+internal sealed class AllowAnyRationalePolicy : IRationalePolicy
+{
+    public static AllowAnyRationalePolicy Instance { get; } = new();
+
+    public bool IsRequired => false;
+
+    public string? ValidateRationale(string? rationale) => null;
+}

--- a/tests/Andy.Policies.Tests.Unit/Overrides/OverrideExpiryCalculationTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Overrides/OverrideExpiryCalculationTests.cs
@@ -48,7 +48,9 @@ public class OverrideExpiryCalculationTests
     {
         var db = InMemoryDbFixture.Create();
         var clock = new FakeTimeProvider(now);
-        var svc = new OverrideService(db, new AllowRbac(), new NoopDispatcher(), clock);
+        var svc = new OverrideService(
+            db, new AllowRbac(), new NoopDispatcher(), clock,
+            rationale: AllowAnyRationalePolicy.Instance);
         return (svc, db, clock);
     }
 

--- a/tests/Andy.Policies.Tests.Unit/Overrides/OverrideStateMachineTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Overrides/OverrideStateMachineTests.cs
@@ -53,7 +53,9 @@ public class OverrideStateMachineTests
     private static (OverrideService svc, AppDbContext db) NewService()
     {
         var db = InMemoryDbFixture.Create();
-        var svc = new OverrideService(db, new AllowRbac(), new NoopDispatcher(), TimeProvider.System);
+        var svc = new OverrideService(
+            db, new AllowRbac(), new NoopDispatcher(), TimeProvider.System,
+            rationale: AllowAnyRationalePolicy.Instance);
         return (svc, db);
     }
 

--- a/tests/Andy.Policies.Tests.Unit/Services/BindingResolutionServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/BindingResolutionServiceTests.cs
@@ -3,6 +3,7 @@
 
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Exceptions;
+using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Domain.Entities;
 using Andy.Policies.Domain.Enums;
 using Andy.Policies.Infrastructure.Data;
@@ -33,11 +34,12 @@ namespace Andy.Policies.Tests.Unit.Services;
 public class BindingResolutionServiceTests
 {
     private static (BindingResolutionService resolver, ScopeService scopes, AppDbContext db)
-        NewServices()
+        NewServices(IOverrideService? overrides = null)
     {
         var db = InMemoryDbFixture.Create();
-        var scopes = new ScopeService(db, TimeProvider.System);
-        var resolver = new BindingResolutionService(db, scopes);
+        var scopes = new ScopeService(
+            db, TimeProvider.System, TestAuditWriter.Instance, AllowAnyRationalePolicy.Instance);
+        var resolver = new BindingResolutionService(db, scopes, overrides);
         return (resolver, scopes, db);
     }
 
@@ -299,5 +301,87 @@ public class BindingResolutionServiceTests
         result.ScopeNodeId.Should().BeNull("no scope node matched — fallback to exact-match");
         result.Policies.Should().ContainSingle();
         result.Policies[0].PolicyKey.Should().Be("exact-only");
+    }
+
+    [Fact]
+    public async Task MatchingPrincipalExempt_RemovesPolicy_AndExplainsOverride()
+    {
+        var overrides = new StubOverrideService();
+        var (resolver, scopes, db) = NewServices(overrides);
+        var chain = await SeedFiveLevelChainAsync(scopes);
+        var (_, version) = await SeedPolicyAndPublishAsync(db, "exempted");
+        await AddScopeBindingAsync(db, chain.Repo, version.Id, BindStrength.Mandatory);
+        var grant = Override(version.Id, OverrideScopeKind.Principal, "user:42", OverrideEffect.Exempt);
+        overrides.Active[(OverrideScopeKind.Principal, "user:42")] = new[] { grant };
+
+        var result = await resolver.ResolveForScopeAsync(
+            chain.Repo, new OverrideResolutionContext("user:42", Array.Empty<string>()));
+
+        result.Policies.Should().BeEmpty();
+        result.AppliedOverrides.Should().ContainSingle().Which.OverrideId.Should().Be(grant.Id);
+    }
+
+    [Fact]
+    public async Task PrincipalOverride_BeatsCohort_WhileCohortReplaceSubstitutesForOtherPrincipal()
+    {
+        var overrides = new StubOverrideService();
+        var (resolver, scopes, db) = NewServices(overrides);
+        var chain = await SeedFiveLevelChainAsync(scopes);
+        var (_, baseline) = await SeedPolicyAndPublishAsync(db, "baseline");
+        var replacementPolicy = PolicyBuilders.APolicy(name: "replacement");
+        var replacement = PolicyBuilders.AVersion(
+            replacementPolicy.Id, number: 3, state: LifecycleState.WindingDown);
+        db.Policies.Add(replacementPolicy);
+        db.PolicyVersions.Add(replacement);
+        await db.SaveChangesAsync();
+        await AddScopeBindingAsync(db, chain.Repo, baseline.Id, BindStrength.Mandatory);
+
+        var cohort = Override(
+            baseline.Id, OverrideScopeKind.Cohort, "cohort:beta", OverrideEffect.Replace,
+            replacement.Id, approvedAt: DateTimeOffset.UtcNow.AddMinutes(-2));
+        var principal = Override(
+            baseline.Id, OverrideScopeKind.Principal, "user:42", OverrideEffect.Exempt,
+            approvedAt: DateTimeOffset.UtcNow.AddMinutes(-1));
+        overrides.Active[(OverrideScopeKind.Cohort, "cohort:beta")] = new[] { cohort };
+        overrides.Active[(OverrideScopeKind.Principal, "user:42")] = new[] { principal };
+
+        var principalResult = await resolver.ResolveForScopeAsync(
+            chain.Repo, new OverrideResolutionContext("user:42", new[] { "cohort:beta" }));
+        var cohortResult = await resolver.ResolveForScopeAsync(
+            chain.Repo, new OverrideResolutionContext("user:7", new[] { "cohort:beta" }));
+
+        principalResult.Policies.Should().BeEmpty("principal-specific overrides have precedence");
+        cohortResult.Policies.Should().ContainSingle().Which.PolicyVersionId.Should().Be(replacement.Id);
+        cohortResult.AppliedOverrides.Should().ContainSingle().Which.OverrideId.Should().Be(cohort.Id);
+    }
+
+    private static OverrideDto Override(
+        Guid policyVersionId,
+        OverrideScopeKind scopeKind,
+        string scopeRef,
+        OverrideEffect effect,
+        Guid? replacementId = null,
+        DateTimeOffset? approvedAt = null) => new(
+            Guid.NewGuid(), policyVersionId, scopeKind, scopeRef, effect, replacementId,
+            "proposer", "approver", OverrideState.Approved,
+            DateTimeOffset.UtcNow.AddHours(-1), approvedAt ?? DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow.AddHours(1), "test", null);
+
+    private sealed class StubOverrideService : IOverrideService
+    {
+        public Dictionary<(OverrideScopeKind Kind, string Ref), IReadOnlyList<OverrideDto>> Active { get; } = new();
+
+        public Task<IReadOnlyList<OverrideDto>> GetActiveAsync(
+            OverrideScopeKind scopeKind, string scopeRef, CancellationToken ct = default) =>
+            Task.FromResult(Active.GetValueOrDefault((scopeKind, scopeRef))
+                ?? (IReadOnlyList<OverrideDto>)Array.Empty<OverrideDto>());
+
+        public Task<OverrideDto> ProposeAsync(ProposeOverrideRequest request, string proposerSubjectId, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<OverrideDto> ApproveAsync(Guid id, string approverSubjectId, string? rationale = null, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<OverrideDto> RevokeAsync(Guid id, RevokeOverrideRequest request, string actorSubjectId, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<OverrideDto> RejectAsync(Guid id, RejectOverrideRequest request, string actorSubjectId, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<OverrideDto> ExpireAsync(Guid id, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<OverrideDto?> GetAsync(Guid id, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<OverrideDto>> ListAsync(OverrideListFilter filter, CancellationToken ct = default) => throw new NotSupportedException();
     }
 }

--- a/tests/Andy.Policies.Tests.Unit/Services/BindingServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/BindingServiceTests.cs
@@ -39,7 +39,8 @@ public class BindingServiceTests
     {
         var db = InMemoryDbFixture.Create();
         var audit = new RecordingAuditWriter();
-        var service = new BindingService(db, audit, TimeProvider.System);
+        var service = new BindingService(
+            db, audit, TimeProvider.System, tightenValidator: null, AllowAnyRationalePolicy.Instance);
         return (service, db, audit);
     }
 

--- a/tests/Andy.Policies.Tests.Unit/Services/BindingServiceTightenOnlyTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/BindingServiceTightenOnlyTests.cs
@@ -30,10 +30,12 @@ public class BindingServiceTightenOnlyTests
         NewServices()
     {
         var db = InMemoryDbFixture.Create();
-        var scopes = new ScopeService(db, TimeProvider.System);
+        var scopes = new ScopeService(
+            db, TimeProvider.System, TestAuditWriter.Instance, AllowAnyRationalePolicy.Instance);
         var validator = new TightenOnlyValidator(db, scopes);
         var audit = new NoopAuditWriter(NullLogger<NoopAuditWriter>.Instance);
-        var binding = new BindingService(db, audit, TimeProvider.System, validator);
+        var binding = new BindingService(
+            db, audit, TimeProvider.System, validator, AllowAnyRationalePolicy.Instance);
         return (binding, scopes, validator, db);
     }
 

--- a/tests/Andy.Policies.Tests.Unit/Services/BundleResolverTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/BundleResolverTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Text;
+using Andy.Policies.Application.Dtos;
 using Andy.Policies.Application.Interfaces;
 using Andy.Policies.Domain.Entities;
 using Andy.Policies.Domain.Enums;
@@ -38,14 +39,16 @@ public class BundleResolverTests
 
     private static BundleSnapshot Snapshot(
         IEnumerable<BundlePolicyEntry>? policies = null,
-        IEnumerable<BundleBindingEntry>? bindings = null) => new(
+        IEnumerable<BundleBindingEntry>? bindings = null,
+        IEnumerable<BundleOverrideEntry>? overrides = null,
+        IEnumerable<BundleScopeEntry>? scopes = null) => new(
             SchemaVersion: "1",
             CapturedAt: CapturedAt,
             AuditTailHash: new string('0', 64),
             Policies: (policies ?? Array.Empty<BundlePolicyEntry>()).ToList(),
             Bindings: (bindings ?? Array.Empty<BundleBindingEntry>()).ToList(),
-            Overrides: Array.Empty<BundleOverrideEntry>(),
-            Scopes: Array.Empty<BundleScopeEntry>());
+            Overrides: (overrides ?? Array.Empty<BundleOverrideEntry>()).ToList(),
+            Scopes: (scopes ?? Array.Empty<BundleScopeEntry>()).ToList());
 
     private static async Task<Bundle> SeedBundleAsync(
         AppDbContext db,
@@ -296,5 +299,86 @@ public class BundleResolverTests
             "second-call answer must match the first byte-for-byte; a cache " +
             "hit that produced a different shape would mean the resolver is " +
             "mutating the cached snapshot in place");
+    }
+
+    [Fact]
+    public async Task EffectiveResolution_MatchesEveryBridgeTargetAcrossAncestorChain()
+    {
+        var (resolver, db, _) = NewResolver();
+        var org = new BundleScopeEntry(Guid.NewGuid(), null, "Org", "org:acme", "Acme");
+        var tenant = new BundleScopeEntry(Guid.NewGuid(), org.ScopeNodeId, "Tenant", "tenant:t1", "T1");
+        var team = new BundleScopeEntry(Guid.NewGuid(), tenant.ScopeNodeId, "Team", "team:red", "Red");
+        var repo = new BundleScopeEntry(Guid.NewGuid(), team.ScopeNodeId, "Repo", "repo:acme/svc", "Svc");
+        var template = new BundleScopeEntry(Guid.NewGuid(), repo.ScopeNodeId, "Template", "template:deploy", "Deploy");
+        var versions = Enumerable.Range(0, 5).Select(_ => Guid.NewGuid()).ToArray();
+        var policies = versions.Select((id, i) => Policy(id, $"p{i}")).ToArray();
+        var bindings = new[]
+        {
+            Binding(versions[0], "Org", org.Ref),
+            Binding(versions[1], "Tenant", tenant.Ref),
+            Binding(versions[2], "ScopeNode", $"scope:{team.ScopeNodeId}"),
+            Binding(versions[3], "Repo", repo.Ref),
+            Binding(versions[4], "Template", template.Ref),
+        };
+        var bundle = await SeedBundleAsync(db, Snapshot(
+            policies, bindings, scopes: new[] { org, tenant, team, repo, template }));
+
+        var result = await resolver.ResolveEffectiveForScopeAsync(bundle.Id, template.ScopeNodeId);
+
+        result!.Policies.Should().HaveCount(5);
+        result.Policies.Select(p => p.SourceBindingId).Should()
+            .BeEquivalentTo(bindings.Select(b => b.BindingId));
+        result.Policies.Single(p => p.PolicyVersionId == versions[0]).SourceScopeNodeId.Should().Be(org.ScopeNodeId);
+        result.Policies.Single(p => p.PolicyVersionId == versions[4]).SourceScopeNodeId.Should().Be(template.ScopeNodeId);
+    }
+
+    [Fact]
+    public async Task EffectiveResolution_AppliesPinnedPrincipalAndCohortOverridesWithExplanation()
+    {
+        var (resolver, db, _) = NewResolver();
+        var scope = new BundleScopeEntry(Guid.NewGuid(), null, "Repo", "repo:acme/svc", "Svc");
+        var baselineId = Guid.NewGuid();
+        var replacementId = Guid.NewGuid();
+        var baseline = Policy(baselineId, "baseline");
+        var replacement = Policy(replacementId, "replacement", 2);
+        var binding = Binding(baselineId, "Repo", scope.Ref, BindStrength.Mandatory);
+        var cohort = new BundleOverrideEntry(
+            Guid.NewGuid(), baselineId, "Cohort", "cohort:beta", "Replace",
+            replacementId, CapturedAt.AddDays(1), replacement, CapturedAt.AddMinutes(-2));
+        var principal = new BundleOverrideEntry(
+            Guid.NewGuid(), baselineId, "Principal", "user:42", "Exempt",
+            null, CapturedAt.AddDays(1), null, CapturedAt.AddMinutes(-1));
+        var bundle = await SeedBundleAsync(db, Snapshot(
+            new[] { baseline }, new[] { binding }, new[] { cohort, principal }, new[] { scope }));
+
+        var principalResult = await resolver.ResolveEffectiveForScopeAsync(
+            bundle.Id, scope.ScopeNodeId,
+            new OverrideResolutionContext("user:42", new[] { "cohort:beta" }));
+        var cohortResult = await resolver.ResolveEffectiveForScopeAsync(
+            bundle.Id, scope.ScopeNodeId,
+            new OverrideResolutionContext("user:7", new[] { "cohort:beta" }));
+
+        principalResult!.Policies.Should().BeEmpty("principal overrides take precedence over cohort matches");
+        principalResult.AppliedOverrides.Should().ContainSingle().Which.OverrideId.Should().Be(principal.OverrideId);
+        cohortResult!.Policies.Should().ContainSingle().Which.PolicyVersionId.Should().Be(replacementId);
+        cohortResult.AppliedOverrides.Should().ContainSingle().Which.OverrideId.Should().Be(cohort.OverrideId);
+    }
+
+    [Fact]
+    public async Task EffectiveResolution_OldSnapshotWithoutOverrides_PreservesBaseline()
+    {
+        var (resolver, db, _) = NewResolver();
+        var scope = new BundleScopeEntry(Guid.NewGuid(), null, "Repo", "repo:legacy", "Legacy");
+        var versionId = Guid.NewGuid();
+        var bundle = await SeedBundleAsync(db, Snapshot(
+            new[] { Policy(versionId) }, new[] { Binding(versionId, "Repo", scope.Ref) },
+            scopes: new[] { scope }));
+
+        var result = await resolver.ResolveEffectiveForScopeAsync(
+            bundle.Id, scope.ScopeNodeId,
+            new OverrideResolutionContext("user:42", new[] { "cohort:beta" }));
+
+        result!.Policies.Should().ContainSingle().Which.PolicyVersionId.Should().Be(versionId);
+        result.AppliedOverrides.Should().BeEmpty();
     }
 }

--- a/tests/Andy.Policies.Tests.Unit/Services/BundleSnapshotBuilderTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/BundleSnapshotBuilderTests.cs
@@ -227,6 +227,43 @@ public class BundleSnapshotBuilderTests
     }
 
     [Fact]
+    public async Task Build_EmbedsReplacementPolicyAndApprovalOrderForPinnedResolution()
+    {
+        await using var db = NewDb();
+        var (_, baselineId) = await SeedPolicyVersionAsync(db, "baseline");
+        var (_, replacementId) = await SeedPolicyVersionAsync(
+            db, "replacement", LifecycleState.WindingDown);
+        var approvedAt = Now.AddHours(-2);
+        var grant = new Override
+        {
+            Id = Guid.NewGuid(),
+            PolicyVersionId = baselineId,
+            ScopeKind = OverrideScopeKind.Cohort,
+            ScopeRef = "cohort:beta",
+            Effect = OverrideEffect.Replace,
+            ReplacementPolicyVersionId = replacementId,
+            State = OverrideState.Approved,
+            ExpiresAt = Now.AddDays(1),
+            ProposerSubjectId = "alice",
+            ApproverSubjectId = "bob",
+            Rationale = "controlled replacement",
+            ProposedAt = Now.AddHours(-3),
+            ApprovedAt = approvedAt,
+        };
+        db.Overrides.Add(grant);
+        await db.SaveChangesAsync();
+
+        var entry = (await new BundleSnapshotBuilder(db).BuildAsync(Now))
+            .Overrides.Should().ContainSingle().Subject;
+
+        entry.OverrideId.Should().Be(grant.Id);
+        entry.ApprovedAt.Should().Be(approvedAt);
+        entry.ReplacementPolicyVersionId.Should().Be(replacementId);
+        entry.ReplacementPolicy.Should().NotBeNull();
+        entry.ReplacementPolicy!.Name.Should().Be("replacement");
+    }
+
+    [Fact]
     public async Task Build_OrdersCollectionsStably()
     {
         await using var db = NewDb();

--- a/tests/Andy.Policies.Tests.Unit/Services/ItemServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/ItemServiceTests.cs
@@ -4,6 +4,7 @@
 using Andy.Policies.Application.Dtos;
 using Andy.Policies.Infrastructure.Data;
 using Andy.Policies.Infrastructure.Services;
+using Andy.Policies.Tests.Unit.Fixtures;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
@@ -11,6 +12,9 @@ namespace Andy.Policies.Tests.Unit.Services;
 
 public class ItemServiceTests
 {
+    private static ItemService NewService(AppDbContext db) => new(
+        db, TestAuditWriter.Instance, AllowAnyRationalePolicy.Instance);
+
     private static AppDbContext CreateInMemoryDb()
     {
         var options = new DbContextOptionsBuilder<AppDbContext>()
@@ -23,7 +27,7 @@ public class ItemServiceTests
     public async Task CreateAsync_ShouldReturnNewItem()
     {
         using var db = CreateInMemoryDb();
-        var service = new ItemService(db);
+        var service = NewService(db);
         var request = new CreateItemRequest("Test Item", "A test description");
 
         var result = await service.CreateAsync(request, "test-user");
@@ -39,7 +43,7 @@ public class ItemServiceTests
     public async Task GetAllAsync_ShouldReturnAllItems()
     {
         using var db = CreateInMemoryDb();
-        var service = new ItemService(db);
+        var service = NewService(db);
         await service.CreateAsync(new CreateItemRequest("Item 1", null), "user1");
         await service.CreateAsync(new CreateItemRequest("Item 2", null), "user2");
 
@@ -52,7 +56,7 @@ public class ItemServiceTests
     public async Task GetByIdAsync_WhenNotFound_ShouldReturnNull()
     {
         using var db = CreateInMemoryDb();
-        var service = new ItemService(db);
+        var service = NewService(db);
 
         var result = await service.GetByIdAsync(Guid.NewGuid());
 
@@ -63,10 +67,11 @@ public class ItemServiceTests
     public async Task UpdateAsync_ShouldUpdateItem()
     {
         using var db = CreateInMemoryDb();
-        var service = new ItemService(db);
+        var service = NewService(db);
         var created = await service.CreateAsync(new CreateItemRequest("Original", null), "user1");
 
-        var updated = await service.UpdateAsync(created.Id, new CreateItemRequest("Updated", "New desc"));
+        var updated = await service.UpdateAsync(
+            created.Id, new CreateItemRequest("Updated", "New desc"), "user1");
 
         Assert.NotNull(updated);
         Assert.Equal("Updated", updated!.Name);
@@ -78,10 +83,10 @@ public class ItemServiceTests
     public async Task DeleteAsync_ShouldRemoveItem()
     {
         using var db = CreateInMemoryDb();
-        var service = new ItemService(db);
+        var service = NewService(db);
         var created = await service.CreateAsync(new CreateItemRequest("To Delete", null), "user1");
 
-        var deleted = await service.DeleteAsync(created.Id);
+        var deleted = await service.DeleteAsync(created.Id, "user1", "delete test item");
         var found = await service.GetByIdAsync(created.Id);
 
         Assert.True(deleted);
@@ -92,9 +97,9 @@ public class ItemServiceTests
     public async Task DeleteAsync_WhenNotFound_ShouldReturnFalse()
     {
         using var db = CreateInMemoryDb();
-        var service = new ItemService(db);
+        var service = NewService(db);
 
-        var deleted = await service.DeleteAsync(Guid.NewGuid());
+        var deleted = await service.DeleteAsync(Guid.NewGuid(), "user1", "missing item");
 
         Assert.False(deleted);
     }

--- a/tests/Andy.Policies.Tests.Unit/Services/OverrideServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/OverrideServiceTests.cs
@@ -39,7 +39,8 @@ public class OverrideServiceTests
         var events = new RecordingDispatcher();
         var rbac = new StubRbac { Allow = rbacAllow };
         var clock = new FakeTimeProvider(new DateTimeOffset(2026, 4, 27, 12, 0, 0, TimeSpan.Zero));
-        var service = new OverrideService(db, rbac, events, clock);
+        var service = new OverrideService(
+            db, rbac, events, clock, rationale: AllowAnyRationalePolicy.Instance);
         return (service, db, events, rbac, clock);
     }
 
@@ -406,7 +407,8 @@ public class OverrideServiceTests
         var allowingRbac = new StubRbac { Allow = true };
         var clock = new FakeTimeProvider(new DateTimeOffset(2026, 4, 27, 12, 0, 0, TimeSpan.Zero));
 
-        var allowingSvc = new OverrideService(db, allowingRbac, events, clock);
+        var allowingSvc = new OverrideService(
+            db, allowingRbac, events, clock, rationale: AllowAnyRationalePolicy.Instance);
         var (_, version) = await SeedActiveAsync(db, "p15");
         var proposed = await allowingSvc.ProposeAsync(
             ExemptRequest(version.Id, clock.GetUtcNow().AddDays(1)),
@@ -414,7 +416,8 @@ public class OverrideServiceTests
         await allowingSvc.ApproveAsync(proposed.Id, Approver);
 
         var denyingRbac = new StubRbac { Allow = false };
-        var denyingSvc = new OverrideService(db, denyingRbac, events, clock);
+        var denyingSvc = new OverrideService(
+            db, denyingRbac, events, clock, rationale: AllowAnyRationalePolicy.Instance);
 
         await FluentActions.Invoking(() => denyingSvc.RevokeAsync(
                 proposed.Id, new RevokeOverrideRequest("attempt"), "user:not-allowed"))
@@ -485,13 +488,17 @@ public class OverrideServiceTests
         var events = new RecordingDispatcher();
         var clock = new FakeTimeProvider(new DateTimeOffset(2026, 5, 7, 12, 0, 0, TimeSpan.Zero));
 
-        var allowingSvc = new OverrideService(db, new StubRbac { Allow = true }, events, clock);
+        var allowingSvc = new OverrideService(
+            db, new StubRbac { Allow = true }, events, clock,
+            rationale: AllowAnyRationalePolicy.Instance);
         var (_, version) = await SeedActiveAsync(db, "rj4");
         var proposed = await allowingSvc.ProposeAsync(
             ExemptRequest(version.Id, clock.GetUtcNow().AddDays(1)),
             Proposer);
 
-        var denyingSvc = new OverrideService(db, new StubRbac { Allow = false }, events, clock);
+        var denyingSvc = new OverrideService(
+            db, new StubRbac { Allow = false }, events, clock,
+            rationale: AllowAnyRationalePolicy.Instance);
 
         await FluentActions.Invoking(() => denyingSvc.RejectAsync(
                 proposed.Id, new RejectOverrideRequest("nope"), "user:not-allowed"))

--- a/tests/Andy.Policies.Tests.Unit/Services/PlanEvaluation/PlanEvaluatorTaskTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/PlanEvaluation/PlanEvaluatorTaskTests.cs
@@ -194,7 +194,7 @@ public class PlanEvaluatorTaskTests
         // Two tasks: one read-only, one prod-deploy. A reject rule on
         // noProductionDeploy must only fire for the prod task — the
         // read-only task must come back clean.
-        var readOnly = ATask(tools: new[] { "read-file" }, env: null);
+        var readOnly = ATask(tools: new[] { "read-file" }, env: "dev");
         var prod = ATask(tools: new[] { "deploy" }, env: "prod");
         var view = AView(tasks: new[] { readOnly, prod }, tier: "sandbox");
 
@@ -272,7 +272,7 @@ public class PlanEvaluatorTaskTests
     public async Task Different_tasks_in_same_goal_are_cached_independently()
     {
         var t1 = ATask(env: "prod");
-        var t2 = ATask(tools: new[] { "read-file" });
+        var t2 = ATask(tools: new[] { "read-file" }, env: "dev");
         var view = AView(tasks: new[] { t1, t2 }, tier: "sandbox");
 
         var rules = """

--- a/tests/Andy.Policies.Tests.Unit/Services/PlanEvaluation/PlanEvaluatorTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/PlanEvaluation/PlanEvaluatorTests.cs
@@ -180,9 +180,9 @@ public class PlanEvaluatorTests
     [Fact]
     public async Task Surfaces_data_unavailable_on_predicates_with_missing_inputs()
     {
-        // No tier, no approved list, no budget — three predicates
-        // surface "data unavailable". The fourth and fifth still
-        // evaluate. The wire response must reflect this verbatim.
+        // No tier, approved list, budget, estimated cost, or target
+        // environment. Every predicate whose input is missing must
+        // surface "data unavailable" rather than silently passing.
         var view = AView(
             tasks: new[] { ATask(tools: new[] { "read-file" }) },
             tier: null,
@@ -204,9 +204,10 @@ public class PlanEvaluatorTests
         byName[PlanPredicateNames.RespectsCostBudget].Passed.Should().BeFalse();
         byName[PlanPredicateNames.RespectsCostBudget].Reason.Should().Be("data unavailable");
 
-        // The other two evaluate normally.
+        // Read-only still evaluates because its input is present.
         byName[PlanPredicateNames.AllTasksReadOnly].Passed.Should().BeTrue();
-        byName[PlanPredicateNames.NoProductionDeploy].Passed.Should().BeTrue();
+        byName[PlanPredicateNames.NoProductionDeploy].Passed.Should().BeFalse();
+        byName[PlanPredicateNames.NoProductionDeploy].Reason.Should().Be("data unavailable");
     }
 
     [Fact]

--- a/tests/Andy.Policies.Tests.Unit/Services/PlanEvaluation/PlanPredicateTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/PlanEvaluation/PlanPredicateTests.cs
@@ -92,6 +92,17 @@ public class PlanPredicateTests
         r.Outcome.Should().Be(PredicateOutcome.Pass);
     }
 
+    [Fact]
+    public void AllTasksReadOnly_is_unevaluable_when_tools_contract_is_missing()
+    {
+        var task = new PlanEvaluationTaskView(Guid.NewGuid(), "coder", null, "dev");
+
+        var result = new AllTasksReadOnlyPredicate().Evaluate(View(tasks: new[] { task }));
+
+        result.Outcome.Should().Be(PredicateOutcome.Unevaluable);
+        result.Reason.Should().Contain("data unavailable");
+    }
+
     // ---- workspaceIsSandbox -----------------------------------------------
 
     [Theory]
@@ -131,10 +142,18 @@ public class PlanPredicateTests
         {
             Task(env: "dev"),
             Task(env: "staging"),
-            Task(env: null),
         });
 
         p.Evaluate(v).Outcome.Should().Be(PredicateOutcome.Pass);
+    }
+
+    [Fact]
+    public void NoProductionDeploy_is_unevaluable_when_any_target_environment_is_missing()
+    {
+        var p = new NoProductionDeployPredicate();
+        var v = View(tasks: new[] { Task(env: "dev"), Task(env: null) });
+
+        p.Evaluate(v).Outcome.Should().Be(PredicateOutcome.Unevaluable);
     }
 
     [Theory]

--- a/tests/Andy.Policies.Tests.Unit/Services/PolicyServiceListFilterTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/PolicyServiceListFilterTests.cs
@@ -15,13 +15,16 @@ namespace Andy.Policies.Tests.Unit.Services;
 /// P1.10 (#80): coverage backfill for <c>IPolicyService.ListPoliciesAsync</c>'s
 /// non-scope filter axes. Existing <c>PolicyServiceTests</c> covered the scope
 /// path; namePrefix, enforcement, and severity filters were untested. Each
-/// filter applies against the *active version* (highest non-Draft) per P1's
-/// resolution rule, so the arrange phase mirrors the existing scope test:
+/// filter applies only against the version whose lifecycle state is exactly
+/// <c>Active</c>, so the arrange phase mirrors the existing scope test:
 /// create a draft, then flip <c>State</c> directly on the tracked entity to
 /// simulate publishing without depending on the Epic P2 transition service.
 /// </summary>
 public class PolicyServiceListFilterTests
 {
+    private static PolicyService NewService(Andy.Policies.Infrastructure.Data.AppDbContext db) =>
+        new(db, rationale: AllowAnyRationalePolicy.Instance);
+
     private static async Task PublishAllAsync(Andy.Policies.Infrastructure.Data.AppDbContext db)
     {
         await foreach (var v in db.PolicyVersions.AsAsyncEnumerable())
@@ -35,7 +38,7 @@ public class PolicyServiceListFilterTests
     public async Task ListPoliciesAsync_FiltersByNamePrefix()
     {
         using var db = InMemoryDbFixture.Create();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         await service.CreateDraftAsync(PolicyBuilders.AMinimalCreateRequest("alpha-1"), "sam");
         await service.CreateDraftAsync(PolicyBuilders.AMinimalCreateRequest("alpha-2"), "sam");
         await service.CreateDraftAsync(PolicyBuilders.AMinimalCreateRequest("beta-1"), "sam");
@@ -50,7 +53,7 @@ public class PolicyServiceListFilterTests
     public async Task ListPoliciesAsync_FiltersByEnforcement()
     {
         using var db = InMemoryDbFixture.Create();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         await service.CreateDraftAsync(
             PolicyBuilders.AMinimalCreateRequest("must-policy", enforcement: "Must"), "sam");
         await service.CreateDraftAsync(
@@ -68,7 +71,7 @@ public class PolicyServiceListFilterTests
     public async Task ListPoliciesAsync_FiltersBySeverity()
     {
         using var db = InMemoryDbFixture.Create();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         await service.CreateDraftAsync(
             PolicyBuilders.AMinimalCreateRequest("info", severity: "Info"), "sam");
         await service.CreateDraftAsync(
@@ -86,7 +89,7 @@ public class PolicyServiceListFilterTests
     public async Task ListPoliciesAsync_CombinesFilters_ConjunctiveAnd()
     {
         using var db = InMemoryDbFixture.Create();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         await service.CreateDraftAsync(
             PolicyBuilders.AMinimalCreateRequest("hot-1", enforcement: "Must", severity: "Critical"), "sam");
         await service.CreateDraftAsync(
@@ -110,7 +113,7 @@ public class PolicyServiceListFilterTests
     public async Task ListPoliciesAsync_EnforcementFilter_IsCaseInsensitive(string enforcementFilter)
     {
         using var db = InMemoryDbFixture.Create();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         await service.CreateDraftAsync(
             PolicyBuilders.AMinimalCreateRequest("locked", enforcement: "Must"), "sam");
         await PublishAllAsync(db);
@@ -126,7 +129,7 @@ public class PolicyServiceListFilterTests
         // Distinct from the other filter axes: namePrefix matches against the
         // stable Policy.Name and applies even when there's no active version.
         using var db = InMemoryDbFixture.Create();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         await service.CreateDraftAsync(PolicyBuilders.AMinimalCreateRequest("draft-stays-draft"), "sam");
 
         var results = await service.ListPoliciesAsync(new ListPoliciesQuery(NamePrefix: "draft-"));

--- a/tests/Andy.Policies.Tests.Unit/Services/PolicyServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/PolicyServiceTests.cs
@@ -7,6 +7,7 @@ using Andy.Policies.Application.Queries;
 using Andy.Policies.Domain.Enums;
 using Andy.Policies.Infrastructure.Data;
 using Andy.Policies.Infrastructure.Services;
+using Andy.Policies.Tests.Unit.Fixtures;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Xunit;
@@ -15,6 +16,9 @@ namespace Andy.Policies.Tests.Unit.Services;
 
 public class PolicyServiceTests
 {
+    private static PolicyService NewService(AppDbContext db) =>
+        new(db, rationale: AllowAnyRationalePolicy.Instance);
+
     private static AppDbContext CreateInMemoryDb()
     {
         var options = new DbContextOptionsBuilder<AppDbContext>()
@@ -40,7 +44,7 @@ public class PolicyServiceTests
     public async Task CreateDraftAsync_AssignsVersionOne_ForNewPolicy()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
 
         var dto = await service.CreateDraftAsync(MinimalCreate("no-prod"), "sam");
 
@@ -56,7 +60,7 @@ public class PolicyServiceTests
     public async Task CreateDraftAsync_WhenSlugDuplicate_ThrowsConflictException()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         await service.CreateDraftAsync(MinimalCreate("high-risk"), "sam");
 
         var ex = await Assert.ThrowsAsync<ConflictException>(
@@ -69,7 +73,7 @@ public class PolicyServiceTests
     public async Task CreateDraftAsync_WhenScopeContainsWildcard_ThrowsValidationException()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
 
         await Assert.ThrowsAsync<ValidationException>(
             () => service.CreateDraftAsync(MinimalCreate("bad-scope", scope: "*"), "sam"));
@@ -79,7 +83,7 @@ public class PolicyServiceTests
     public async Task CreateDraftAsync_WhenNameInvalid_ThrowsValidationException()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
 
         var ex = await Assert.ThrowsAsync<ValidationException>(
             () => service.CreateDraftAsync(MinimalCreate("BadSlug"), "sam"));
@@ -90,7 +94,7 @@ public class PolicyServiceTests
     public async Task CreateDraftAsync_WhenRulesJsonMalformed_ThrowsValidationException()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         var request = MinimalCreate("bad-json") with { RulesJson = "{not: 'json'" };
 
         await Assert.ThrowsAsync<ValidationException>(
@@ -101,7 +105,7 @@ public class PolicyServiceTests
     public async Task CreateDraftAsync_WhenRulesJsonTooLarge_ThrowsValidationException()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         // 65 KB — just over the 64 KB cap.
         var oversized = "{\"x\":\"" + new string('a', 64 * 1024 + 100) + "\"}";
         var request = MinimalCreate("big") with { RulesJson = oversized };
@@ -115,7 +119,7 @@ public class PolicyServiceTests
     public async Task CreateDraftAsync_CanonicalisesScopes()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         var req = MinimalCreate("canonical") with { Scopes = new[] { "tool:write", "prod", "tool:write" } };
 
         var dto = await service.CreateDraftAsync(req, "sam");
@@ -127,7 +131,7 @@ public class PolicyServiceTests
     public async Task UpdateDraftAsync_MutatesFields_InDraftState()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         var created = await service.CreateDraftAsync(MinimalCreate("mutable"), "sam");
 
         var updated = await service.UpdateDraftAsync(
@@ -150,7 +154,7 @@ public class PolicyServiceTests
     public async Task UpdateDraftAsync_WhenVersionIsPublished_ThrowsConflictException()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         var created = await service.CreateDraftAsync(MinimalCreate("published"), "sam");
 
         // Forcefully transition the underlying entity to Active (P2 territory — simulated here).
@@ -168,7 +172,7 @@ public class PolicyServiceTests
     public async Task UpdateDraftAsync_WhenVersionNotFound_ThrowsNotFoundException()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         var req = new UpdatePolicyVersionRequest("x", "must", "critical", Array.Empty<string>(), "{}");
 
         await Assert.ThrowsAsync<NotFoundException>(
@@ -179,7 +183,7 @@ public class PolicyServiceTests
     public async Task BumpDraftFromVersionAsync_AssignsNextVersionNumber()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         var v1 = await service.CreateDraftAsync(MinimalCreate("bump-target"), "sam");
 
         // Simulate P2 publish so the draft-count guard does not fire.
@@ -198,7 +202,7 @@ public class PolicyServiceTests
     public async Task BumpDraftFromVersionAsync_WhenOpenDraftExists_ThrowsConflictException()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         var v1 = await service.CreateDraftAsync(MinimalCreate("has-draft"), "sam");
         // v1 is still Draft — a bump attempt must refuse.
 
@@ -213,17 +217,17 @@ public class PolicyServiceTests
     public async Task BumpDraftFromVersionAsync_WhenPolicyMissing_ThrowsNotFoundException()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
 
         await Assert.ThrowsAsync<NotFoundException>(
             () => service.BumpDraftFromVersionAsync(Guid.NewGuid(), Guid.NewGuid(), "sam"));
     }
 
     [Fact]
-    public async Task GetActiveVersionAsync_ReturnsHighestNonDraft()
+    public async Task GetActiveVersionAsync_ReturnsActiveVersion()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         var v1 = await service.CreateDraftAsync(MinimalCreate("active"), "sam");
         var entity = await db.PolicyVersions.FirstAsync(v => v.Id == v1.Id);
         entity.State = LifecycleState.Active;
@@ -235,11 +239,29 @@ public class PolicyServiceTests
         Assert.Equal(v1.Id, active!.Id);
     }
 
+    [Theory]
+    [InlineData(LifecycleState.Draft)]
+    [InlineData(LifecycleState.WindingDown)]
+    [InlineData(LifecycleState.Retired)]
+    public async Task GetActiveVersionAsync_DoesNotReturnAnyNonActiveState(LifecycleState state)
+    {
+        using var db = CreateInMemoryDb();
+        var service = NewService(db);
+        var version = await service.CreateDraftAsync(MinimalCreate($"not-active-{state.ToString().ToLowerInvariant()}"), "sam");
+        var entity = await db.PolicyVersions.FirstAsync(v => v.Id == version.Id);
+        entity.State = state;
+        await db.SaveChangesAsync();
+
+        var active = await service.GetActiveVersionAsync(version.PolicyId);
+
+        Assert.Null(active);
+    }
+
     [Fact]
     public async Task GetActiveVersionAsync_ReturnsNull_WhenAllDraft()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         var v1 = await service.CreateDraftAsync(MinimalCreate("all-draft"), "sam");
 
         var active = await service.GetActiveVersionAsync(v1.PolicyId);
@@ -251,7 +273,7 @@ public class PolicyServiceTests
     public async Task ListPoliciesAsync_FiltersByScope_AgainstActiveVersion()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
 
         // Two published policies, one scoped to prod.
         var a = await service.CreateDraftAsync(MinimalCreate("a-policy", scope: "prod"), "sam");
@@ -274,7 +296,7 @@ public class PolicyServiceTests
     public async Task ListPoliciesAsync_ExcludesPoliciesWithNoActiveVersion_WhenFilterIsApplied()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         await service.CreateDraftAsync(MinimalCreate("never-published", scope: "prod"), "sam");
 
         // A filter-scoped query on a policy that's still Draft should return nothing.
@@ -290,7 +312,7 @@ public class PolicyServiceTests
     public async Task ListPoliciesAsync_RespectsPagination()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         for (var i = 0; i < 5; i++)
         {
             await service.CreateDraftAsync(MinimalCreate($"p-{i}"), "sam");
@@ -307,7 +329,7 @@ public class PolicyServiceTests
     public async Task ListPoliciesAsync_CapsTakeAtFiveHundred()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         // Request well above the cap; service should not crash, just return whatever we have.
         var results = await service.ListPoliciesAsync(new ListPoliciesQuery(Take: 10_000));
 
@@ -318,7 +340,7 @@ public class PolicyServiceTests
     public async Task GetPolicyAsync_ReturnsNull_WhenMissing()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
 
         var result = await service.GetPolicyAsync(Guid.NewGuid());
 
@@ -329,7 +351,7 @@ public class PolicyServiceTests
     public async Task PolicyDto_ReportsVersionCountAndActiveVersionId()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         var v1 = await service.CreateDraftAsync(MinimalCreate("count-me"), "sam");
 
         // Still all Draft — ActiveVersionId should be null.
@@ -353,7 +375,7 @@ public class PolicyServiceTests
     public async Task ProposeDraftAsync_FlipsReadyForReview_AndIsIdempotent()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         var draft = await service.CreateDraftAsync(MinimalCreate("propose-1"), "author");
 
         var proposed = await service.ProposeDraftAsync(
@@ -376,7 +398,7 @@ public class PolicyServiceTests
     public async Task ProposeDraftAsync_NonDraftState_ThrowsConflict()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         var draft = await service.CreateDraftAsync(MinimalCreate("propose-2"), "author");
 
         // Force out of Draft (skip the lifecycle service — this test is
@@ -393,7 +415,7 @@ public class PolicyServiceTests
     public async Task RejectDraftAsync_ClearsReadyForReview_AndRequiresRationale()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         var draft = await service.CreateDraftAsync(MinimalCreate("reject-1"), "author");
         await service.ProposeDraftAsync(draft.PolicyId, draft.Id, "ready", "author");
 
@@ -412,7 +434,7 @@ public class PolicyServiceTests
     public async Task RejectDraftAsync_WhenNotReadyForReview_IsNoOp()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
         var draft = await service.CreateDraftAsync(MinimalCreate("reject-2"), "author");
 
         // Not yet proposed — reject is idempotent / no-op, no exception.
@@ -425,7 +447,7 @@ public class PolicyServiceTests
     public async Task ListPendingApprovalAsync_ReturnsOnlyDraftWithReadyForReview()
     {
         using var db = CreateInMemoryDb();
-        var service = new PolicyService(db);
+        var service = NewService(db);
 
         var d1 = await service.CreateDraftAsync(MinimalCreate("pending-1"), "author");
         var d2 = await service.CreateDraftAsync(MinimalCreate("pending-2"), "author");

--- a/tests/Andy.Policies.Tests.Unit/Services/ScopeCycleRejectionTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/ScopeCycleRejectionTests.cs
@@ -28,7 +28,8 @@ public class ScopeCycleRejectionTests
     private static (ScopeService scopes, AppDbContext db) NewServices()
     {
         var db = InMemoryDbFixture.Create();
-        return (new ScopeService(db, TimeProvider.System), db);
+        return (new ScopeService(
+            db, TimeProvider.System, TestAuditWriter.Instance, AllowAnyRationalePolicy.Instance), db);
     }
 
     [Fact]

--- a/tests/Andy.Policies.Tests.Unit/Services/ScopeServiceTestExtensions.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/ScopeServiceTestExtensions.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Rivoli AI 2026. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Andy.Policies.Application.Dtos;
+using Andy.Policies.Infrastructure.Services;
+
+namespace Andy.Policies.Tests.Unit.Services;
+
+internal static class ScopeServiceTestExtensions
+{
+    private const string Actor = "test:actor";
+
+    public static Task<ScopeNodeDto> CreateAsync(
+        this ScopeService service,
+        CreateScopeNodeRequest request,
+        CancellationToken ct = default) =>
+        service.CreateAsync(request, Actor, ct);
+
+    public static Task<ScopeNodeDto> UpdateAsync(
+        this ScopeService service,
+        Guid id,
+        UpdateScopeNodeRequest request,
+        CancellationToken ct = default) =>
+        service.UpdateAsync(id, request, Actor, ct);
+
+    public static Task DeleteAsync(
+        this ScopeService service,
+        Guid id,
+        CancellationToken ct = default) =>
+        service.DeleteAsync(id, Actor, "test rationale", ct);
+}

--- a/tests/Andy.Policies.Tests.Unit/Services/ScopeServiceTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/ScopeServiceTests.cs
@@ -25,7 +25,8 @@ public class ScopeServiceTests
     private static (ScopeService service, AppDbContext db) NewService()
     {
         var db = InMemoryDbFixture.Create();
-        var service = new ScopeService(db, TimeProvider.System);
+        var service = new ScopeService(
+            db, TimeProvider.System, TestAuditWriter.Instance, AllowAnyRationalePolicy.Instance);
         return (service, db);
     }
 

--- a/tests/Andy.Policies.Tests.Unit/Services/TightenOnlyMatrixTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/TightenOnlyMatrixTests.cs
@@ -29,7 +29,8 @@ public class TightenOnlyMatrixTests
     private static (TightenOnlyValidator validator, ScopeService scopes, AppDbContext db) NewServices()
     {
         var db = InMemoryDbFixture.Create();
-        var scopes = new ScopeService(db, TimeProvider.System);
+        var scopes = new ScopeService(
+            db, TimeProvider.System, TestAuditWriter.Instance, AllowAnyRationalePolicy.Instance);
         var validator = new TightenOnlyValidator(db, scopes);
         return (validator, scopes, db);
     }

--- a/tests/Andy.Policies.Tests.Unit/Services/TightenOnlyValidatorTests.cs
+++ b/tests/Andy.Policies.Tests.Unit/Services/TightenOnlyValidatorTests.cs
@@ -26,7 +26,8 @@ public class TightenOnlyValidatorTests
         NewServices()
     {
         var db = InMemoryDbFixture.Create();
-        var scopes = new ScopeService(db, TimeProvider.System);
+        var scopes = new ScopeService(
+            db, TimeProvider.System, TestAuditWriter.Instance, AllowAnyRationalePolicy.Instance);
         var validator = new TightenOnlyValidator(db, scopes);
         return (validator, scopes, db);
     }

--- a/tools/Andy.Policies.Cli/Commands/BindingCommands.cs
+++ b/tools/Andy.Policies.Cli/Commands/BindingCommands.cs
@@ -114,10 +114,14 @@ internal static class BindingCommands
             aliases: new[] { "--bind-strength" },
             getDefaultValue: () => "Recommended",
             description: "Mandatory or Recommended. Defaults to Recommended.");
+        var rationaleOpt = new Option<string?>(
+            aliases: new[] { "--rationale", "-r" },
+            description: "Reason recorded in the audit chain; required when rationale enforcement is enabled.");
         command.AddOption(policyVersionOpt);
         command.AddOption(targetTypeOpt);
         command.AddOption(targetRefOpt);
         command.AddOption(bindStrengthOpt);
+        command.AddOption(rationaleOpt);
 
         command.SetHandler(async ctx =>
         {
@@ -133,7 +137,14 @@ internal static class BindingCommands
             using var http = ClientFactory.Create(api, tok);
             var resp = await http.PostAsJsonAsync(
                 "/api/bindings",
-                new { policyVersionId = pv, targetType = tt, targetRef = tr, bindStrength = bs },
+                new
+                {
+                    policyVersionId = pv,
+                    targetType = tt,
+                    targetRef = tr,
+                    bindStrength = bs,
+                    rationale = ctx.ParseResult.GetValueForOption(rationaleOpt),
+                },
                 ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode)
             {

--- a/tools/Andy.Policies.Cli/Commands/ItemCommands.cs
+++ b/tools/Andy.Policies.Cli/Commands/ItemCommands.cs
@@ -41,28 +41,41 @@ public static class ItemCommands
         var createCommand = new Command("create", "Create a new item");
         var nameOpt = new Option<string>("--name", "Item name") { IsRequired = true };
         var descOpt = new Option<string?>("--description", "Item description");
+        var createRationaleOpt = new Option<string?>(
+            aliases: new[] { "--rationale", "-r" },
+            description: "Reason recorded in the audit chain; required when rationale enforcement is enabled.");
         createCommand.AddOption(nameOpt);
         createCommand.AddOption(descOpt);
-        createCommand.SetHandler(async (apiUrl, token, name, desc) =>
+        createCommand.AddOption(createRationaleOpt);
+        createCommand.SetHandler(async (apiUrl, token, name, desc, rationale) =>
         {
             using var client = CreateClient(apiUrl, token);
-            var response = await client.PostAsJsonAsync("/api/items", new { Name = name, Description = desc });
+            var response = await client.PostAsJsonAsync(
+                "/api/items", new { Name = name, Description = desc, Rationale = rationale });
             response.EnsureSuccessStatusCode();
             var body = await response.Content.ReadAsStringAsync();
             Console.WriteLine(body);
-        }, apiUrlOption, tokenOption, nameOpt, descOpt);
+        }, apiUrlOption, tokenOption, nameOpt, descOpt, createRationaleOpt);
         parent.AddCommand(createCommand);
 
         var deleteCommand = new Command("delete", "Delete an item");
         var deleteIdArg = new Argument<string>("id", "Item ID");
+        var deleteRationaleOpt = new Option<string?>(
+            aliases: new[] { "--rationale", "-r" },
+            description: "Reason recorded in the audit chain; required when rationale enforcement is enabled.");
         deleteCommand.AddArgument(deleteIdArg);
-        deleteCommand.SetHandler(async (apiUrl, token, id) =>
+        deleteCommand.AddOption(deleteRationaleOpt);
+        deleteCommand.SetHandler(async (apiUrl, token, id, rationale) =>
         {
             using var client = CreateClient(apiUrl, token);
-            var response = await client.DeleteAsync($"/api/items/{id}");
+            using var request = new HttpRequestMessage(HttpMethod.Delete, $"/api/items/{id}")
+            {
+                Content = JsonContent.Create(new { Rationale = rationale }),
+            };
+            var response = await client.SendAsync(request);
             response.EnsureSuccessStatusCode();
             Console.WriteLine($"Item {id} deleted.");
-        }, apiUrlOption, tokenOption, deleteIdArg);
+        }, apiUrlOption, tokenOption, deleteIdArg, deleteRationaleOpt);
         parent.AddCommand(deleteCommand);
     }
 

--- a/tools/Andy.Policies.Cli/Commands/OverrideCommands.cs
+++ b/tools/Andy.Policies.Cli/Commands/OverrideCommands.cs
@@ -182,7 +182,11 @@ internal static class OverrideCommands
     {
         var command = new Command("approve", "Approve a proposed override (must differ from proposer).");
         var idArg = new Argument<Guid>("id", "Override id (GUID)");
+        var rationaleOpt = new Option<string?>(
+            aliases: new[] { "--rationale", "-r" },
+            description: "Approval reason recorded in the audit chain; required when rationale enforcement is enabled.");
         command.AddArgument(idArg);
+        command.AddOption(rationaleOpt);
 
         command.SetHandler(async ctx =>
         {
@@ -193,8 +197,10 @@ internal static class OverrideCommands
             var ct = ctx.GetCancellationToken();
 
             using var http = ClientFactory.Create(api, tok);
-            var resp = await http.PostAsync(
-                $"/api/overrides/{id}/approve", content: null, ct).ConfigureAwait(false);
+            var resp = await http.PostAsJsonAsync(
+                $"/api/overrides/{id}/approve",
+                new { rationale = ctx.ParseResult.GetValueForOption(rationaleOpt) },
+                ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode)
             {
                 ctx.ExitCode = await ExitCodes.HandleAsync(resp, ct).ConfigureAwait(false);

--- a/tools/Andy.Policies.Cli/Commands/ScopeCommands.cs
+++ b/tools/Andy.Policies.Cli/Commands/ScopeCommands.cs
@@ -130,10 +130,14 @@ internal static class ScopeCommands
         var displayOpt = new Option<string>(
             aliases: new[] { "--display-name", "-n" },
             description: "Human-readable display name.") { IsRequired = true };
+        var rationaleOpt = new Option<string?>(
+            aliases: new[] { "--rationale", "-r" },
+            description: "Reason recorded in the audit chain; required when rationale enforcement is enabled.");
         command.AddOption(parentOpt);
         command.AddOption(typeOpt);
         command.AddOption(refOpt);
         command.AddOption(displayOpt);
+        command.AddOption(rationaleOpt);
 
         command.SetHandler(async ctx =>
         {
@@ -149,7 +153,14 @@ internal static class ScopeCommands
             using var http = ClientFactory.Create(api, tok);
             var resp = await http.PostAsJsonAsync(
                 "/api/scopes",
-                new { parentId = parent, type, @ref = refValue, displayName },
+                new
+                {
+                    parentId = parent,
+                    type,
+                    @ref = refValue,
+                    displayName,
+                    rationale = ctx.ParseResult.GetValueForOption(rationaleOpt),
+                },
                 ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode)
             {
@@ -166,7 +177,11 @@ internal static class ScopeCommands
     {
         var command = new Command("delete", "Delete a leaf scope node (refused with non-zero exit if it has descendants).");
         var idArg = new Argument<Guid>("id", "Scope node id (GUID).");
+        var rationaleOpt = new Option<string?>(
+            aliases: new[] { "--rationale", "-r" },
+            description: "Reason recorded in the audit chain; required when rationale enforcement is enabled.");
         command.AddArgument(idArg);
+        command.AddOption(rationaleOpt);
 
         command.SetHandler(async ctx =>
         {
@@ -176,7 +191,14 @@ internal static class ScopeCommands
             var ct = ctx.GetCancellationToken();
 
             using var http = ClientFactory.Create(api, tok);
-            var resp = await http.DeleteAsync($"/api/scopes/{id}", ct).ConfigureAwait(false);
+            using var request = new HttpRequestMessage(HttpMethod.Delete, $"/api/scopes/{id}")
+            {
+                Content = JsonContent.Create(new
+                {
+                    rationale = ctx.ParseResult.GetValueForOption(rationaleOpt),
+                }),
+            };
+            var resp = await http.SendAsync(request, ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode)
             {
                 ctx.ExitCode = await ExitCodes.HandleAsync(resp, ct).ConfigureAwait(false);

--- a/tools/Andy.Policies.Cli/Commands/VersionCommands.cs
+++ b/tools/Andy.Policies.Cli/Commands/VersionCommands.cs
@@ -171,6 +171,9 @@ internal static class VersionCommands
         var scopesOpt = new Option<string[]>("--scopes", "Scope tags (repeat or comma-separate)") { AllowMultipleArgumentsPerToken = true };
         var rulesJsonOpt = new Option<string?>("--rules-json", "Inline rules JSON");
         var rulesFileOpt = new Option<FileInfo?>("--rules-file", "Path to a UTF-8 JSON file containing the rules document");
+        var rationaleOpt = new Option<string?>(
+            aliases: new[] { "--rationale", "-r" },
+            description: "Reason recorded in the audit chain; required when rationale enforcement is enabled.");
         command.AddOption(nameOpt);
         command.AddOption(descOpt);
         command.AddOption(summaryOpt);
@@ -179,6 +182,7 @@ internal static class VersionCommands
         command.AddOption(scopesOpt);
         command.AddOption(rulesJsonOpt);
         command.AddOption(rulesFileOpt);
+        command.AddOption(rationaleOpt);
 
         command.SetHandler(async ctx =>
         {
@@ -207,6 +211,7 @@ internal static class VersionCommands
                 severity = ctx.ParseResult.GetValueForOption(sevOpt),
                 scopes,
                 rulesJson,
+                rationale = ctx.ParseResult.GetValueForOption(rationaleOpt),
             };
 
             using var http = ClientFactory.Create(api, tok);
@@ -233,6 +238,9 @@ internal static class VersionCommands
         var scopesOpt = new Option<string[]>("--scopes", "Scope tags (repeat or comma-separate)") { AllowMultipleArgumentsPerToken = true };
         var rulesJsonOpt = new Option<string?>("--rules-json", "Inline rules JSON");
         var rulesFileOpt = new Option<FileInfo?>("--rules-file", "Path to a UTF-8 JSON file containing the rules document");
+        var rationaleOpt = new Option<string?>(
+            aliases: new[] { "--rationale", "-r" },
+            description: "Reason recorded in the audit chain; required when rationale enforcement is enabled.");
         command.AddArgument(policyArg);
         command.AddArgument(versionArg);
         command.AddOption(summaryOpt);
@@ -241,6 +249,7 @@ internal static class VersionCommands
         command.AddOption(scopesOpt);
         command.AddOption(rulesJsonOpt);
         command.AddOption(rulesFileOpt);
+        command.AddOption(rationaleOpt);
 
         command.SetHandler(async ctx =>
         {
@@ -276,6 +285,7 @@ internal static class VersionCommands
                 severity = ctx.ParseResult.GetValueForOption(sevOpt),
                 scopes,
                 rulesJson,
+                rationale = ctx.ParseResult.GetValueForOption(rationaleOpt),
             };
 
             var resp = await http.PutAsJsonAsync($"/api/policies/{policyId}/versions/{versionId}", payload, ct).ConfigureAwait(false);
@@ -295,8 +305,12 @@ internal static class VersionCommands
         var command = new Command("draft-bump", "Create a new draft version cloned from an existing version");
         var policyArg = new Argument<string>("policyIdOrName", "Policy id (GUID) or name slug");
         var sourceArg = new Argument<Guid>("sourceVersionId", "Source version id (GUID)");
+        var rationaleOpt = new Option<string?>(
+            aliases: new[] { "--rationale", "-r" },
+            description: "Reason recorded in the audit chain; required when rationale enforcement is enabled.");
         command.AddArgument(policyArg);
         command.AddArgument(sourceArg);
+        command.AddOption(rationaleOpt);
         command.SetHandler(async ctx =>
         {
             var api = ctx.ParseResult.GetValueForOption(apiUrl)!;
@@ -313,7 +327,10 @@ internal static class VersionCommands
                 return;
             }
 
-            var resp = await http.PostAsync($"/api/policies/{policyId}/versions/{sourceVersionId}/bump", content: null, ct).ConfigureAwait(false);
+            var resp = await http.PostAsJsonAsync(
+                $"/api/policies/{policyId}/versions/{sourceVersionId}/bump",
+                new { rationale = ctx.ParseResult.GetValueForOption(rationaleOpt) },
+                ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode)
             {
                 ctx.ExitCode = await ExitCodes.HandleAsync(resp, ct).ConfigureAwait(false);


### PR DESCRIPTION
## Summary

- make catalog mutation auditing atomic and enforce canonical actors and rationale
- align live and bundle-pinned resolution, override semantics, and exact Active filtering
- enforce operation-specific RBAC across MCP and gRPC surfaces
- fail closed when plan security metadata is unavailable
- update regression coverage, documentation, and OpenAPI

## Verification

- 696 unit tests passed
- 681 integration tests passed; 5 skipped
- 11 E2E tests passed
- 145 Angular tests passed
- full solution build completed with zero warnings and errors
- git diff --check passed

Related to #244 through #256.