### PR TITLE
Add coord repository coordination

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "coord-guard"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "coord board 2>/dev/null || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.coord/config.json
+++ b/.coord/config.json
@@ -1,0 +1,90 @@
+{
+  "$comment": "Coordination protocol for this repository. Reviewed like code. Live state is not here, it is in the coord service.",
+  "baseBranch": "main",
+  "worktreeRoot": "../andy-policies-lanes",
+  "branchPattern": "agent/{agent}/{issue}-{slug}",
+  "protectedBranches": [
+    "main",
+    "master",
+    "release"
+  ],
+  "leaseSeconds": 1800,
+  "closeRequiresEvidence": true,
+  "integrationAuthority": false,
+  "idleLadder": [
+    "issue",
+    "review",
+    "audit",
+    "sweep",
+    "worktree-gc"
+  ],
+  "singleWriter": [
+    {
+      "name": ".coord/config.json",
+      "reason": "Changes to lane layout and coordination rules affect all active sessions."
+    },
+    {
+      "name": "Andy.Policies.sln, Directory.Build.props",
+      "reason": "Coordinate dependency and build configuration changes across lanes."
+    }
+  ],
+  "verify": [
+    {
+      "name": "Patch whitespace",
+      "command": "git diff --check",
+      "required": true
+    },
+    {
+      "name": "Solution tests",
+      "command": "dotnet test Andy.Policies.sln",
+      "required": true
+    }
+  ],
+  "sweeps": [
+    {
+      "area": "tests",
+      "description": "Missing, skipped, or vacuous tests for shipped behavior.",
+      "cadenceHours": 168,
+      "method": "Pick the two or three modules changed most in the last month (`git log --format= --name-only`\nover that range, sorted by frequency). For each:\n1. list the behaviors a user depends on, from the code, not from the existing test names;\n2. find which of those a test would actually catch if it broke. A test that asserts a\n   function returns what it just computed catches nothing;\n3. check for skipped, commented-out, or always-true assertions, and for tests that pass\n   when you delete the implementation line they claim to cover.\nFile one issue per specific untested behavior, naming the module, the behavior, and how it\nwould fail. Do not file \"add more tests\".\nStop when the selected modules are covered. Say which modules you looked at."
+    },
+    {
+      "area": "docs",
+      "description": "Documentation that no longer matches the code.",
+      "cadenceHours": 336,
+      "method": "Take README and the docs a newcomer would read first. For each concrete claim:\n1. a command, flag, path, or file name: run it or open it;\n2. a described behavior: find the code and check it still does that;\n3. a count, version, or size: recompute it. Numbers in prose drift silently.\nAlso check the reverse direction: a feature added recently that nothing documents.\nFile one issue per divergence, quoting the stale line and what is true instead.\nStop when the entry-point documents are verified. Say which files you checked."
+    },
+    {
+      "area": "defects",
+      "description": "Latent bugs, unhandled errors, and TODO or FIXME markers.",
+      "cadenceHours": 168,
+      "method": "Read for the failure modes tests do not reach:\n1. every TODO, FIXME, XXX and HACK marker: is it still true, and does it hide a defect?\n2. error paths that swallow: empty catch blocks, ignored return values, unchecked exit codes;\n3. boundaries: empty input, one element, absent optional value, concurrent callers,\n   a path that does not exist, a network call that never returns;\n4. anything whose comment and code disagree. One of them is wrong.\nFile an issue only where you can state a concrete failure: inputs, and what goes wrong.\nA code smell with no failure is not a defect. Stop when the pass is complete; say what you read."
+    },
+    {
+      "area": "dead-code",
+      "description": "Unreferenced code, dead flags, and superseded modules.",
+      "cadenceHours": 720,
+      "method": "Find what nothing reaches: exported symbols with no importer, private functions with no\ncaller, configuration keys nothing reads, feature flags with one branch never taken, and\nmodules superseded by a replacement that both still exist.\nVerify each candidate by searching the whole repository including tests and scripts, and\ncheck the history: recently added code with no caller yet may be a half-landed feature,\nwhich is a different issue from dead code and should be filed as such.\nFile one issue listing the symbols and the evidence that nothing reaches them."
+    },
+    {
+      "area": "deps",
+      "description": "Outdated or vulnerable dependencies.",
+      "cadenceHours": 336,
+      "method": "Run the ecosystem audit and outdated commands for this project.\nFor each finding, state whether the vulnerable path is actually reached: an advisory in a\ntransitive dependency of a build-only tool is not the same risk as one in a request path.\nGroup by upgrade rather than by advisory, since one bump usually clears several.\nFile issues only for upgrades worth doing, with the version, what breaks, and the risk if\nleft. A list of every available minor bump is noise."
+    }
+  ],
+  "scanRoots": [],
+  "siblings": [],
+  "$siblingsExample": [
+    {
+      "name": "DiagramKit",
+      "source": "../DiagramKit",
+      "mode": "worktree",
+      "pin": "origin/main"
+    },
+    {
+      "name": "swift-ide-components",
+      "source": "../swift-ide-components",
+      "mode": "symlink"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ site/
 # OT5 (rivoli-ai/conductor#1263): allow Andy.Telemetry.<v>.nupkg
 # under local-packages/ to flow through the local nuget feed.
 !local-packages/*.nupkg
+.coord/state/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "coord": {
+      "command": "coord-mcp",
+      "args": [],
+      "env": {}
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# Agent Operating Contract
+
+This repository is changed by several agents and people at the same time.
+
+<!-- coord:begin -->
+## Coordination
+
+Several agents and people change this repository at the same time. Coordination runs through
+`coord`, a local service. It is not paperwork about the work: it is how you get a place to work
+and how you find out what everybody else is doing.
+
+Read `docs/coordination/README.md` once. Then, every session:
+
+```bash
+coord register --agent <your-id>     # opus5, codex, kimik3, and so on. Once per session.
+coord next                           # what to work on. Never empty while work exists.
+coord start <target> --next "..."    # your claim, your branch, your worktree, in one call.
+```
+
+### The rules that are enforced, not requested
+
+- **You may not commit in the primary checkout, on a protected branch, or in a worktree you do
+  not hold.** A pre-commit hook checks this. Run `coord start` and work in the directory it
+  gives you.
+- **Two agents cannot hold one issue.** `coord start` either gives you the claim or tells you
+  who has it. Do not work around a refusal; take something else from `coord next`.
+- **An issue does not close without evidence.** `coord close_issue` requires the commit or pull
+  request, the command you ran, and its result. Anything closed another way is detected and
+  queued for audit.
+
+### The rules that depend on you
+
+- **Keep your claim current.** `coord update --next "..."` whenever scope, ownership, a blocker
+  or the integration order changes. Updates renew your lease. During long work, call
+  `coord heartbeat` before the configured lease expires (30 minutes by default). Other agents read
+  your next action to decide whether to wait for you or route around you.
+- **A blocker is not an idle state.** Record it with `coord update --status blocked --blockedOn
+  "..."`, then call `coord next` and take unblocked work on a surface that does not overlap.
+- **Never idle while work exists.** After finishing, handing off, or blocking anything, call
+  `coord next` immediately. It ranks open issues first, then unreviewed pull requests, then
+  unverified closures, then stale sweep areas, then orphaned worktrees. Only when it returns
+  nothing is there nothing to do.
+- **Stay inside your claimed surface.** Expand the claim before expanding the change. Stage
+  explicit paths; never `git add -A` in a checkout that could hold another lane's work.
+- **Mirror decisions to the issue.** The board is live state, the GitHub issue is the durable
+  record. Any ownership decision, blocker or changed integration order belongs on both.
+- **Do not merge, push, close, or release unless you have been given integration authority.**
+  Report a branch and a commit to whoever has it.
+
+### What every tool result tells you
+
+Every `coord` call returns the live board and everything that changed since your last call. You
+do not need to poll and you should not: if you have nothing to do, `coord next` will find you
+something, and `coord wait` blocks properly when it genuinely cannot.
+<!-- coord:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,3 +221,14 @@ The Gitleaks CI job has been removed — the action requires a paid licence for 
 
 This project was scaffolded from [andy-service-template](https://github.com/rivoli-ai/andy-service-template).
 Run `check-compliance.sh` from the template repo to verify template compliance.
+
+<!-- coord:begin -->
+## Coordination and agent contract
+
+The instructions in [AGENTS.md](AGENTS.md) apply to every agent working here, Claude Code
+included. Read it first, then `docs/coordination/README.md`.
+
+Coordination is not file-based in this repository. Do not look for a claims table or a board file
+to edit: run `coord next` and `coord start`. The live state is in the service, and it is
+returned to you on every call.
+<!-- coord:end -->

--- a/docs/coordination/FAILURE_MODES.md
+++ b/docs/coordination/FAILURE_MODES.md
@@ -1,0 +1,36 @@
+# Coordination Failure Modes
+
+Incidents that produced the rules in this system. Add to it. A rule whose incident is written
+down is a rule the next agent understands instead of works around.
+
+## Two agents in one checkout
+
+A branch is not isolation. Two sessions sharing a working copy share `HEAD` and the index, so
+agents with entirely disjoint file ownership still collide. In one incident an agent working in
+the primary tree aborted another lane's in-progress merge. In another, an integration session and
+a feature session both ran `git merge` in the same checkout, and the resolution that survived
+did not compile.
+
+Rule: every lane gets its own worktree, created by `coord start`, including integration.
+
+## The ledger stalled the work it coordinated
+
+Every lane appended a row to one coordination table. Two lanes adding unrelated rows is not a
+disagreement, but git sees two edits at one anchor and calls it a conflict, and GitHub runs no
+checks at all on a pull request that has a conflict. The result presented as "CI is broken", and
+lanes spent their time diagnosing the wrong thing.
+
+Rule: live coordination state is not a file in the repository.
+
+## A closed issue had only half its work landed
+
+An issue spanning two repositories was closed when the library half merged. The consuming half
+was never integrated, and nothing noticed for weeks.
+
+Rule: closing requires evidence verified against pushed integration state.
+
+## Whole-tree staging published another lane's work
+
+`git add -A` in a shared checkout committed files belonging to a different lane.
+
+Rule: stage explicit paths.

--- a/docs/coordination/README.md
+++ b/docs/coordination/README.md
@@ -1,0 +1,142 @@
+
+
+<!-- coord:begin -->
+# Development Coordination
+
+How several agents and people change this repository at once without losing each other's work.
+
+This describes coordination between the tools and people writing the software. It is not the
+product's own collaboration design.
+
+## Why this is a service and not a file
+
+Both predecessors of this system kept live state under version control: a directory of claim
+files in one repository, a board document in another. Both worked until they did not, in the same
+way. Two agents editing a ledger is a merge conflict, GitHub runs no checks at all on a pull
+request that has a conflict, and so a bookkeeping collision presents as "CI is broken" or "the
+checks never appeared". Agents then spend hours diagnosing the wrong thing.
+
+There is a second, quieter failure. A claim committed to a feature branch is invisible to anyone
+starting from the default branch, so an agent can implement for hours behind a claim nobody can
+see. Publishing every status change through a pull request is the only fix available to a
+file-based ledger, and it is slower than the work it coordinates.
+
+So live state moved out of git. What stays in the repository is the protocol, which changes
+rarely, and `.coord/config.json`, which is this project's configuration. What lives in the
+service is anything that changes by the minute: who holds what, which worktrees are live, what
+the queue is. What lives on GitHub is the issues, which remain the durable record.
+
+## The three sources of truth
+
+| Subject | Authority | Why |
+|---|---|---|
+| Issues, pull requests, their state and content | GitHub | It outlives every local process and every agent session. |
+| Claims, leases, worktree verdicts, the queue | the coord service | These change constantly and must be atomic. A file cannot be. |
+| The protocol and this project's configuration | this repository | It is reviewed like code, because it is a contract. |
+
+Coord never asks you to reconcile these by hand. Issue mutations are write-through: GitHub is
+updated first, the local mirror second. A disagreement between them is a bug in the sync loop,
+not a task for an agent.
+
+## Claims
+
+A claim is a row with a holder, a next action, a branch, a worktree and a lease. Taking one is
+atomic: two agents calling `coord start` on the same issue at the same instant serialize, and
+exactly one wins. The loser is told who won and what their next action is, which is the
+information it needs to pick different work.
+
+A lease expires if the holder stops reporting. Any `coord` call renews it, so an agent that is
+working does not also have to remember to say it is working. An agent that dies releases its work
+back to the queue with an event that says why, instead of holding it forever.
+
+During long work, run `coord heartbeat` before the configured lease expires (30 minutes by
+default). `coord update` also renews it. If it expires, run `coord start <target> --next "..."`
+to resume your recorded lane. Coord checks its repository, branch and ownership before
+re-taking the claim, preserving existing changes.
+
+Ownership is by target, and additionally by branch and by worktree. Two lanes cannot share a
+branch and cannot share a worktree, because both have already caused losses in this organisation.
+
+## Worktrees
+
+Every lane works in its own worktree on its own branch, created together by `coord start`.
+There are no exceptions, including for integration: merging and closing issues are work and need
+a worktree like anything else.
+
+A branch is not isolation. Two sessions in one checkout share `HEAD` and the index, so agents
+with entirely disjoint file ownership still collide there. This has happened: one agent working
+in the primary tree aborted another lane's in-progress merge, and separately, an integration
+session and a feature session both ran `git merge` in one checkout and the resolution that
+survived did not compile.
+
+A worktree isolates files and refs. It does not isolate the machine. Home directories, running
+applications, preference domains, keychains and shared temporary paths are visible to every lane
+at once. Treat each of them as owned by whoever claimed it.
+
+Coord scans for worktrees continuously and gives each one a verdict:
+
+| Verdict | Meaning |
+|---|---|
+| `primary` | The main checkout. No lane may work here. |
+| `live` | Held by a current claim. |
+| `orphan-clean` | No claim, clean, fully merged. An agent may remove it. |
+| `orphan-dirty` | No claim, but uncommitted or unmerged work. Only a person decides. |
+| `prunable` | Git records it, but the directory is gone. |
+| `unregistered` | On disk, pointing at this repository, and git does not know it exists. |
+
+That last row is why the scan looks at the disk rather than only asking git. A worktree whose
+administrative entry was pruned while its files stayed behind looks like an ordinary source
+directory to every other tool.
+
+## The queue
+
+`coord next` returns ranked work and does not return an empty list while any work exists. The
+order is deliberate:
+
+1. **open issues** that are unclaimed and unblocked;
+2. **pull requests** with no reviewer, so reviews are picked up as work rather than as a favour;
+3. **audits**, meaning anything closed or edited without recorded verification;
+4. **sweeps**, meaning an area of the repository whose review cadence has elapsed;
+5. **orphaned worktrees**.
+
+Reviews, audits, sweeps and cleanup sit in the same ranked list as issues, below them. That is
+the whole mechanism for "pick up a review when you have time" and for "review the repository on
+your own initiative": both happen automatically when there is spare capacity, and neither
+competes with shipping.
+
+When even that is empty, the queue offers assistance work derived from real state: unblocking
+another lane, verifying a recent closure, narrowing a blocker. Never invent work to appear busy,
+and never duplicate an implementation somebody else is doing.
+
+## Sweeps
+
+A sweep is a periodic, self-directed review of one area: tests, documentation, defects, dead
+code, dependencies. Areas and cadences are in `.coord/config.json`. When an area goes stale it
+enters the queue, and whoever takes it files what they find with `coord file_issue`.
+
+Filing is deduplicated against everything open and recently closed, so sweeping repeatedly does
+not flood the backlog with the same finding under three different titles.
+
+Closing the last filed issue is not the finish line. The issue list only holds problems somebody
+already noticed, which is what sweeps exist to correct.
+
+## Closing an issue
+
+Closing requires the commit or pull request, the exact command run against pushed integration
+state, and its result. Coord posts that evidence to the issue before the state changes, so the
+record survives even if the close itself fails.
+
+An assignee, a branch name, a stale claim, a local commit, an unmerged branch, or an "already
+fixed" comment is not completion. Anything closed outside coord is detected on the next sync and
+queued for audit, and an audit that fails reopens the issue.
+
+## Handing off
+
+A handoff carries: branch and commit, or an explicit statement that the work is an uncommitted
+diff; the acceptance criteria completed; the surfaces claimed and the files actually changed; the
+commands run and their results, including anything skipped; dependencies on other repositories
+and the integration order they require; known risks and incomplete work.
+
+Report disagreement with the brief, or an assumption you are unsure of, rather than resolving it
+silently.
+<!-- coord:end -->


### PR DESCRIPTION
This repository lacked the shared coord setup used to claim work and isolate concurrent changes. Add the managed agent instructions, coordination configuration and documentation, and MCP/Claude hook declarations. Preserve existing project guidance and hook behavior.

Validation: parsed all generated JSON, verified managed blocks and hook setup, and ran `git diff --cached --check`. The primary installation passed `coord doctor`. This changes development setup only; application test suites were not run locally.

Git hooks installed by `coord init` are machine-local; run `coord init` after cloning to install them.
